### PR TITLE
feat: recovery-options

### DIFF
--- a/cli/src/commands/agent/run/stream.rs
+++ b/cli/src/commands/agent/run/stream.rs
@@ -56,25 +56,6 @@ pub async fn process_responses_stream(
         match &response {
             Ok(response) => {
                 if let Some(metadata) = &response.metadata {
-                    eprintln!("[interactive] stream metadata: {}", metadata);
-                    if metadata
-                        .get("history_updated")
-                        .and_then(Value::as_bool)
-                        .unwrap_or(false)
-                    {
-                        let checkpoint_id = metadata
-                            .get("checkpoint_id")
-                            .and_then(Value::as_str)
-                            .unwrap_or_default();
-                        if checkpoint_id.is_empty() {
-                            eprintln!("[interactive] history_updated: true");
-                        } else {
-                            eprintln!(
-                                "[interactive] history_updated: true, checkpoint_id: {}",
-                                checkpoint_id
-                            );
-                        }
-                    }
                     latest_metadata = Some(metadata.clone());
                 }
                 // Handle usage first - it can come in any event, including those with no content

--- a/libs/api/src/lib.rs
+++ b/libs/api/src/lib.rs
@@ -450,8 +450,6 @@ impl Client {
 
         let response = self.handle_response_error(response).await?;
 
-        eprintln!("Recovery options response: {:?}", response);
-
         let value: serde_json::Value = response.json().await.map_err(|e| e.to_string())?;
         if value.is_null() {
             return Ok(RecoveryOptionsResponse {
@@ -512,8 +510,6 @@ impl Client {
             action,
             selected_option_id,
         };
-
-        eprintln!("Submitting recovery action: {:?}", payload);
 
         let response = self
             .client
@@ -594,8 +590,7 @@ impl Client {
         let stream = response.bytes_stream().eventsource().map(|event| {
             event
                 .map_err(|err| {
-                    eprintln!("stream: failed to read response: {:?}", err);
-                    ApiStreamError::Unknown("Failed to read response".to_string())
+                    ApiStreamError::Unknown(format!("Failed to read response: {:?}", err))
                 })
                 .and_then(|event| match event.event.as_str() {
                     "error" => Err(ApiStreamError::from(event.data)),

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -362,6 +362,9 @@ pub enum InputEvent {
     StreamUsage(stakpak_shared::models::integrations::openai::Usage),
     RequestTotalUsage,
     TotalUsage(stakpak_shared::models::integrations::openai::Usage),
+    // Checkpoint message replacement
+    ReplaceMessagesFromCheckpoint(Vec<stakpak_shared::models::integrations::openai::ChatMessage>),
+    SetRenderedCheckpointMessages(Vec<Message>),
 }
 
 #[derive(Debug)]

--- a/tui/src/event.rs
+++ b/tui/src/event.rs
@@ -29,7 +29,7 @@ pub fn map_crossterm_event_to_input_event(event: Event) -> Option<InputEvent> {
                 KeyCode::Char('s') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                     Some(InputEvent::HandleCtrlS)
                 }
-                KeyCode::Char('m') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                KeyCode::Char('x') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                     Some(InputEvent::ExpandNotifications)
                 }
                 KeyCode::Char('g') if key.modifiers.contains(KeyModifiers::CONTROL) => {

--- a/tui/src/view.rs
+++ b/tui/src/view.rs
@@ -421,7 +421,7 @@ fn render_loading_indicator(f: &mut Frame, state: &mut AppState, area: Rect) {
 
     // Middle message for recovery options
     let middle_message = (!state.recovery_options.is_empty())
-        .then_some("Detected agent tool call loop . ctr+g for more");
+        .then_some("Detected agent tool call loop . ctrl+x for more");
     let middle_len = middle_message.map(|msg| msg.len()).unwrap_or(0);
 
     let left_len: usize = left_spans.iter().map(|s| s.content.len()).sum();


### PR DESCRIPTION
### What’s in place so far:
- API client now returns the full recovery response payload (options plus response id) for future actions.
- Interactive mode forwards that full response to the TUI, which stores both the metadata and option list.
- Recovery popup styling matches the other dialogs: bottom-docked, cyan title, yellow border, keyboard help on the left, and aligned numbering that changes color when selected.
- Added placeholder recovery data in AppState::new() so the UI can be exercised before the backend is ready.

### Still unfinished:
Draft PR – the workflow relies on fake data; no real recovery actions are triggered yet.