### PR TITLE
feat: add local rulebook support via Stakpak API

### DIFF
--- a/cli/src/commands/acp/server.rs
+++ b/cli/src/commands/acp/server.rs
@@ -85,6 +85,7 @@ impl StakpakAcpAgent {
             }
             ProviderType::Local => {
                 let client = LocalClient::new(LocalClientConfig {
+                    stakpak_base_url: Some(config.api_endpoint.clone()),
                     store_path: None,
                     anthropic_config: config.anthropic.clone(),
                     openai_config: config.openai.clone(),

--- a/cli/src/commands/agent/run/mode_async.rs
+++ b/cli/src/commands/agent/run/mode_async.rs
@@ -87,6 +87,7 @@ pub async fn run_async(ctx: AppConfig, config: RunAsyncConfig) -> Result<(), Str
         }
         ProviderType::Local => {
             let client = LocalClient::new(LocalClientConfig {
+                stakpak_base_url: Some(ctx_clone.api_endpoint.clone()),
                 store_path: None,
                 anthropic_config: ctx_clone.anthropic.clone(),
                 openai_config: ctx_clone.openai.clone(),
@@ -141,6 +142,7 @@ pub async fn run_async(ctx: AppConfig, config: RunAsyncConfig) -> Result<(), Str
         }
         ProviderType::Local => {
             let client = LocalClient::new(LocalClientConfig {
+                stakpak_base_url: Some(ctx.api_endpoint.clone()),
                 store_path: None,
                 anthropic_config: ctx.anthropic.clone(),
                 openai_config: ctx.openai.clone(),

--- a/cli/src/commands/agent/run/mode_interactive.rs
+++ b/cli/src/commands/agent/run/mode_interactive.rs
@@ -168,6 +168,7 @@ pub async fn run_interactive(
                 }
                 ProviderType::Local => {
                     let client = LocalClient::new(LocalClientConfig {
+                        stakpak_base_url: Some(api_endpoint_for_client.clone()),
                         store_path: None,
                         anthropic_config: ctx_clone.anthropic.clone(),
                         openai_config: ctx_clone.openai.clone(),
@@ -1016,6 +1017,7 @@ pub async fn run_interactive(
                 ProviderType::Local => {
                     let client = LocalClient::new(LocalClientConfig {
                         store_path: None,
+                        stakpak_base_url: Some(new_config.api_endpoint.clone()),
                         anthropic_config: new_config.anthropic.clone(),
                         openai_config: new_config.openai.clone(),
                         eco_model: new_config.eco_model.clone(),
@@ -1088,6 +1090,7 @@ pub async fn run_interactive(
             ProviderType::Local => {
                 let client = LocalClient::new(LocalClientConfig {
                     store_path: None,
+                    stakpak_base_url: Some(final_api_endpoint.clone()),
                     anthropic_config: ctx.anthropic.clone(),
                     openai_config: ctx.openai.clone(),
                     eco_model: ctx.eco_model.clone(),

--- a/cli/src/commands/agent/run/profile_switch.rs
+++ b/cli/src/commands/agent/run/profile_switch.rs
@@ -45,6 +45,7 @@ pub async fn validate_profile_switch(
         }
         ProviderType::Local => {
             let client = LocalClient::new(LocalClientConfig {
+                stakpak_base_url: Some(new_config.api_endpoint.clone()),
                 store_path: None,
                 anthropic_config: new_config.anthropic.clone(),
                 openai_config: new_config.openai.clone(),

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -159,6 +159,7 @@ async fn get_client(config: &AppConfig) -> Result<Arc<dyn AgentProvider>, String
         }
         ProviderType::Local => {
             let client = LocalClient::new(LocalClientConfig {
+                stakpak_base_url: Some(config.api_endpoint.clone()),
                 store_path: None,
                 anthropic_config: config.anthropic.clone(),
                 openai_config: config.openai.clone(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -247,6 +247,7 @@ async fn main() {
                         ProviderType::Local => {
                             let client = LocalClient::new(LocalClientConfig {
                                 store_path: None,
+                                stakpak_base_url: Some(config.api_endpoint.clone()),
                                 anthropic_config: config.anthropic.clone(),
                                 openai_config: config.openai.clone(),
                                 eco_model: config.eco_model.clone(),

--- a/libs/api/src/local/tests.rs
+++ b/libs/api/src/local/tests.rs
@@ -16,6 +16,7 @@ async fn test_local_db_operations() {
         .to_string();
 
     let config = LocalClientConfig {
+        stakpak_base_url: None,
         store_path: Some(db_path.clone()),
         anthropic_config: None,
         openai_config: None,


### PR DESCRIPTION
- Add stakpak_base_url config to LocalClientConfig
- Implement list_rulebooks() for LocalClient using /v1/rules endpoint
- Wire stakpak_base_url through all LocalClient instantiations:
  - ACP server mode
  - Async agent mode
  - Interactive agent mode
  - Profile switching
- Add TLS client support for API requests
- Return empty list when stakpak_base_url not configured

This enables local mode to fetch and use rulebooks from the Stakpak platform.