### PR TITLE
Add usage to command palette; tui enhancements

### DIFF
--- a/tui/src/services/command_palette.rs
+++ b/tui/src/services/command_palette.rs
@@ -26,6 +26,7 @@ pub enum CommandAction {
     SubmitIssue,
     GetSupport,
     NewSession,
+    ShowUsage,
 }
 
 impl Command {
@@ -76,6 +77,12 @@ pub fn get_all_commands() -> Vec<Command> {
             "Resume last session",
             "/resume",
             CommandAction::ResumeSession,
+        ),
+        Command::new(
+            "Usage",
+            "Show token usage for this session",
+            "/usage",
+            CommandAction::ShowUsage,
         ),
         Command::new(
             "Status",

--- a/tui/src/services/helper_block.rs
+++ b/tui/src/services/helper_block.rs
@@ -229,6 +229,7 @@ pub fn push_help_message(state: &mut AppState) {
     use ratatui::style::{Color, Modifier, Style};
     use ratatui::text::{Line, Span};
     let mut lines = Vec::new();
+    lines.push(Line::from(""));
     // usage mode
     lines.push(Line::from(vec![Span::styled(
         "Usage Mode",

--- a/tui/src/services/update.rs
+++ b/tui/src/services/update.rs
@@ -720,7 +720,6 @@ pub fn update(
         InputEvent::ShellCompleted(_code) => {
             // Command completed, reset active command state
             state.waiting_for_shell_input = false;
-            state.text_area.set_shell_mode(false);
             if let Some(dialog_command) = &state.dialog_command {
                 let dialog_command_id = dialog_command.id.clone();
                 let result = shell_command_to_tool_call_result(state);
@@ -774,6 +773,7 @@ pub fn update(
                 state.show_shell_mode = false;
                 state.dialog_command = None;
                 state.toggle_approved_message = true;
+                state.text_area.set_shell_mode(false);
             }
             if state.ondemand_shell_mode {
                 let new_tool_call_result = shell_command_to_tool_call_result(state);
@@ -785,7 +785,6 @@ pub fn update(
             state.active_shell_command = None;
             state.active_shell_command_output = None;
             state.text_area.set_text("");
-            state.text_area.set_shell_mode(false);
             state.messages.push(Message::plain_text(""));
             state.is_tool_call_shell_command = false;
             adjust_scroll(state, message_area_height, message_area_width);
@@ -2555,6 +2554,9 @@ fn execute_command_palette_selection(
         }
         CommandAction::GetSupport => {
             push_support_message(state);
+        }
+        CommandAction::ShowUsage => {
+            push_usage_message(state);
         }
     }
     state.text_area.set_text("");


### PR DESCRIPTION
- Add ShowUsage command action and /usage command in command palette
- Implement usage message handler in update service
- Refactor shell mode cleanup to avoid redundant set_shell_mode calls
- Add spacing in help message display