### PR TITLE
fix: strip v prefix from version in release workflow

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -35,7 +35,9 @@ jobs:
         id: check
         run: |
           TAG=${GITHUB_REF#refs/tags/}
-          echo "version=$TAG" >> $GITHUB_OUTPUT
+          # Remove 'v' prefix if present
+          VERSION=${TAG#v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
           if [[ "$TAG" == *"-beta"* ]]; then
             echo "is_beta=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Summary

- Fixes double `v` prefix bug in Homebrew formula updates (e.g., `vv0.3.5` → `v0.3.5`)
- The `setup` job now strips the `v` prefix from the git tag before outputting the version
- This aligns with how `publish_crates_io` already handles version extraction

## Problem

The `setup` job was outputting `v0.3.5` as the version, which when combined with `v${VERSION}` in the Homebrew job resulted in `vv0.3.5` in URLs and commit messages.

## Validation

| Job | Uses `setup.outputs.version` | Impact |
|-----|------------------------------|--------|
| **docker** | Yes - for image tags | ✅ Tags will be `0.3.5` (standard for docker) |
| **docker_warden** | Yes - for image tags | ✅ Tags will be `0.3.5` |
| **homebrew** | Yes - with `v${VERSION}` prefix | ✅ **Fixed!** URLs will be `v0.3.5` |
| **update-release-notes** | No - extracts directly from `GITHUB_REF` | ✅ Unaffected |
| **publish_crates_io** | No - extracts directly and strips `v` | ✅ Unaffected |