### PR TITLE
fix: include portable-pty for Windows builds

### DIFF
--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -43,7 +43,7 @@ unwrap_used = "deny"
 expect_used = "deny"
 
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(any(unix, windows))'.dependencies]
 portable-pty = "0.8"
 
 [target.'cfg(not(target_os = "android"))'.dependencies]


### PR DESCRIPTION
Fixes Windows build failure in v0.3.9 release.

**Root cause:** `portable-pty` was only included as a dependency for Unix targets (`cfg(unix)`), but the code in `shell_mode.rs` uses it unconditionally for the `run_pty_command` function.

**Fix:** Changed the target config from `cfg(unix)` to `cfg(any(unix, windows))` so the crate is available on both platforms.

Ref: https://github.com/stakpak/agent/actions/runs/20626967176