### PR TITLE
fix: correct config path from ./stakpak to .stakpak

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -7,7 +7,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 const STAKPAK_API_ENDPOINT: &str = "https://apiv2.stakpak.dev";
-const STAKPAK_CONFIG_PATH: &str = "./stakpak/config.toml";
+const STAKPAK_CONFIG_PATH: &str = ".stakpak/config.toml";
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct RulebookConfig {


### PR DESCRIPTION
## Problem
The refactor in commit 538e638 accidentally changed the config directory from `.stakpak` to `./stakpak` (missing dot in directory name).

This caused:
- Profile loading to fail (e.g., `--profile work` couldn't find profiles)
- Warden not mounting the config file correctly

## Root Cause
Line 10 in `cli/src/config.rs`:
```rust
const STAKPAK_CONFIG_PATH: &str = "./stakpak/config.toml";
```

Should be:
```rust
const STAKPAK_CONFIG_PATH: &str = ".stakpak/config.toml";
```

## Solution
Fixed the typo to restore correct path resolution to `~/.stakpak/config.toml`

## Testing
Verified all profiles load correctly:
- ✓ `--profile work`
- ✓ `--profile local`
- ✓ `--profile readonly`

## Impact
- Fixes profile loading regression introduced in v0.2.67
- Restores warden config volume mounting