### PR TITLE
feat: add telemetry for local providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls 0.23.35",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -1306,6 +1306,37 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn 2.0.110",
 ]
 
@@ -2244,6 +2275,20 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -3931,7 +3976,22 @@ dependencies = [
  "shared_library",
  "shell-words",
  "winapi",
- "winreg",
+ "winreg 0.10.1",
+]
+
+[[package]]
+name = "posthog-rs"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610d236077c94c96194b0d2b40989bda4bf8faf60e15a0da6ef8ffd4c78f6c1c"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "reqwest 0.11.27",
+ "semver",
+ "serde",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -4325,6 +4385,47 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-rustls 0.24.2",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration 0.5.1",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 0.25.4",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
@@ -4352,13 +4453,13 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.35",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
- "system-configuration",
+ "system-configuration 0.6.1",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.26.4",
@@ -4383,7 +4484,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 1.3.1",
- "reqwest",
+ "reqwest 0.12.15",
  "serde",
  "thiserror 1.0.69",
  "tower-service",
@@ -4401,7 +4502,7 @@ dependencies = [
  "getrandom 0.2.16",
  "http 1.3.1",
  "hyper 1.8.1",
- "reqwest",
+ "reqwest 0.12.15",
  "reqwest-middleware",
  "retry-policies",
  "thiserror 2.0.17",
@@ -4460,7 +4561,7 @@ dependencies = [
  "pin-project-lite",
  "process-wrap",
  "rand 0.9.2",
- "reqwest",
+ "reqwest 0.12.15",
  "rmcp-macros",
  "schemars",
  "serde",
@@ -4706,6 +4807,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
@@ -4741,7 +4854,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
  "security-framework 2.11.1",
@@ -4757,6 +4870,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.5.1",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -4804,6 +4926,16 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted 0.9.0",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -4908,6 +5040,16 @@ dependencies = [
  "pbkdf2",
  "salsa20",
  "sha2",
+]
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5381,7 +5523,7 @@ dependencies = [
  "open",
  "rand 0.9.2",
  "regex",
- "reqwest",
+ "reqwest 0.12.15",
  "rmcp",
  "rpassword",
  "rustls 0.23.35",
@@ -5418,7 +5560,7 @@ dependencies = [
  "libsql",
  "once_cell",
  "regex",
- "reqwest",
+ "reqwest 0.12.15",
  "rmcp",
  "serde",
  "serde_json",
@@ -5436,7 +5578,7 @@ version = "0.3.2"
 dependencies = [
  "anyhow",
  "futures",
- "reqwest",
+ "reqwest 0.12.15",
  "rmcp",
  "serde_json",
  "stakpak-shared",
@@ -5450,7 +5592,7 @@ name = "stakpak-mcp-proxy"
 version = "0.3.2"
 dependencies = [
  "anyhow",
- "reqwest",
+ "reqwest 0.12.15",
  "rmcp",
  "serde",
  "serde_json",
@@ -5470,7 +5612,7 @@ dependencies = [
  "chrono",
  "fast_html2md",
  "rand 0.9.2",
- "reqwest",
+ "reqwest 0.12.15",
  "rmcp",
  "serde",
  "serde_json",
@@ -5501,10 +5643,11 @@ dependencies = [
  "hyper 1.8.1",
  "itertools 0.14.0",
  "notify",
+ "posthog-rs",
  "rand 0.9.2",
  "rcgen",
  "regex",
- "reqwest",
+ "reqwest 0.12.15",
  "reqwest-middleware",
  "reqwest-retry",
  "rmcp",
@@ -5679,13 +5822,34 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.9.4",
- "system-configuration-sys",
+ "system-configuration-sys 0.6.0",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -5924,6 +6088,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
  "tokio",
 ]
 
@@ -6531,6 +6705,12 @@ checksum = "ee3e3b5f5e80bc89f30ce8d0343bf4e5f12341c51f3e26cbeecbc7c85443e85b"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
@@ -7144,6 +7324,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -68,6 +68,8 @@ pub struct ProfileConfig {
 pub struct Settings {
     pub machine_name: Option<String>,
     pub auto_append_gitignore: Option<bool>,
+    pub user_id: Option<String>,
+    pub collect_telemetry: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -101,6 +103,8 @@ pub struct AppConfig {
     pub smart_model: Option<String>,
     pub eco_model: Option<String>,
     pub recovery_model: Option<String>,
+    pub user_id: Option<String>,
+    pub collect_telemetry: Option<bool>,
 }
 
 #[derive(Deserialize, Clone)]
@@ -135,6 +139,8 @@ impl From<AppConfig> for Settings {
         Settings {
             machine_name: config.machine_name,
             auto_append_gitignore: config.auto_append_gitignore,
+            user_id: config.user_id,
+            collect_telemetry: config.collect_telemetry,
         }
     }
 }
@@ -144,6 +150,8 @@ impl From<OldAppConfig> for Settings {
         Settings {
             machine_name: old_config.machine_name,
             auto_append_gitignore: old_config.auto_append_gitignore,
+            user_id: Some(uuid::Uuid::new_v4().to_string()),
+            collect_telemetry: Some(true),
         }
     }
 }
@@ -185,6 +193,8 @@ impl Default for ConfigFile {
             settings: Settings {
                 machine_name: None,
                 auto_append_gitignore: Some(true),
+                user_id: Some(uuid::Uuid::new_v4().to_string()),
+                collect_telemetry: Some(true),
             },
         }
     }
@@ -200,6 +210,8 @@ impl ConfigFile {
             settings: Settings {
                 machine_name: None,
                 auto_append_gitignore: Some(true),
+                user_id: Some(uuid::Uuid::new_v4().to_string()),
+                collect_telemetry: Some(true),
             },
         }
     }
@@ -231,7 +243,15 @@ impl ConfigFile {
     }
 
     fn set_app_config_settings(&mut self, config: AppConfig) {
-        self.settings = config.into();
+        let existing_user_id = self.settings.user_id.clone();
+        let existing_collect_telemetry = self.settings.collect_telemetry;
+
+        self.settings = Settings {
+            machine_name: config.machine_name,
+            auto_append_gitignore: config.auto_append_gitignore,
+            user_id: config.user_id.or(existing_user_id),
+            collect_telemetry: config.collect_telemetry.or(existing_collect_telemetry),
+        };
     }
 
     fn contains_readonly(&self) -> bool {
@@ -452,6 +472,8 @@ impl AppConfig {
             smart_model: profile_config.smart_model,
             eco_model: profile_config.eco_model,
             recovery_model: profile_config.recovery_model,
+            user_id: settings.user_id,
+            collect_telemetry: settings.collect_telemetry,
         }
     }
 
@@ -640,6 +662,8 @@ auto_append_gitignore = true
             smart_model: None,
             eco_model: None,
             recovery_model: None,
+            user_id: Some("test-user-id".into()),
+            collect_telemetry: Some(true),
         }
     }
 
@@ -756,6 +780,8 @@ auto_append_gitignore = true
             settings: Settings {
                 machine_name: None,
                 auto_append_gitignore: Some(true),
+                user_id: Some("test-user-id".into()),
+                collect_telemetry: Some(true),
             },
         };
 
@@ -1002,6 +1028,8 @@ auto_append_gitignore = true
             smart_model: None,
             eco_model: None,
             recovery_model: None,
+            user_id: Some("test-user-id".into()),
+            collect_telemetry: Some(true),
         };
 
         config.save().unwrap();

--- a/cli/src/onboarding/mod.rs
+++ b/cli/src/onboarding/mod.rs
@@ -170,12 +170,19 @@ pub async fn run_onboarding(config: &mut AppConfig, mode: OnboardingMode) {
 }
 
 async fn handle_own_keys_flow(config: &mut AppConfig, profile_name: &str) -> bool {
+    let mut disclaimer_shown = false;
+
     loop {
         print!("\x1b[u");
         print!("\x1b[0J");
         print!("\x1b[K");
         let _ = io::stdout().flush();
         print!("\x1b[s");
+
+        if !disclaimer_shown {
+            crate::onboarding::styled_output::render_telemetry_disclaimer();
+            disclaimer_shown = true;
+        }
 
         let provider_choice = select_option(
             "Choose provider or bring your own model",
@@ -270,13 +277,17 @@ async fn handle_openai_setup(config: &mut AppConfig, profile_name: &str) -> bool
                 NavResult::Forward(Some(true)) | NavResult::Forward(None) => {
                     let config_path = get_config_path_string(config);
 
-                    if let Err(e) = save_to_profile(&config_path, profile_name, profile.clone()) {
-                        crate::onboarding::styled_output::render_error(&format!(
-                            "Failed to save configuration: {}",
-                            e
-                        ));
-                        std::process::exit(1);
-                    }
+                    let telemetry =
+                        match save_to_profile(&config_path, profile_name, profile.clone()) {
+                            Ok(t) => t,
+                            Err(e) => {
+                                crate::onboarding::styled_output::render_error(&format!(
+                                    "Failed to save configuration: {}",
+                                    e
+                                ));
+                                std::process::exit(1);
+                            }
+                        };
 
                     print!("\r\n");
                     crate::onboarding::styled_output::render_success(
@@ -293,6 +304,8 @@ async fn handle_openai_setup(config: &mut AppConfig, profile_name: &str) -> bool
                     if let Some(key) = &profile.api_key {
                         config.api_key = Some(key.clone());
                     }
+                    config.user_id = telemetry.user_id;
+                    config.collect_telemetry = telemetry.collect_telemetry;
 
                     true
                 }
@@ -345,13 +358,17 @@ async fn handle_gemini_setup(config: &mut AppConfig, profile_name: &str) -> bool
                 NavResult::Forward(Some(true)) | NavResult::Forward(None) => {
                     let config_path = get_config_path_string(config);
 
-                    if let Err(e) = save_to_profile(&config_path, profile_name, profile.clone()) {
-                        crate::onboarding::styled_output::render_error(&format!(
-                            "Failed to save configuration: {}",
-                            e
-                        ));
-                        std::process::exit(1);
-                    }
+                    let telemetry =
+                        match save_to_profile(&config_path, profile_name, profile.clone()) {
+                            Ok(t) => t,
+                            Err(e) => {
+                                crate::onboarding::styled_output::render_error(&format!(
+                                    "Failed to save configuration: {}",
+                                    e
+                                ));
+                                std::process::exit(1);
+                            }
+                        };
 
                     print!("\r\n");
                     crate::onboarding::styled_output::render_success(
@@ -369,6 +386,8 @@ async fn handle_gemini_setup(config: &mut AppConfig, profile_name: &str) -> bool
                     if let Some(key) = &profile.api_key {
                         config.api_key = Some(key.clone());
                     }
+                    config.user_id = telemetry.user_id;
+                    config.collect_telemetry = telemetry.collect_telemetry;
 
                     true
                 }
@@ -421,13 +440,17 @@ async fn handle_anthropic_setup(config: &mut AppConfig, profile_name: &str) -> b
                 NavResult::Forward(Some(true)) | NavResult::Forward(None) => {
                     let config_path = get_config_path_string(config);
 
-                    if let Err(e) = save_to_profile(&config_path, profile_name, profile.clone()) {
-                        crate::onboarding::styled_output::render_error(&format!(
-                            "Failed to save configuration: {}",
-                            e
-                        ));
-                        std::process::exit(1);
-                    }
+                    let telemetry =
+                        match save_to_profile(&config_path, profile_name, profile.clone()) {
+                            Ok(t) => t,
+                            Err(e) => {
+                                crate::onboarding::styled_output::render_error(&format!(
+                                    "Failed to save configuration: {}",
+                                    e
+                                ));
+                                std::process::exit(1);
+                            }
+                        };
 
                     print!("\r\n");
                     crate::onboarding::styled_output::render_success(
@@ -445,6 +468,8 @@ async fn handle_anthropic_setup(config: &mut AppConfig, profile_name: &str) -> b
                     if let Some(key) = &profile.api_key {
                         config.api_key = Some(key.clone());
                     }
+                    config.user_id = telemetry.user_id;
+                    config.collect_telemetry = telemetry.collect_telemetry;
 
                     true
                 }
@@ -508,13 +533,16 @@ async fn handle_hybrid_setup(config: &mut AppConfig, profile_name: &str) -> bool
 
     match crate::onboarding::menu::prompt_yes_no("Proceed with this configuration?", true) {
         NavResult::Forward(Some(true)) | NavResult::Forward(None) => {
-            if let Err(e) = save_to_profile(&config_path, profile_name, profile.clone()) {
-                crate::onboarding::styled_output::render_error(&format!(
-                    "Failed to save configuration: {}",
-                    e
-                ));
-                std::process::exit(1);
-            }
+            let telemetry = match save_to_profile(&config_path, profile_name, profile.clone()) {
+                Ok(t) => t,
+                Err(e) => {
+                    crate::onboarding::styled_output::render_error(&format!(
+                        "Failed to save configuration: {}",
+                        e
+                    ));
+                    std::process::exit(1);
+                }
+            };
 
             print!("\r\n");
             crate::onboarding::styled_output::render_success("✓ Configuration saved successfully");
@@ -533,6 +561,8 @@ async fn handle_hybrid_setup(config: &mut AppConfig, profile_name: &str) -> bool
             if let Some(key) = &profile.api_key {
                 config.api_key = Some(key.clone());
             }
+            config.user_id = telemetry.user_id;
+            config.collect_telemetry = telemetry.collect_telemetry;
 
             true
         }
@@ -665,13 +695,17 @@ async fn handle_byom_setup(config: &mut AppConfig, profile_name: &str) -> bool {
     let config_path = get_config_path_string(config);
 
     if let Some(profile) = configure_byom(2, 4) {
-        if let Err(e) = preview_and_save_to_profile(&config_path, profile_name, profile.clone()) {
-            crate::onboarding::styled_output::render_error(&format!(
-                "Failed to save configuration: {}",
-                e
-            ));
-            std::process::exit(1);
-        }
+        let telemetry =
+            match preview_and_save_to_profile(&config_path, profile_name, profile.clone()) {
+                Ok(t) => t,
+                Err(e) => {
+                    crate::onboarding::styled_output::render_error(&format!(
+                        "Failed to save configuration: {}",
+                        e
+                    ));
+                    std::process::exit(1);
+                }
+            };
 
         // Update AppConfig with saved values so we can use them immediately
         config.provider = profile
@@ -686,6 +720,8 @@ async fn handle_byom_setup(config: &mut AppConfig, profile_name: &str) -> bool {
         if let Some(key) = &profile.api_key {
             config.api_key = Some(key.clone());
         }
+        config.user_id = telemetry.user_id;
+        config.collect_telemetry = telemetry.collect_telemetry;
 
         true
     } else {

--- a/cli/src/onboarding/styled_output.rs
+++ b/cli/src/onboarding/styled_output.rs
@@ -188,3 +188,46 @@ pub fn render_default_models(smart_model: &str, eco_model: &str) {
     print!("  {}Eco: {}{}\r\n", Colors::GRAY, Colors::WHITE, eco_model);
     print!("\r\n");
 }
+
+/// Render a styled telemetry disclaimer box for local providers
+pub fn render_telemetry_disclaimer() {
+    let border = Colors::CYAN;
+    let r = Colors::RESET;
+
+    print!("\r\n");
+    print!(
+        "{}╭──────────────────────────────────────────────────────────╮{}\r\n",
+        border, r
+    );
+    print!(
+        "{}│{}  {}Anonymous Usage Tracking{}                                {}│{}\r\n",
+        border,
+        r,
+        Colors::GREEN,
+        r,
+        border,
+        r
+    );
+    print!(
+        "{}│{}  We collect anonymous telemetry to improve Stakpak.      {}│{}\r\n",
+        border, r, border, r
+    );
+    print!(
+        "{}│{}  No prompts, code, or personal data is collected.        {}│{}\r\n",
+        border, r, border, r
+    );
+    print!(
+        "{}│{}  Opt-out: set {}collect_telemetry = false{} in config        {}│{}\r\n",
+        border,
+        r,
+        Colors::YELLOW,
+        r,
+        border,
+        r
+    );
+    print!(
+        "{}╰──────────────────────────────────────────────────────────╯{}\r\n",
+        border, r
+    );
+    print!("\r\n");
+}

--- a/libs/shared/Cargo.toml
+++ b/libs/shared/Cargo.toml
@@ -32,6 +32,7 @@ futures-util = { workspace = true }
 reqwest-middleware = { version = "0.4.2", features = ["json"] }
 reqwest-retry = "0.8.0"
 itertools = "0.14.0"
+posthog-rs = "0.3.5"
 
 [dev-dependencies]
 tempfile = { workspace = true}

--- a/libs/shared/src/lib.rs
+++ b/libs/shared/src/lib.rs
@@ -10,5 +10,6 @@ pub mod remote_store;
 pub mod secret_manager;
 pub mod secrets;
 pub mod task_manager;
+pub mod telemetry;
 pub mod tls_client;
 pub mod utils;

--- a/libs/shared/src/telemetry.rs
+++ b/libs/shared/src/telemetry.rs
@@ -1,0 +1,53 @@
+//! Telemetry module for anonymous usage tracking
+//!
+//! This module provides PostHog integration for tracking local provider usage.
+//! Telemetry is opt-out and collects no personal data, prompts, or session content.
+
+use serde::Serialize;
+use std::fmt;
+
+const POSTHOG_API_KEY: &str = "phc_QA5vkh1LnITsEmIhDeSZ2cE8veaBdpUKceWa3b9X3K9";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum TelemetryEvent {
+    FirstOpen,
+    UserPrompted,
+}
+
+impl fmt::Display for TelemetryEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TelemetryEvent::FirstOpen => write!(f, "local_provider_first_open"),
+            TelemetryEvent::UserPrompted => write!(f, "local_provider_user_prompted"),
+        }
+    }
+}
+
+pub fn capture_event(
+    user_id: &str,
+    machine_name: Option<&str>,
+    enabled: bool,
+    event: TelemetryEvent,
+) {
+    if !enabled {
+        return;
+    }
+
+    let user_id = user_id.to_string();
+    let machine_name = machine_name.map(|s| s.to_string());
+    let event_name = event.to_string();
+
+    tokio::spawn(async move {
+        let client = posthog_rs::client(POSTHOG_API_KEY).await;
+        let mut posthog_event = posthog_rs::Event::new(event_name, user_id);
+        posthog_event.insert_prop("provider", "local").unwrap();
+
+        if let Some(name) = machine_name
+            && posthog_event.insert_prop("machine_name", name).is_err()
+        {
+            return;
+        }
+
+        let _ = client.capture(posthog_event).await;
+    });
+}


### PR DESCRIPTION
### Telemetry Implementation Review
- Opt-out Telemetry: Added collect_telemetry flag (default: true), allowing users to opt-out.
- Anonymous ID: Implemented UUID generation for user_id, ensuring anonymity while allowing basic user counting.
- Event Tracking:
1- local_provider_first_open: Fires once when a local provider is set up (successfully implemented with is_first_telemetry_setup check).
2- Local_provider_user_prompted: Fires on every prompt to a local provider.
- Disclaimer: Added a styled, bordered disclaimer during onboarding to transparently inform users about data collection.
