### PR TITLE
ACP upgrade and fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,15 +54,29 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.1.1"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b91e5ec3ce05e8effb2a7a3b7b1a587daa6699b9f98bbde6a35e44b8c6c773a"
+checksum = "76133c067c37ae7a3641c3ad1ec88f36aac06cea5f9b3b49b5c29f18214f9101"
 dependencies = [
+ "agent-client-protocol-schema",
  "anyhow",
  "async-broadcast",
+ "async-trait",
  "futures",
  "log",
  "parking_lot",
+ "schemars 1.0.4",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "agent-client-protocol-schema"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36bd1f574102fc8611d1018e06246307c3d16ed862d4259cab55bbf4be804e84"
+dependencies = [
+ "anyhow",
  "schemars 1.0.4",
  "serde",
  "serde_json",
@@ -4770,6 +4784,7 @@ name = "stakpak"
 version = "0.2.63"
 dependencies = [
  "agent-client-protocol",
+ "async-trait",
  "chrono",
  "clap 4.5.41",
  "config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ rustls-platform-verifier = "0.5"
 crossterm = "0.29"
 tempfile = "3.0"
 similar = { version = "2.7.0", features = ["inline"] }
+async-trait = "0.1"
 
 # Required nightly
 [workspace.lints.clippy]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -35,12 +35,13 @@ crossterm = { workspace = true }
 open = "5.3.2"
 glob = "0.3"
 # ACP dependencies
-agent-client-protocol = "0.1.1"
+agent-client-protocol = "0.4.7"
 jsonrpc-core = "18.0.0"
 jsonrpc-derive = "18.0.0"
 tokio-util = { version = "0.7", features = ["compat"] }
 log = "0.4"
 regex = { workspace = true }
+async-trait = { workspace = true }
 
 [lints.clippy]
 unwrap_used = "deny"

--- a/cli/src/commands/acp/fs_handler.rs
+++ b/cli/src/commands/acp/fs_handler.rs
@@ -50,6 +50,7 @@ pub fn spawn_fs_handler(
                 } => {
                     log::info!("Processing ACP read_text_file: {:?}", path);
                     let request = acp::ReadTextFileRequest {
+                        meta: None,
                         session_id,
                         path,
                         line,
@@ -69,6 +70,7 @@ pub fn spawn_fs_handler(
                 } => {
                     log::info!("Processing ACP write_text_file: {:?}", path);
                     let request = acp::WriteTextFileRequest {
+                        meta: None,
                         session_id,
                         path,
                         content,

--- a/libs/shared/Cargo.toml
+++ b/libs/shared/Cargo.toml
@@ -27,7 +27,7 @@ rustls-platform-verifier = { workspace = true }
 russh = { version = "0.53.0" }
 russh-sftp = { version = "2.1.1" }
 dirs = "5.0"
-async-trait = "0.1"
+async-trait = { workspace = true }
 futures = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## ACP Protocol Upgrade and Improvements

### ✅ Protocol Upgrade
- Upgraded ACP protocol from 0.1.1 to 0.4.7
- Added `async-trait` dependency for proper trait implementation

### ✅ Breaking Changes Fixed
- Added missing `meta: None` fields to all ACP structs
- Updated method signatures to match new trait definition
- Fixed lifetime parameter mismatches
- Corrected return types for `authenticate` and `load_session` methods

### ✅ Bug Fixes
- Fixed tool call cancellation logic that was incorrectly detecting cancellations
- Resolved race condition in cancellation check that was looking at all messages instead of current tool results

### ✅ Error Handling Improvements
- Replaced generic "Internal error" messages with descriptive error details
- Added specific error messages for tool execution failures
- Improved debugging experience with actionable error information