### PR TITLE
Add central OS trust for tls clients, required for warden

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3644,6 +3644,7 @@ dependencies = [
  "reqwest",
  "rmcp",
  "rustls",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ rustls-pemfile = "2.1.2"
 tokio-rustls = "0.26.0"
 axum-server = { version = "0.7.2", features = ["tls-rustls"] }
 time = { version = "0.3", features = ["macros"] }
+rustls-platform-verifier = "0.5"
 
 # Required nightly
 [workspace.lints.clippy]

--- a/cli/src/commands/auto_update.rs
+++ b/cli/src/commands/auto_update.rs
@@ -1,5 +1,7 @@
 use crate::utils::check_update::get_latest_cli_version;
 use crate::utils::plugins::{PluginConfig, extract_tar_gz, extract_zip, get_download_info};
+use reqwest::header::HeaderMap;
+use stakpak_shared::tls_client::create_tls_client;
 use std::env;
 use std::fs;
 use std::path::PathBuf;
@@ -124,7 +126,7 @@ async fn download_and_extract_binary(config: &PluginConfig) -> Result<String, St
     println!("Downloading {}...", config.name);
 
     // Download the archive
-    let client = reqwest::Client::new();
+    let client = create_tls_client(HeaderMap::new())?;
     let response = client
         .get(&download_url)
         .send()

--- a/cli/src/utils/check_update.rs
+++ b/cli/src/utils/check_update.rs
@@ -1,5 +1,6 @@
 use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
 use serde::Deserialize;
+use stakpak_shared::tls_client::create_tls_client;
 use std::error::Error;
 
 use crate::commands::auto_update::run_auto_update;
@@ -33,9 +34,7 @@ pub async fn get_latest_cli_version() -> Result<String, Box<dyn Error>> {
     let mut headers = HeaderMap::new();
     headers.insert(USER_AGENT, HeaderValue::from_static("update-checker"));
 
-    let client = reqwest::Client::builder()
-        .default_headers(headers)
-        .build()?;
+    let client = create_tls_client(headers)?;
 
     let url = "https://api.github.com/repos/stakpak/cli/releases/latest".to_string();
 

--- a/cli/src/utils/plugins.rs
+++ b/cli/src/utils/plugins.rs
@@ -1,5 +1,7 @@
 use flate2::read::GzDecoder;
 use reqwest;
+use reqwest::header::HeaderMap;
+use stakpak_shared::tls_client::create_tls_client;
 use std::fs;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
@@ -153,7 +155,7 @@ async fn get_latest_version(config: &PluginConfig) -> Result<String, String> {
     let version_url = format!("{}/latest_version.txt", config.base_url);
 
     // Download the version file
-    let client = reqwest::Client::new();
+    let client = create_tls_client(HeaderMap::new())?;
     let response = client
         .get(&version_url)
         .send()
@@ -231,7 +233,7 @@ async fn download_and_install_plugin(config: &PluginConfig) -> Result<String, St
     println!("Downloading {} plugin...", config.name);
 
     // Download the archive
-    let client = reqwest::Client::new();
+    let client = create_tls_client(HeaderMap::new())?;
     let response = client
         .get(&download_url)
         .send()

--- a/libs/api/Cargo.toml
+++ b/libs/api/Cargo.toml
@@ -13,6 +13,6 @@ chrono = { workspace = true }
 reqwest = { workspace = true }
 rmcp = { workspace = true }
 rustls = { workspace = true }
+rustls-platform-verifier = { workspace = true }
 eventsource-stream = "0.2.3"
 url = "2.5.0"
-rustls-platform-verifier = "0.5"

--- a/libs/api/src/lib.rs
+++ b/libs/api/src/lib.rs
@@ -4,6 +4,7 @@ use reqwest::{Client as ReqwestClient, Error as ReqwestError, Response, header};
 use rmcp::model::Content;
 use rmcp::model::JsonRpcResponse;
 use serde::{Deserialize, Serialize};
+use stakpak_shared::tls_client::create_tls_client;
 use url::Url;
 pub mod models;
 use futures_util::Stream;
@@ -20,7 +21,6 @@ pub mod kevin_v1;
 pub mod norbert_v1;
 pub mod stuart_v1;
 pub use models::Block;
-use rustls_platform_verifier::BuilderVerifierExt;
 
 #[derive(Clone, Debug)]
 
@@ -85,18 +85,7 @@ impl Client {
                 .expect("Invalid user agent format"),
         );
 
-        // needed to use OS-provided CA certificates with Rustls
-        let arc_crypto_provider = std::sync::Arc::new(rustls::crypto::ring::default_provider());
-        let tls_config = rustls::ClientConfig::builder_with_provider(arc_crypto_provider)
-            .with_safe_default_protocol_versions()
-            .expect("Failed to build client TLS config")
-            .with_platform_verifier()
-            .with_no_client_auth();
-        let client = ReqwestClient::builder()
-            .use_preconfigured_tls(tls_config)
-            .default_headers(headers)
-            .build()
-            .expect("Failed to create HTTP client");
+        let client = create_tls_client(headers)?;
 
         Ok(Self {
             client,

--- a/libs/shared/Cargo.toml
+++ b/libs/shared/Cargo.toml
@@ -22,6 +22,8 @@ time = { workspace = true }
 regex = { workspace = true }
 chrono = { workspace = true }
 rmcp = { workspace = true }
+reqwest = { workspace = true }
+rustls-platform-verifier = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/libs/shared/src/lib.rs
+++ b/libs/shared/src/lib.rs
@@ -6,4 +6,5 @@ pub mod models;
 pub mod secret_manager;
 pub mod secrets;
 pub mod task_manager;
+pub mod tls_client;
 pub mod utils;

--- a/libs/shared/src/tls_client.rs
+++ b/libs/shared/src/tls_client.rs
@@ -1,0 +1,20 @@
+use reqwest::{Client, header::HeaderMap};
+use rustls_platform_verifier::BuilderVerifierExt;
+
+pub fn create_tls_client(headers: HeaderMap) -> Result<Client, String> {
+    // needed to use OS-provided CA certificates with Rustls
+    let arc_crypto_provider = std::sync::Arc::new(rustls::crypto::ring::default_provider());
+    let tls_config = rustls::ClientConfig::builder_with_provider(arc_crypto_provider)
+        .with_safe_default_protocol_versions()
+        .expect("Failed to build client TLS config")
+        .with_platform_verifier()
+        .with_no_client_auth();
+
+    let client = Client::builder()
+        .use_preconfigured_tls(tls_config)
+        .default_headers(headers)
+        .build()
+        .expect("Failed to create HTTP client");
+
+    Ok(client)
+}


### PR DESCRIPTION
Make sure update operations also use OS-trusted certificate chains, this makes sure all client functionality works as expected with warden