### PR TITLE
feat: Python in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 RUN cargo build --release --target-dir /usr/src/app/target
 RUN strip /usr/src/app/target/release/stakpak
 
-FROM debian:bookworm-slim
+FROM python:3.13-slim-bookworm
 LABEL org.opencontainers.image.source="https://github.com/stakpak/agent" \
     org.opencontainers.image.description="Stakpak Agent" \
     maintainer="contact@stakpak.dev"


### PR DESCRIPTION
- Use [python:3.13-slim-bookworm](https://hub.docker.com/layers/library/python/3.13-slim-bookworm/images/sha256-932fc08817fe81cc89e3c41adb7d0d8e89ad4aed911ab10744e799a3779c4872) which has [debian:bookworm-slim](https://hub.docker.com/layers/library/debian/bookworm-slim/images/sha256-96e103b4715d1777c321dd7384d13d268b387897a7ad86b78ae0d3a474aec366) as a base image to add python runtime

Closes #201