### PR TITLE
feat(tui): include directories in @ file search and respect gitignore

### DIFF
--- a/tui/src/services/file_search.rs
+++ b/tui/src/services/file_search.rs
@@ -100,7 +100,7 @@ impl Default for FileSearch {
 }
 
 impl FileSearch {
-    /// Load all files from current directory using parallel walking with ignore crate
+    /// Load all files and directories from current directory using parallel walking with ignore crate
     pub fn scan_directory(&mut self, dir: &Path) {
         let dir_str = dir.to_string_lossy().to_string();
 


### PR DESCRIPTION
## Summary

Enhances the @ file search feature in the TUI to include directories alongside files and properly respect gitignore rules.

## Changes

- Include directories in search results: The @ trigger now lists both files and directories. Directories are displayed with a trailing / to distinguish them from files.
- Respect gitignore files: Explicitly enabled support for:
  - .gitignore files
  - Global gitignore (~/.config/git/ignore)
  - .git/info/exclude
- Exclude .git directory: Uses OverrideBuilder with the !.git/ pattern to exclude the .git directory from search results.
- Rename function: load_files_from_directory → scan_directory for clarity.

## Files Changed

tui/src/services/file_search.rs