### PR TITLE
feat: add stakai to crates.io publish pipeline

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -199,6 +199,7 @@ jobs:
           
           # Publish dependencies first, then the main crate
           # Order matters: publish dependencies before dependents
+          publish_package stakai
           publish_package stakpak-shared
           publish_package stakpak-api
           publish_package stakpak-popup-widget

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5427,7 +5427,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakai"
-version = "0.1.0"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ homepage = "https://stakpak.io"
 
 
 [workspace.dependencies]
+stakai = { path = "libs/ai", version = "0.3.5" }
 stakpak-api = { path = "libs/api", version = "0.3.5" }
 stakpak-mcp-server = { path = "libs/mcp/server", version = "0.3.5" }
 stakpak-mcp-client = { path = "libs/mcp/client", version = "0.3.5" }
@@ -85,7 +86,6 @@ schemars = { version = "1.1.0", features = ["chrono"] }
 async-trait = "0.1"
 open = "5.3.2"
 log = "0.4"
-stakai = { path = "libs/ai" }
 
 # Required nightly
 [workspace.lints.clippy]

--- a/libs/ai/Cargo.toml
+++ b/libs/ai/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "stakai"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 authors = ["Stakpak <engineering@stakpak.dev>"]
 description = "A provider-agnostic Rust SDK for AI completions with streaming support - Built by Stakpak"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/stakpak/stakai"
+license = "Apache-2.0"
+repository = "https://github.com/stakpak/agent"
 homepage = "https://stakpak.dev"
 documentation = "https://docs.rs/stakai"
 keywords = ["ai", "llm", "openai", "anthropic", "sdk"]


### PR DESCRIPTION
- Add stakai as first package in publish order (no workspace deps)
- Add version to stakai workspace dependency for crates.io compatibility
- Update libs/ai/Cargo.toml to use workspace version and Apache-2.0 license