### PR TITLE
fix: shortcuts popup scroll navigation out-of-bounds bug

### DIFF
--- a/tui/src/services/handlers/navigation.rs
+++ b/tui/src/services/handlers/navigation.rs
@@ -136,11 +136,7 @@ pub fn handle_up_navigation(state: &mut AppState) {
 
     if state.show_shortcuts_popup {
         // Handle scrolling up in shortcuts popup (like collapsed messages)
-        if state.shortcuts_scroll >= SCROLL_LINES {
-            state.shortcuts_scroll -= SCROLL_LINES;
-        } else {
-            state.shortcuts_scroll = 0;
-        }
+        state.shortcuts_scroll = state.shortcuts_scroll.saturating_sub(SCROLL_LINES);
         return;
     }
     if state.show_rulebook_switcher {
@@ -205,15 +201,7 @@ pub fn handle_down_navigation(
 
     if state.show_shortcuts_popup {
         // Handle scrolling down in shortcuts popup (like collapsed messages)
-        let all_lines = crate::services::shortcuts_popup::get_cached_shortcuts_content(None);
-        let total_lines = all_lines.len();
-        let max_scroll = total_lines;
-
-        if state.shortcuts_scroll + SCROLL_LINES < max_scroll {
-            state.shortcuts_scroll += SCROLL_LINES;
-        } else {
-            state.shortcuts_scroll = max_scroll;
-        }
+        state.shortcuts_scroll = state.shortcuts_scroll.saturating_add(SCROLL_LINES);
         return;
     }
     if state.show_rulebook_switcher {

--- a/tui/src/services/shortcuts_popup.rs
+++ b/tui/src/services/shortcuts_popup.rs
@@ -7,6 +7,8 @@ use ratatui::{
 };
 use std::sync::OnceLock;
 
+use crate::constants::SCROLL_BUFFER_LINES;
+
 #[derive(Debug, Clone)]
 pub struct Shortcut {
     pub key: String,
@@ -100,11 +102,11 @@ pub fn get_cached_shortcuts_content(width: Option<usize>) -> &'static Vec<Line<'
         let shortcuts = get_all_shortcuts();
 
         // Group shortcuts by category
-        let mut categories: std::collections::HashMap<String, Vec<&Shortcut>> =
+        let mut categories: std::collections::HashMap<&str, Vec<&Shortcut>> =
             std::collections::HashMap::new();
         for shortcut in &shortcuts {
             categories
-                .entry(shortcut.category.clone())
+                .entry(&shortcut.category)
                 .or_default()
                 .push(shortcut);
         }
@@ -127,7 +129,7 @@ pub fn get_cached_shortcuts_content(width: Option<usize>) -> &'static Vec<Line<'
 
         // Process categories in the EXACT order defined above
         for category_name in &category_order {
-            if let Some(category_shortcuts) = categories.get(*category_name) {
+            if let Some(category_shortcuts) = categories.get(category_name) {
                 // Add category header
                 let category_style = Style::default()
                     .fg(Color::Cyan)
@@ -174,7 +176,7 @@ pub fn get_shortcuts_count() -> usize {
     get_all_shortcuts().len()
 }
 
-pub fn render_shortcuts_popup(f: &mut Frame, state: &crate::app::AppState) {
+pub fn render_shortcuts_popup(f: &mut Frame, state: &mut crate::app::AppState) {
     // Calculate popup size (60% width, fit height to content)
     let area = centered_rect(60, 80, f.area());
 
@@ -220,13 +222,10 @@ pub fn render_shortcuts_popup(f: &mut Frame, state: &crate::app::AppState) {
     let shortcuts_count = get_shortcuts_count();
 
     // Calculate scroll position (similar to collapsed messages)
-    const SCROLL_BUFFER_LINES: usize = 2;
     let max_scroll = total_lines.saturating_sub(height.saturating_sub(SCROLL_BUFFER_LINES));
-    let scroll = if state.shortcuts_scroll > max_scroll {
-        max_scroll
-    } else {
-        state.shortcuts_scroll
-    };
+
+    state.shortcuts_scroll = state.shortcuts_scroll.min(max_scroll);
+    let scroll = state.shortcuts_scroll;
 
     // Add top arrow indicator if there are hidden items above
     let mut visible_lines = Vec::new();


### PR DESCRIPTION
## Description
Fixed scrolling bug where pressing Down beyond the bottom of shortcuts popup caused the scroll position to keep incrementing. This required multiple Up presses to restore visual scrolling.

## Related Issues
Fixes #356 

## Changes Made
- Clamp scroll position in render function to prevent over scrolling
- Simplify navigation handlers to use `saturating_add()`/`saturating_sub()`
- Remove duplicate `SCROLL_BUFFER_LINES` constant, import from constants module
- Optimize category HashMap to use &str instead of String to avoid cloning

## Testing
- [x] All tests pass locally
- [ ] Added tests for new functionality
- [x] Tested on Windows terminal wsl2

## Screenshots
![WindowsTerminal_zknUeCX0K9](https://github.com/user-attachments/assets/729dc47e-683b-4481-99da-48dc4fba0087)

## Breaking Changes
None