### PR TITLE
fix: URL-encode rulebook URI in API client

### DIFF
--- a/libs/api/src/stakpak/client.rs
+++ b/libs/api/src/stakpak/client.rs
@@ -261,7 +261,8 @@ impl StakpakApiClient {
 
     /// Get a rulebook by URI
     pub async fn get_rulebook_by_uri(&self, uri: &str) -> Result<RuleBook, String> {
-        let url = format!("{}/v1/rules/{}", self.base_url, uri);
+        let encoded_uri = urlencoding::encode(uri);
+        let url = format!("{}/v1/rules/{}", self.base_url, encoded_uri);
         let response = self
             .client
             .get(&url)
@@ -289,7 +290,8 @@ impl StakpakApiClient {
 
     /// Delete a rulebook
     pub async fn delete_rulebook(&self, uri: &str) -> Result<(), String> {
-        let url = format!("{}/v1/rules/{}", self.base_url, uri);
+        let encoded_uri = urlencoding::encode(uri);
+        let url = format!("{}/v1/rules/{}", self.base_url, encoded_uri);
         let response = self
             .client
             .delete(&url)


### PR DESCRIPTION
## Problem

The `read_rulebook` tool call was failing when trying to fetch rulebooks because the URI wasn't being URL-encoded before making the HTTP request.

When calling `read_rulebook` with a URI like:
```
stakpak://stakpak.dev/v1/aws-architecture-design.md
```

The code was building a malformed URL:
```
https://api.stakpak.dev/v1/rules/stakpak://stakpak.dev/v1/aws-architecture-design.md
```

The special characters (`://`, `/`) need to be percent-encoded.

## Solution

Added `urlencoding::encode(uri)` to both:
- `get_rulebook_by_uri()`
- `delete_rulebook()`

This matches the pattern already used in `libs/api/src/client/provider.rs:121`.

## Testing

- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo check --package stakpak-api` ✅