### PR TITLE
fix test: use `config.store_path` (temp dir) instead of deafult home path

### DIFF
--- a/libs/api/src/local/mod.rs
+++ b/libs/api/src/local/mod.rs
@@ -72,16 +72,20 @@ const TITLE_GENERATOR_PROMPT: &str = include_str!("./prompts/session_title_gener
 
 impl LocalClient {
     pub async fn new(config: LocalClientConfig) -> Result<Self, String> {
-        let default_store_path = std::env::home_dir()
-            .unwrap_or_default()
-            .join(DEFAULT_STORE_PATH);
+        let store_path = config.store_path.unwrap_or_else(|| {
+            std::env::home_dir()
+                .unwrap_or_default()
+                .join(DEFAULT_STORE_PATH)
+                .display()
+                .to_string()
+        });
 
-        if let Some(parent) = default_store_path.parent() {
+        if let Some(parent) = std::path::Path::new(&store_path).parent() {
             std::fs::create_dir_all(parent)
                 .map_err(|e| format!("Failed to create database directory: {}", e))?;
         }
 
-        let db = Builder::new_local(default_store_path.display().to_string())
+        let db = Builder::new_local(store_path)
             .build()
             .await
             .map_err(|e| e.to_string())?;

--- a/libs/api/src/local/tests.rs
+++ b/libs/api/src/local/tests.rs
@@ -19,7 +19,7 @@ async fn test_local_db_operations() {
 
     let config = LocalClientConfig {
         stakpak_base_url: None,
-        store_path: Some(db_path.clone()),
+        store_path: Some(db_path),
         anthropic_config: None,
         openai_config: None,
         gemini_config: None,


### PR DESCRIPTION
   ## Description
 use `config.store_path` (which is a temp dir) instead of ignoring it and using the default home path

   ## Testing
   - [x] All tests pass locally

   ## Screenshots
   the tests before the PR 
   ```
   test local::tests::test_local_db_operations ... FAILED

failures:

---- local::tests::test_local_db_operations stdout ----

thread 'local::tests::test_local_db_operations' (40622) panicked at libs/api/src/local/tests.rs:56:5:
assertion `left == right` failed
  left: 18
 right: 1
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

<img width="917" height="390" alt="image" src="https://github.com/user-attachments/assets/6c91fbb9-115a-4093-908d-9d7ac3436fbc" />

With this PR it's now created using `tempfile::tempdir()` and deleted after the test

   ## Breaking Changes
   None
