### PR TITLE
feat(cli): Add token usage output to async mode

### DIFF
--- a/libs/shared/src/models/llm.rs
+++ b/libs/shared/src/models/llm.rs
@@ -651,7 +651,7 @@ pub enum TokenType {
     CacheWriteInputTokens,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 pub struct PromptTokensDetails {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input_tokens: Option<u32>,

--- a/tui/src/services/handlers/tool.rs
+++ b/tui/src/services/handlers/tool.rs
@@ -27,13 +27,8 @@ pub fn handle_stream_tool_result(
     }
 
     // Check for interactive stall notification
-    // Check for interactive stall notification
     const INTERACTIVE_STALL_MARKER: &str = "__INTERACTIVE_STALL__";
     if progress.message.contains(INTERACTIVE_STALL_MARKER) {
-        // Stop the loader
-        state.loading = false;
-        state.is_streaming = false;
-
         // Extract the message content (everything after the marker)
         let stall_message = progress
             .message


### PR DESCRIPTION
- Accumulate token usage across all API calls in async mode
- Display session usage summary after final agent response
- Add Default derive to PromptTokensDetails struct
- Show prompt tokens breakdown (input, cache write, cache read)
- Remove disable loading on interactive commands

Fixes missing usage output when running with --async flag