### PR TITLE
Feat: Ondemand Shell Mode

### DIFF
--- a/cli/src/commands/agent/run/mode_interactive.rs
+++ b/cli/src/commands/agent/run/mode_interactive.rs
@@ -217,26 +217,19 @@ pub async fn run_interactive(ctx: AppConfig, config: RunInteractiveConfig) -> Re
                         }
                         continue;
                     }
-                    OutputEvent::SendToolResult(tool_call_result, is_cancelled) => {
-                        if is_cancelled {
-                            messages.push(tool_result(
-                                tool_call_result.call.clone().id,
-                                tool_call_result.result.clone(),
-                            ));
-                        } else {
-                            send_input_event(&input_tx, InputEvent::Loading(true)).await?;
-                            messages.push(tool_result(
-                                tool_call_result.call.clone().id,
-                                tool_call_result.result.clone(),
-                            ));
+                    OutputEvent::SendToolResult(tool_call_result) => {
+                        send_input_event(&input_tx, InputEvent::Loading(true)).await?;
+                        messages.push(tool_result(
+                            tool_call_result.call.clone().id,
+                            tool_call_result.result.clone(),
+                        ));
 
-                            send_input_event(&input_tx, InputEvent::Loading(false)).await?;
+                        send_input_event(&input_tx, InputEvent::Loading(false)).await?;
 
-                            if !tools_queue.is_empty() {
-                                let tool_call = tools_queue.remove(0);
-                                send_tool_call(&input_tx, &tool_call).await?;
-                                continue;
-                            }
+                        if !tools_queue.is_empty() {
+                            let tool_call = tools_queue.remove(0);
+                            send_tool_call(&input_tx, &tool_call).await?;
+                            continue;
                         }
                     }
                     OutputEvent::Memorize => {

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -61,6 +61,7 @@ pub struct AppState {
     pub waiting_for_shell_input: bool,
     pub is_tool_call_shell_command: bool,
     pub is_pasting: bool,
+    pub ondemand_shell_mode: bool,
 }
 
 #[derive(Debug)]
@@ -120,8 +121,8 @@ pub enum OutputEvent {
     RejectTool(ToolCall),
     ListSessions,
     SwitchToSession(String),
-    SendToolResult(ToolCallResult),
     Memorize,
+    SendToolResult(ToolCallResult, bool),
 }
 
 impl AppState {
@@ -200,6 +201,7 @@ impl AppState {
             waiting_for_shell_input: false,
             is_tool_call_shell_command: false,
             is_pasting: false,
+            ondemand_shell_mode: false,
         }
     }
 

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -122,7 +122,7 @@ pub enum OutputEvent {
     ListSessions,
     SwitchToSession(String),
     Memorize,
-    SendToolResult(ToolCallResult, bool),
+    SendToolResult(ToolCallResult),
 }
 
 impl AppState {

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -62,6 +62,7 @@ pub struct AppState {
     pub is_tool_call_shell_command: bool,
     pub is_pasting: bool,
     pub ondemand_shell_mode: bool,
+    pub shell_tool_calls: Option<Vec<ToolCallResult>>,
 }
 
 #[derive(Debug)]
@@ -116,7 +117,7 @@ pub enum InputEvent {
 
 #[derive(Debug)]
 pub enum OutputEvent {
-    UserMessage(String),
+    UserMessage(String, Option<Vec<ToolCallResult>>),
     AcceptTool(ToolCall),
     RejectTool(ToolCall),
     ListSessions,
@@ -202,6 +203,7 @@ impl AppState {
             is_tool_call_shell_command: false,
             is_pasting: false,
             ondemand_shell_mode: false,
+            shell_tool_calls: None,
         }
     }
 

--- a/tui/src/event.rs
+++ b/tui/src/event.rs
@@ -38,7 +38,6 @@ pub fn map_crossterm_event_to_input_event(event: Event) -> Option<InputEvent> {
                 KeyCode::Char('b') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                     Some(InputEvent::CursorLeft)
                 }
-                KeyCode::Char('!') => Some(InputEvent::ShellMode),
                 KeyCode::Char('<') if key.modifiers.contains(KeyModifiers::ALT) => {
                     Some(InputEvent::InputCursorPrevWord)
                 }

--- a/tui/src/lib.rs
+++ b/tui/src/lib.rs
@@ -133,7 +133,7 @@ pub async fn run_tui(
                        if let InputEvent::InputSubmitted = event {
                            if state.show_shell_mode && !state.waiting_for_shell_input {
                            } else if !state.show_shell_mode && !state.input.trim().is_empty() && !state.input.trim().starts_with('/') {
-                               let _ = output_tx.try_send(OutputEvent::UserMessage(state.input.clone()));
+                               let _ = output_tx.try_send(OutputEvent::UserMessage(state.input.clone(), state.shell_tool_calls.clone()));
                            }
                        }
 

--- a/tui/src/services/update.rs
+++ b/tui/src/services/update.rs
@@ -168,7 +168,7 @@ pub fn update(
         InputEvent::ShellCompleted(_code) => {
             if state.dialog_command.is_some() {
                 let result = shell_command_to_tool_call(state);
-                let _ = output_tx.try_send(OutputEvent::SendToolResult(result, false));
+                let _ = output_tx.try_send(OutputEvent::SendToolResult(result));
             }
             if !state.ondemand_shell_mode {
                 state.active_shell_command = None;
@@ -420,7 +420,7 @@ fn handle_input_submitted(
     if state.ondemand_shell_mode {
         let result = shell_command_to_tool_call(state);
         eprintln!("result: {:?}", result);
-        let _ = output_tx.try_send(OutputEvent::SendToolResult(result, true));
+        let _ = output_tx.try_send(OutputEvent::SendToolResult(result));
         state.ondemand_shell_mode = false;
     }
 

--- a/tui/src/services/update.rs
+++ b/tui/src/services/update.rs
@@ -68,7 +68,6 @@ pub fn update(
                 handle_input_submitted(state, message_area_height, output_tx, shell_tx);
             }
         }
-        InputEvent::ShellMode => handle_shell_mode(state),
         InputEvent::InputChangedNewline => handle_input_changed(state, '\n'),
         InputEvent::InputSubmittedWith(s) => {
             handle_input_submitted_with(state, s, message_area_height)
@@ -305,6 +304,10 @@ fn handle_dropdown_down(state: &mut AppState) {
 fn handle_input_changed(state: &mut AppState, c: char) {
     if c == '?' && state.input.is_empty() {
         state.show_shortcuts = !state.show_shortcuts;
+        return;
+    }
+    if c == '!' && state.input.is_empty() {
+        handle_shell_mode(state);
         return;
     }
 


### PR DESCRIPTION
- User can stay in shell mode and closes it at will
- In the next user prompt, all previous commands in previous enclosed shell mode it submitted before the user prompt, providing history of previous run commands by the user so the assistant is aware of them.