### PR TITLE
feat(tui): add up/down navigation for profile switcher

### DIFF
--- a/tui/src/services/handlers/navigation.rs
+++ b/tui/src/services/handlers/navigation.rs
@@ -114,6 +114,14 @@ pub fn handle_dropdown_down(state: &mut AppState) {
 
 /// Handles upward navigation with approval popup check
 pub fn handle_up_navigation(state: &mut AppState) {
+    if state.show_profile_switcher {
+        if state.profile_switcher_selected > 0 {
+            state.profile_switcher_selected -= 1;
+        } else {
+            state.profile_switcher_selected = state.available_profiles.len().saturating_sub(1);
+        }
+        return;
+    }
     if state.show_shortcuts_popup {
         match state.shortcuts_popup_mode {
             crate::app::ShortcutsPopupMode::Commands => {
@@ -173,6 +181,14 @@ pub fn handle_down_navigation(
     message_area_height: usize,
     message_area_width: usize,
 ) {
+    if state.show_profile_switcher {
+        if state.profile_switcher_selected < state.available_profiles.len().saturating_sub(1) {
+            state.profile_switcher_selected += 1;
+        } else {
+            state.profile_switcher_selected = 0;
+        }
+        return;
+    }
     if state.show_shortcuts_popup {
         match state.shortcuts_popup_mode {
             crate::app::ShortcutsPopupMode::Commands => {


### PR DESCRIPTION
## Description
Add keyboard navigation support for the profile switcher popup in TUI.

## Changes Made
- Add circular up navigation in profile switcher (wraps from first to last item)
- Add circular down navigation in profile switcher (wraps from last to first item)
- Navigation is only active when profile switcher popup is visible

## Testing
- [x] All tests pass locally
- [ ] Tested on Linux/macOS/Windows

## Breaking Changes
None