### PR TITLE
[DRAFT] Patch/enhancementsV2

### DIFF
--- a/tui/src/services/confirmation_dialog.rs
+++ b/tui/src/services/confirmation_dialog.rs
@@ -29,14 +29,8 @@ pub fn render_confirmation_dialog(f: &mut Frame, state: &AppState) {
     };
 
     let mut message = "Press Enter to continue or Esc to cancel and reprompt";
-    if state.dialog_command.is_some() {
-        let command = state
-            .dialog_command
-            .as_ref()
-            .unwrap()
-            .function
-            .arguments
-            .clone();
+    if let Some(dialog_command) = state.dialog_command.as_ref() {
+        let command = dialog_command.function.arguments.clone();
         if command.contains("sudo") {
             message = "This is a sudo command '$' to run the command yourself or Esc to cancel and reprompt";
         }

--- a/tui/src/services/confirmation_dialog.rs
+++ b/tui/src/services/confirmation_dialog.rs
@@ -28,8 +28,22 @@ pub fn render_confirmation_dialog(f: &mut Frame, state: &AppState) {
         height: dialog_height,
     };
 
+    let mut message = "Press Enter to continue or Esc to cancel and reprompt";
+    if state.dialog_command.is_some() {
+        let command = state
+            .dialog_command
+            .as_ref()
+            .unwrap()
+            .function
+            .arguments
+            .clone();
+        if command.contains("sudo") {
+            message = "This is a sudo command '$' to run the command yourself or Esc to cancel and reprompt";
+        }
+    }
+
     let line = Line::from(vec![Span::styled(
-        "Press Enter to continue, '$' to run the command yourself or Esc to cancel and reprompt",
+        message,
         Style::default()
             .fg(Color::White)
             .add_modifier(Modifier::BOLD),

--- a/tui/src/services/hint_helper.rs
+++ b/tui/src/services/hint_helper.rs
@@ -20,7 +20,9 @@ pub fn render_hint_or_shortcuts(f: &mut Frame, state: &AppState, area: Rect) {
 
     if state.show_shortcuts {
         let shortcuts = vec![
-            Line::from("/ for commands      PageUp/Down(Fn + ↑/↓) for fast scroll      shift + enter or ctrl + j to insert newline"),
+            Line::from(
+                "/ for commands      PageUp/Down(Fn + ↑/↓) for fast scroll      shift + enter or ctrl + j to insert newline",
+            ),
             Line::from(format!(
                 "{}for shell mode     ↵ to send message    ctrl + c to quit",
                 SHELL_PROMPT_PREFIX.trim()

--- a/tui/src/services/hint_helper.rs
+++ b/tui/src/services/hint_helper.rs
@@ -20,7 +20,7 @@ pub fn render_hint_or_shortcuts(f: &mut Frame, state: &AppState, area: Rect) {
 
     if state.show_shortcuts {
         let shortcuts = vec![
-            Line::from("/ for commands       shift + enter or ctrl + j to insert newline"),
+            Line::from("/ for commands      PageUp/Down(Fn + ↑/↓) for fast scroll      shift + enter or ctrl + j to insert newline"),
             Line::from(format!(
                 "{}for shell mode     ↵ to send message    ctrl + c to quit",
                 SHELL_PROMPT_PREFIX.trim()

--- a/tui/src/services/update.rs
+++ b/tui/src/services/update.rs
@@ -82,8 +82,16 @@ pub fn update(
         InputEvent::ScrollDown => {
             handle_scroll_down(state, message_area_height, message_area_width)
         }
-        InputEvent::PageUp => handle_page_up(state, message_area_height),
-        InputEvent::PageDown => handle_page_down(state, message_area_height, message_area_width),
+        InputEvent::PageUp => {
+            state.stay_at_bottom = false; // unlock from bottom
+            handle_page_up(state, message_area_height);
+            adjust_scroll(state, message_area_height, message_area_width);
+        }
+        InputEvent::PageDown => {
+            state.stay_at_bottom = false; // unlock from bottom
+            handle_page_down(state, message_area_height, message_area_width);
+            adjust_scroll(state, message_area_height, message_area_width);
+        }
         InputEvent::Quit => {}
         InputEvent::CursorLeft => {
             if state.cursor_position > 0 {

--- a/tui/src/services/update.rs
+++ b/tui/src/services/update.rs
@@ -592,28 +592,27 @@ fn handle_input_submitted(
         state.input.clear();
         state.cursor_position = 0;
 
-        let tool_call_args = state
-            .dialog_command
-            .as_ref()
-            .unwrap()
-            .function
-            .arguments
-            .clone();
+        let tool_call_args = if let Some(cmd) = state.dialog_command.as_ref() {
+            cmd.function.arguments.clone()
+        } else {
+            String::new()
+        };
+
         let command = tool_call_args
             .split("\"command\": \"")
             .nth(1)
-            .unwrap()
-            .split("\"")
-            .nth(0)
-            .unwrap();
-        let active_commands = vec!["ssh", "sudo"];
-        if active_commands.iter().any(|cmd| command.contains(cmd)) {
-            state.show_shell_mode = true;
-            state.is_dialog_open = false;
-            state.input.clear();
-            state.cursor_position = 0;
-            state.run_shell_command(command.to_string(), shell_tx);
-            return;
+            .and_then(|s| s.split('\"').next())
+            .unwrap_or("");
+        if !command.is_empty() {
+            let active_commands = vec!["ssh", "sudo"];
+            if active_commands.iter().any(|cmd| command.contains(cmd)) {
+                state.show_shell_mode = true;
+                state.is_dialog_open = false;
+                state.input.clear();
+                state.cursor_position = 0;
+                state.run_shell_command(command.to_string(), shell_tx);
+                return;
+            }
         }
 
         if state.dialog_selected == 0 {

--- a/tui/src/services/update.rs
+++ b/tui/src/services/update.rs
@@ -604,7 +604,7 @@ fn handle_input_submitted(
             .and_then(|s| s.split('\"').next())
             .unwrap_or("");
         if !command.is_empty() {
-            let active_commands = vec!["ssh", "sudo"];
+            let active_commands = ["ssh", "sudo"];
             if active_commands.iter().any(|cmd| command.contains(cmd)) {
                 state.show_shell_mode = true;
                 state.is_dialog_open = false;

--- a/tui/src/services/update.rs
+++ b/tui/src/services/update.rs
@@ -591,6 +591,31 @@ fn handle_input_submitted(
         state.is_dialog_open = false;
         state.input.clear();
         state.cursor_position = 0;
+
+        let tool_call_args = state
+            .dialog_command
+            .as_ref()
+            .unwrap()
+            .function
+            .arguments
+            .clone();
+        let command = tool_call_args
+            .split("\"command\": \"")
+            .nth(1)
+            .unwrap()
+            .split("\"")
+            .nth(0)
+            .unwrap();
+        let active_commands = vec!["ssh", "sudo"];
+        if active_commands.iter().any(|cmd| command.contains(cmd)) {
+            state.show_shell_mode = true;
+            state.is_dialog_open = false;
+            state.input.clear();
+            state.cursor_position = 0;
+            state.run_shell_command(command.to_string(), shell_tx);
+            return;
+        }
+
         if state.dialog_selected == 0 {
             if let Some(tool_call) = &state.dialog_command {
                 let _ = output_tx.try_send(OutputEvent::AcceptTool(tool_call.clone()));

--- a/tui/src/view.rs
+++ b/tui/src/view.rs
@@ -413,15 +413,13 @@ fn render_multiline_input(f: &mut Frame, state: &AppState, area: Rect) {
                 if !in_word {
                     word_start = i;
                 }
-            } else {
-                if !in_word {
-                    if word_start < i {
-                        // There were spaces before this word
-                        word_positions.push((word_start, i, true)); // true = whitespace
-                    }
-                    word_start = i;
-                    in_word = true;
+            } else if !in_word {
+                if word_start < i {
+                    // There were spaces before this word
+                    word_positions.push((word_start, i, true)); // true = whitespace
                 }
+                word_start = i;
+                in_word = true;
             }
         }
 


### PR DESCRIPTION
## Changelog

### Enhancement: Fast PageUp/PageDown Scrolling

- Added support for fast scrolling in the messages view using **PageUp** and **PageDown** keys (or `Fn + ↑/↓` on Mac).
- Updated the keyboard shortcuts hint to include PageUp/Down for fast scroll.
- Improved scroll logic so PageUp/Down works even when at the bottom of the view.

---

### Feature: Interactive Shell Mode for Commands

- Added a shell mode that allows running interactive commands (e.g., `ssh`, `sudo`, editors) directly from the TUI.
- Shell commands are now executed inside a PTY, enabling full interactivity (password prompts, editors, etc.).
- User input is forwarded to the running command, and output is displayed in real time in the TUI.
- Improved the user experience for any command that requires input, not just simple output.
- Enhanced the TUI to support toggling shell mode and handling interactive command sessions.
