### PR TITLE
feat(secrets): add Huawei Cloud AK/SK credential detection

### DIFF
--- a/libs/shared/src/secrets/additional_rules.toml
+++ b/libs/shared/src/secrets/additional_rules.toml
@@ -18,3 +18,17 @@ description = "Catch passwords embedded in URLs (e.g., redis://:password@host)"
 regex = '''(?i)(?:://:)([^@\s]{1,50})(?:@)'''
 entropy = 0.5
 keywords = ["://", "@"]
+
+[[rules]]
+id = "huawei-access-key-id"
+description = "Detected a Huawei Cloud Access Key ID (AK), which could allow unauthorized access to Huawei Cloud services."
+regex = '''\b[A-Z0-9]{20}\b'''
+entropy = 3.5
+keywords = ["huawei", "access key id", "accesskeyid", "access_key_id"]
+
+[[rules]]
+id = "huawei-secret-access-key"
+description = "Detected a Huawei Cloud Secret Access Key (SK), which could allow unauthorized access to Huawei Cloud services and data."
+regex = '''\b[A-Za-z0-9]{40}\b'''
+entropy = 4.0
+keywords = ["huawei", "secret access key", "secretaccesskey", "secret_access_key"]


### PR DESCRIPTION
## Summary
Adds detection rules for Huawei Cloud credentials (Access Key ID and Secret Access Key).

## Changes
- **libs/shared/src/secrets/additional_rules.toml**: Added 2 new detection rules
  - `huawei-access-key-id`: Detects 20-char uppercase alphanumeric AK
  - `huawei-secret-access-key`: Detects 40-char alphanumeric SK
  
- **libs/shared/src/secrets/mod.rs**: Added 3 unit tests
  - `test_huawei_cloud_credentials_detection`: CSV format detection
  - `test_huawei_access_key_id_pattern`: AK pattern with keyword
  - `test_huawei_secret_access_key_pattern`: SK pattern with keyword

## Testing
```
cargo test -p stakpak-shared test_huawei
running 3 tests
test secrets::tests::test_huawei_access_key_id_pattern ... ok
test secrets::tests::test_huawei_cloud_credentials_detection ... ok
test secrets::tests::test_huawei_secret_access_key_pattern ... ok
```

Full secrets test suite: 51 passed, 0 failed