### PR TITLE
fix: prevent secret restoration bugs and add Unicode-normalized str_replace

### DIFF
--- a/libs/mcp/proxy/src/server/mod.rs
+++ b/libs/mcp/proxy/src/server/mod.rs
@@ -45,6 +45,84 @@ fn service_error_to_error_data(e: ServiceError, context: &str) -> ErrorData {
     }
 }
 
+/// Single-pass restoration of `[REDACTED_SECRET:...]` placeholders in a string.
+///
+/// Unlike the iterative `restore_secrets()` helper (which calls `String::replace`
+/// for every map entry), this scans forward through the string once, resolving
+/// each placeholder from the map as it is encountered.  Because we advance past
+/// the *replacement text* without re-scanning it, a secret whose value happens
+/// to contain another `[REDACTED_SECRET:...]` token will **not** trigger a
+/// chain replacement.
+fn restore_secrets_single_pass(s: &str, redaction_map: &HashMap<String, String>) -> String {
+    const PREFIX: &str = "[REDACTED_SECRET:";
+
+    if redaction_map.is_empty() {
+        return s.to_string();
+    }
+
+    let mut result = String::with_capacity(s.len());
+    let mut remaining = s;
+
+    while let Some(start) = remaining.find(PREFIX) {
+        // Push everything before the placeholder.
+        result.push_str(&remaining[..start]);
+
+        // Look for the closing `]`.
+        if let Some(rel_end) = remaining[start..].find(']') {
+            let key = &remaining[start..start + rel_end + 1];
+            if let Some(original) = redaction_map.get(key) {
+                result.push_str(original);
+            } else {
+                // Unknown placeholder — keep it verbatim.
+                result.push_str(key);
+            }
+            remaining = &remaining[start + rel_end + 1..];
+        } else {
+            // No closing bracket — push from the prefix onward as-is and stop.
+            result.push_str(&remaining[start..]);
+            return result;
+        }
+    }
+
+    result.push_str(remaining);
+    result
+}
+
+/// Recursively restore redacted secrets in a JSON value tree.
+///
+/// Walks through all string values in the JSON structure and restores
+/// any `[REDACTED_SECRET:...]` placeholders to their original values.
+/// This avoids the pitfall of serializing to a JSON string, doing raw
+/// text replacement (which can break JSON when secret values contain
+/// `"`, `\`, or newlines), and parsing back.
+///
+/// Uses [`restore_secrets_single_pass`] for each string to prevent chain
+/// replacement when a secret's value itself contains a redaction placeholder.
+fn restore_secrets_in_json_value(
+    value: &mut serde_json::Value,
+    redaction_map: &HashMap<String, String>,
+) {
+    match value {
+        serde_json::Value::String(s) => {
+            let restored = restore_secrets_single_pass(s, redaction_map);
+            if restored != *s {
+                *s = restored;
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for (_k, v) in map.iter_mut() {
+                restore_secrets_in_json_value(v, redaction_map);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                restore_secrets_in_json_value(v, redaction_map);
+            }
+        }
+        _ => {}
+    }
+}
+
 pub struct ProxyServer {
     pool: Arc<ClientPool>,
     // Map downstream request IDs to upstream client names
@@ -180,14 +258,13 @@ impl ProxyServer {
         let mut tool_params = params.clone();
         tool_params.name = tool_name.to_string().into();
 
-        if let Some(arguments) = &tool_params.arguments
-            && let Ok(arguments_str) = serde_json::to_string(arguments)
+        // Load the redaction map once, then walk the entire JSON value tree.
+        let redaction_map = self.secret_manager.load_session_redaction_map();
+        if !redaction_map.is_empty()
+            && let Some(arguments) = &mut tool_params.arguments
         {
-            let restored = self
-                .secret_manager
-                .restore_secrets_in_string(&arguments_str);
-            if let Ok(restored_arguments) = serde_json::from_str(&restored) {
-                tool_params.arguments = Some(restored_arguments);
+            for (_key, value) in arguments.iter_mut() {
+                restore_secrets_in_json_value(value, &redaction_map);
             }
         }
 
@@ -672,4 +749,492 @@ pub async fn start_proxy_server(
         .await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Helper: build a redaction map from pairs
+    fn map(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    // ---------------------------------------------------------------
+    // restore_secrets_in_json_value — basic string restoration
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_restore_simple_string() {
+        let redaction_map = map(&[("[REDACTED_SECRET:pw:abc]", "s3cret")]);
+        let mut value = json!("password is [REDACTED_SECRET:pw:abc]");
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value, json!("password is s3cret"));
+    }
+
+    #[test]
+    fn test_restore_no_placeholder() {
+        let redaction_map = map(&[("[REDACTED_SECRET:pw:abc]", "s3cret")]);
+        let mut value = json!("nothing to replace here");
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value, json!("nothing to replace here"));
+    }
+
+    #[test]
+    fn test_restore_empty_map() {
+        let redaction_map = HashMap::new();
+        let mut value = json!("[REDACTED_SECRET:pw:abc] stays");
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value, json!("[REDACTED_SECRET:pw:abc] stays"));
+    }
+
+    #[test]
+    fn test_restore_multiple_placeholders_same_string() {
+        let redaction_map = map(&[
+            ("[REDACTED_SECRET:a:1]", "alpha"),
+            ("[REDACTED_SECRET:b:2]", "beta"),
+        ]);
+        let mut value = json!("[REDACTED_SECRET:a:1] and [REDACTED_SECRET:b:2]");
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value, json!("alpha and beta"));
+    }
+
+    #[test]
+    fn test_restore_repeated_placeholder() {
+        let redaction_map = map(&[("[REDACTED_SECRET:pw:x]", "pass")]);
+        let mut value = json!("[REDACTED_SECRET:pw:x]words and [REDACTED_SECRET:pw:x]words");
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value, json!("passwords and passwords"));
+    }
+
+    // ---------------------------------------------------------------
+    // restore_secrets_in_json_value — nested objects
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_restore_flat_object() {
+        let redaction_map = map(&[("[REDACTED_SECRET:key:1]", "actual_key")]);
+        let mut value = json!({
+            "path": "README.md",
+            "old_str": "key=[REDACTED_SECRET:key:1]",
+            "new_str": "key=new_value"
+        });
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value["old_str"], json!("key=actual_key"));
+        // Untouched fields stay the same
+        assert_eq!(value["path"], json!("README.md"));
+        assert_eq!(value["new_str"], json!("key=new_value"));
+    }
+
+    #[test]
+    fn test_restore_nested_object() {
+        let redaction_map = map(&[("[REDACTED_SECRET:pw:z]", "secret123")]);
+        let mut value = json!({
+            "level1": {
+                "level2": {
+                    "password": "[REDACTED_SECRET:pw:z]"
+                }
+            }
+        });
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value["level1"]["level2"]["password"], json!("secret123"));
+    }
+
+    // ---------------------------------------------------------------
+    // restore_secrets_in_json_value — arrays
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_restore_array_of_strings() {
+        let redaction_map = map(&[("[REDACTED_SECRET:t:1]", "token_abc")]);
+        let mut value = json!(["no secret", "[REDACTED_SECRET:t:1]", "also clean"]);
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value, json!(["no secret", "token_abc", "also clean"]));
+    }
+
+    #[test]
+    fn test_restore_array_of_objects() {
+        let redaction_map = map(&[
+            ("[REDACTED_SECRET:a:1]", "val_a"),
+            ("[REDACTED_SECRET:b:2]", "val_b"),
+        ]);
+        let mut value = json!([
+            {"key": "[REDACTED_SECRET:a:1]"},
+            {"key": "[REDACTED_SECRET:b:2]"}
+        ]);
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value[0]["key"], json!("val_a"));
+        assert_eq!(value[1]["key"], json!("val_b"));
+    }
+
+    #[test]
+    fn test_restore_nested_arrays() {
+        let redaction_map = map(&[("[REDACTED_SECRET:x:1]", "found")]);
+        let mut value = json!([["a", "[REDACTED_SECRET:x:1]"], ["b"]]);
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value, json!([["a", "found"], ["b"]]));
+    }
+
+    // ---------------------------------------------------------------
+    // restore_secrets_in_json_value — non-string types unchanged
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_restore_number_unchanged() {
+        let redaction_map = map(&[("[REDACTED_SECRET:x:1]", "val")]);
+        let mut value = json!(42);
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value, json!(42));
+    }
+
+    #[test]
+    fn test_restore_bool_unchanged() {
+        let redaction_map = map(&[("[REDACTED_SECRET:x:1]", "val")]);
+        let mut value = json!(true);
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value, json!(true));
+    }
+
+    #[test]
+    fn test_restore_null_unchanged() {
+        let redaction_map = map(&[("[REDACTED_SECRET:x:1]", "val")]);
+        let mut value = json!(null);
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value, json!(null));
+    }
+
+    #[test]
+    fn test_restore_mixed_types_in_object() {
+        let redaction_map = map(&[("[REDACTED_SECRET:pw:1]", "secret")]);
+        let mut value = json!({
+            "string_field": "has [REDACTED_SECRET:pw:1]",
+            "number_field": 123,
+            "bool_field": false,
+            "null_field": null,
+            "array_field": [1, "[REDACTED_SECRET:pw:1]", true]
+        });
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value["string_field"], json!("has secret"));
+        assert_eq!(value["number_field"], json!(123));
+        assert_eq!(value["bool_field"], json!(false));
+        assert_eq!(value["null_field"], json!(null));
+        assert_eq!(value["array_field"], json!([1, "secret", true]));
+    }
+
+    // ---------------------------------------------------------------
+    // restore_secrets_in_json_value — secret values with JSON-special chars
+    // This is the key bug the new approach fixes: secrets containing
+    // `"`, `\`, or newlines would break the old serialize→replace→parse path.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_restore_secret_with_double_quote() {
+        let redaction_map = map(&[("[REDACTED_SECRET:pw:q]", "pass\"word")]);
+        let mut value = json!("auth=[REDACTED_SECRET:pw:q]");
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value, json!("auth=pass\"word"));
+    }
+
+    #[test]
+    fn test_restore_secret_with_backslash() {
+        let redaction_map = map(&[("[REDACTED_SECRET:pw:b]", "C:\\Users\\admin")]);
+        let mut value = json!("path=[REDACTED_SECRET:pw:b]");
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value, json!("path=C:\\Users\\admin"));
+    }
+
+    #[test]
+    fn test_restore_secret_with_newline() {
+        let redaction_map = map(&[("[REDACTED_SECRET:pw:n]", "line1\nline2")]);
+        let mut value = json!("content=[REDACTED_SECRET:pw:n]");
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value, json!("content=line1\nline2"));
+    }
+
+    #[test]
+    fn test_restore_secret_with_tab() {
+        let redaction_map = map(&[("[REDACTED_SECRET:pw:t]", "col1\tcol2")]);
+        let mut value = json!("[REDACTED_SECRET:pw:t]");
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value, json!("col1\tcol2"));
+    }
+
+    #[test]
+    fn test_restore_secret_with_all_special_chars() {
+        let secret = "p@ss\"\n\\word\t{end}";
+        let redaction_map = map(&[("[REDACTED_SECRET:pw:all]", secret)]);
+        let mut value = json!({
+            "old_str": "before [REDACTED_SECRET:pw:all] after",
+            "new_str": "replacement"
+        });
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value["old_str"], json!(format!("before {} after", secret)));
+    }
+
+    // ---------------------------------------------------------------
+    // restore_secrets_in_json_value — realistic str_replace scenario
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_restore_str_replace_tool_call() {
+        let redaction_map = map(&[
+            ("[REDACTED_SECRET:url-embedded-passwords:2f6lt3]", "pass"),
+            (
+                "[REDACTED_SECRET:generic-api-key:abc123]",
+                "sk-ant-secret-key-value",
+            ),
+        ]);
+
+        let mut value = json!({
+            "path": "README.md",
+            "old_str": "Generate cryptographically secure [REDACTED_SECRET:url-embedded-passwords:2f6lt3]words with configurable complexity",
+            "new_str": "Generate strong passwords"
+        });
+
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+
+        assert_eq!(
+            value["old_str"],
+            json!("Generate cryptographically secure passwords with configurable complexity")
+        );
+        assert_eq!(value["new_str"], json!("Generate strong passwords"));
+        assert_eq!(value["path"], json!("README.md"));
+    }
+
+    #[test]
+    fn test_restore_run_command_tool_call() {
+        let redaction_map = map(&[("[REDACTED_SECRET:generic-api-key:k1]", "sk-live-abc123")]);
+
+        let mut value = json!({
+            "command": "curl -H 'Authorization: Bearer [REDACTED_SECRET:generic-api-key:k1]' https://api.example.com",
+            "description": "Test API call"
+        });
+
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+
+        assert_eq!(
+            value["command"],
+            json!("curl -H 'Authorization: Bearer sk-live-abc123' https://api.example.com")
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // restore_secrets_in_json_value — edge cases
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_restore_empty_string() {
+        let redaction_map = map(&[("[REDACTED_SECRET:x:1]", "val")]);
+        let mut value = json!("");
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value, json!(""));
+    }
+
+    #[test]
+    fn test_restore_placeholder_is_entire_string() {
+        let redaction_map = map(&[("[REDACTED_SECRET:pw:full]", "the_whole_secret")]);
+        let mut value = json!("[REDACTED_SECRET:pw:full]");
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value, json!("the_whole_secret"));
+    }
+
+    #[test]
+    fn test_restore_deeply_nested() {
+        let redaction_map = map(&[("[REDACTED_SECRET:d:1]", "deep_val")]);
+        let mut value = json!({
+            "a": {
+                "b": {
+                    "c": {
+                        "d": {
+                            "e": "[REDACTED_SECRET:d:1]"
+                        }
+                    }
+                }
+            }
+        });
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value["a"]["b"]["c"]["d"]["e"], json!("deep_val"));
+    }
+
+    #[test]
+    fn test_restore_large_redaction_map() {
+        let mut pairs: Vec<(String, String)> = Vec::new();
+        for i in 0..100 {
+            pairs.push((
+                format!("[REDACTED_SECRET:rule:{}]", i),
+                format!("secret_value_{}", i),
+            ));
+        }
+        let redaction_map: HashMap<String, String> = pairs.iter().cloned().collect();
+
+        let mut value = json!({
+            "field0": "has [REDACTED_SECRET:rule:0]",
+            "field50": "has [REDACTED_SECRET:rule:50]",
+            "field99": "has [REDACTED_SECRET:rule:99]",
+            "clean": "no secrets here"
+        });
+
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+
+        assert_eq!(value["field0"], json!("has secret_value_0"));
+        assert_eq!(value["field50"], json!("has secret_value_50"));
+        assert_eq!(value["field99"], json!("has secret_value_99"));
+        assert_eq!(value["clean"], json!("no secrets here"));
+    }
+
+    #[test]
+    fn test_restore_secret_value_looks_like_placeholder() {
+        // Edge case: a secret value itself looks like a redaction placeholder
+        let redaction_map = map(&[("[REDACTED_SECRET:outer:1]", "[REDACTED_SECRET:inner:2]")]);
+        let mut value = json!("contains [REDACTED_SECRET:outer:1]");
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        // Should restore to the literal string (no recursive resolution)
+        assert_eq!(value, json!("contains [REDACTED_SECRET:inner:2]"));
+    }
+
+    #[test]
+    fn test_restore_no_chain_replacement_both_keys_present() {
+        // Both outer and inner are valid keys in the map.
+        // Outer's value contains inner's key — single-pass must NOT chain.
+        let redaction_map = map(&[
+            ("[REDACTED_SECRET:outer:1]", "[REDACTED_SECRET:inner:2]"),
+            ("[REDACTED_SECRET:inner:2]", "final_secret"),
+        ]);
+        let mut value = json!("[REDACTED_SECRET:outer:1]");
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        // Must stop at the first restoration, not chain into "final_secret"
+        assert_eq!(value, json!("[REDACTED_SECRET:inner:2]"));
+    }
+
+    #[test]
+    fn test_restore_no_chain_replacement_in_object() {
+        let redaction_map = map(&[
+            ("[REDACTED_SECRET:a:1]", "text [REDACTED_SECRET:b:2] text"),
+            ("[REDACTED_SECRET:b:2]", "chained"),
+        ]);
+        let mut value = json!({
+            "field": "before [REDACTED_SECRET:a:1] after"
+        });
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(
+            value["field"],
+            json!("before text [REDACTED_SECRET:b:2] text after")
+        );
+    }
+
+    #[test]
+    fn test_restore_partial_placeholder_not_matched() {
+        let redaction_map = map(&[("[REDACTED_SECRET:pw:abc]", "secret")]);
+        let mut value = json!("partial [REDACTED_SECRET:pw:ab is not replaced");
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(
+            value,
+            json!("partial [REDACTED_SECRET:pw:ab is not replaced")
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // restore_secrets_single_pass — unit tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_single_pass_basic() {
+        let map = map(&[("[REDACTED_SECRET:pw:1]", "secret")]);
+        assert_eq!(
+            restore_secrets_single_pass("auth=[REDACTED_SECRET:pw:1]", &map),
+            "auth=secret"
+        );
+    }
+
+    #[test]
+    fn test_single_pass_no_placeholder() {
+        let map = map(&[("[REDACTED_SECRET:pw:1]", "secret")]);
+        assert_eq!(
+            restore_secrets_single_pass("no placeholders here", &map),
+            "no placeholders here"
+        );
+    }
+
+    #[test]
+    fn test_single_pass_empty_map() {
+        let map = HashMap::new();
+        assert_eq!(
+            restore_secrets_single_pass("[REDACTED_SECRET:pw:1] stays", &map),
+            "[REDACTED_SECRET:pw:1] stays"
+        );
+    }
+
+    #[test]
+    fn test_single_pass_unknown_key_preserved() {
+        let map = map(&[("[REDACTED_SECRET:pw:1]", "secret")]);
+        assert_eq!(
+            restore_secrets_single_pass("[REDACTED_SECRET:unknown:99]", &map),
+            "[REDACTED_SECRET:unknown:99]"
+        );
+    }
+
+    #[test]
+    fn test_single_pass_multiple_placeholders() {
+        let map = map(&[
+            ("[REDACTED_SECRET:a:1]", "alpha"),
+            ("[REDACTED_SECRET:b:2]", "beta"),
+        ]);
+        assert_eq!(
+            restore_secrets_single_pass("[REDACTED_SECRET:a:1] and [REDACTED_SECRET:b:2]", &map),
+            "alpha and beta"
+        );
+    }
+
+    #[test]
+    fn test_single_pass_no_closing_bracket() {
+        let map = map(&[("[REDACTED_SECRET:pw:1]", "secret")]);
+        assert_eq!(
+            restore_secrets_single_pass("broken [REDACTED_SECRET:pw:1 missing bracket", &map),
+            "broken [REDACTED_SECRET:pw:1 missing bracket"
+        );
+    }
+
+    #[test]
+    fn test_single_pass_no_chain() {
+        let map = map(&[
+            ("[REDACTED_SECRET:a:1]", "value has [REDACTED_SECRET:b:2]"),
+            ("[REDACTED_SECRET:b:2]", "should not appear"),
+        ]);
+        assert_eq!(
+            restore_secrets_single_pass("[REDACTED_SECRET:a:1]", &map),
+            "value has [REDACTED_SECRET:b:2]"
+        );
+    }
+
+    #[test]
+    fn test_single_pass_adjacent_placeholders() {
+        let map = map(&[
+            ("[REDACTED_SECRET:a:1]", "X"),
+            ("[REDACTED_SECRET:b:2]", "Y"),
+        ]);
+        assert_eq!(
+            restore_secrets_single_pass("[REDACTED_SECRET:a:1][REDACTED_SECRET:b:2]", &map),
+            "XY"
+        );
+    }
+
+    #[test]
+    fn test_restore_empty_object() {
+        let redaction_map = map(&[("[REDACTED_SECRET:x:1]", "val")]);
+        let mut value = json!({});
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value, json!({}));
+    }
+
+    #[test]
+    fn test_restore_empty_array() {
+        let redaction_map = map(&[("[REDACTED_SECRET:x:1]", "val")]);
+        let mut value = json!([]);
+        restore_secrets_in_json_value(&mut value, &redaction_map);
+        assert_eq!(value, json!([]));
+    }
 }

--- a/libs/mcp/server/src/local_tools.rs
+++ b/libs/mcp/server/src/local_tools.rs
@@ -1616,25 +1616,50 @@ SAFETY NOTES:
             }
         };
 
-        if !original_content.contains(&actual_old_str) {
+        // Try exact match first, then fall back to Unicode-normalized matching.
+        // LLMs commonly normalize curly quotes to straight quotes, en-dashes to
+        // hyphens, etc. The fallback finds the original substring in the file by
+        // normalizing both sides to ASCII and using char-position mapping.
+        let (new_content, replaced_count) = if original_content.contains(&actual_old_str) {
+            // Exact match — fast path.  Use `replacen` for single or
+            // `replace` for all, and derive the count from the result to
+            // avoid scanning the string twice.
+            if replace_all.unwrap_or(false) {
+                let result = original_content.replace(&actual_old_str, &actual_new_str);
+                // Derive count from the length difference.
+                let old_len = actual_old_str.len();
+                let new_len = actual_new_str.len();
+                let count = if old_len == new_len {
+                    // Length-neutral replacement — count via matches (unavoidable).
+                    original_content.matches(&actual_old_str).count()
+                } else {
+                    let orig = original_content.len();
+                    let after = result.len();
+                    // diff = count * (new_len - old_len), signed arithmetic
+                    let diff = after as isize - orig as isize;
+                    let step = new_len as isize - old_len as isize;
+                    (diff / step) as usize
+                };
+                (result, count)
+            } else {
+                (
+                    original_content.replacen(&actual_old_str, &actual_new_str, 1),
+                    1,
+                )
+            }
+        } else if let Some(result) = unicode_normalized_replace(
+            &original_content,
+            &actual_old_str,
+            &actual_new_str,
+            replace_all.unwrap_or(false),
+        ) {
+            // Unicode-normalized fallback matched
+            result
+        } else {
             return Ok(CallToolResult::error(vec![
                 Content::text("STRING_NOT_FOUND"),
                 Content::text("The string old_str was not found in the file"),
             ]));
-        }
-
-        let new_content = if replace_all.unwrap_or(false) {
-            original_content.replace(&actual_old_str, &actual_new_str)
-        } else {
-            original_content.replacen(&actual_old_str, &actual_new_str, 1)
-        };
-
-        let replaced_count = if replace_all.unwrap_or(false) {
-            original_content.matches(&actual_old_str).count()
-        } else if original_content.contains(&actual_old_str) {
-            1
-        } else {
-            0
         };
 
         let unified_diff = self.create_unified_diff(&original_content, &new_content, path, path);
@@ -2030,5 +2055,745 @@ SAFETY NOTES:
         table.push_str("═══════════════════════════════════════\n\n");
 
         table
+    }
+}
+
+/// Normalize a single character: map common Unicode "fancy" characters to their
+/// ASCII equivalents.  Most mappings are 1-to-1, but some are 1-to-many (e.g.
+/// `…` → `...`).  Returns `None` when the character requires no normalisation.
+fn normalize_unicode_char(c: char) -> Option<&'static str> {
+    match c {
+        // Quotation marks
+        '\u{2018}' | '\u{2019}' | '\u{201A}' | '\u{2039}' | '\u{203A}' => Some("'"), // ' ' ‚ ‹ ›  → '
+        '\u{FF07}' => Some("'"), // fullwidth apostrophe → '
+        '\u{201C}' | '\u{201D}' | '\u{201E}' | '\u{00AB}' | '\u{00BB}' => Some("\""), // " " „ « »  → "
+
+        // Dashes
+        '\u{2010}' | '\u{2011}' | '\u{2012}' | '\u{2013}' | '\u{2014}' | '\u{2015}' => Some("-"), // ‐ ‑ ‒ – — ―  → -
+
+        // Spaces
+        '\u{00A0}' | '\u{2002}' | '\u{2003}' | '\u{2009}' | '\u{200A}' | '\u{202F}' => Some(" "), // NBSP, en/em/thin/hair/nnbsp → space
+
+        // Dots / ellipsis  (1-to-many: one char → three chars)
+        '\u{2026}' => Some("..."), // … → ...
+
+        // Other common normalizations
+        '\u{2022}' => Some("*"), // bullet → *
+        '\u{00B7}' => Some("."), // middle dot → .
+
+        _ => None,
+    }
+}
+
+/// Normalize a string by mapping each character through [`normalize_unicode_char`].
+///
+/// Because some mappings are 1-to-many (e.g. `…` → `...`), the returned string
+/// may have a **different** character count than the input.  Use
+/// [`normalize_with_byte_mapping`] when you need to map positions back.
+fn normalize_unicode_to_ascii(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match normalize_unicode_char(c) {
+            Some(replacement) => out.push_str(replacement),
+            None => out.push(c),
+        }
+    }
+    out
+}
+
+/// Result of normalizing a string with byte-position tracking.
+struct NormalizedWithMapping {
+    /// The normalized string.
+    text: String,
+    /// For each char-boundary byte offset in `text`, the corresponding byte
+    /// offset in the **original** string.
+    ///
+    /// Indexed by the char-boundary byte offset in `text`. There is one entry
+    /// per character plus a sentinel at the end equal to the original string's
+    /// byte length. This lets us translate match byte ranges from
+    /// [`str::find`] directly to original byte ranges without an intermediate
+    /// char-index conversion.
+    norm_byte_to_orig_byte: Vec<usize>,
+    /// All char-boundary byte offsets in `text` (sorted).
+    /// Used to locate the *end* of a match: given the match start byte +
+    /// pattern byte length, we round to the next char boundary via binary
+    /// search.  Only needed when the normalized text contains multi-byte
+    /// characters (e.g. non-mapped Unicode like `é`).
+    char_boundaries: Vec<usize>,
+}
+
+/// Normalize `s` while building a byte-level mapping from positions in the
+/// normalized output back to positions in `s`.
+fn normalize_with_byte_mapping(s: &str) -> NormalizedWithMapping {
+    let mut text = String::with_capacity(s.len());
+    let mut norm_byte_to_orig_byte: Vec<usize> = Vec::with_capacity(s.len() + 1);
+    let mut char_boundaries: Vec<usize> = Vec::with_capacity(s.len() + 1);
+
+    for (byte_idx, c) in s.char_indices() {
+        match normalize_unicode_char(c) {
+            Some(replacement) => {
+                for rc in replacement.chars() {
+                    char_boundaries.push(text.len());
+                    norm_byte_to_orig_byte.push(byte_idx);
+                    text.push(rc);
+                }
+            }
+            None => {
+                char_boundaries.push(text.len());
+                norm_byte_to_orig_byte.push(byte_idx);
+                text.push(c);
+            }
+        }
+    }
+
+    // Sentinel: one past the last character.
+    char_boundaries.push(text.len());
+    norm_byte_to_orig_byte.push(s.len());
+
+    NormalizedWithMapping {
+        text,
+        norm_byte_to_orig_byte,
+        char_boundaries,
+    }
+}
+
+impl NormalizedWithMapping {
+    /// Convert a byte offset in the normalized `text` to the corresponding
+    /// byte offset in the original string.  Returns `None` if `norm_byte` does
+    /// not fall on a character boundary (should never happen for offsets
+    /// returned by [`str::find`]).
+    fn orig_byte_at(&self, norm_byte: usize) -> Option<usize> {
+        let idx = self.char_boundaries.binary_search(&norm_byte).ok()?;
+        Some(self.norm_byte_to_orig_byte[idx])
+    }
+}
+
+/// Attempt to find `old_str` in `content` using Unicode-normalized matching,
+/// then perform the replacement on the *original* content preserving its
+/// encoding.
+///
+/// Returns `Some((new_content, replaced_count))` on success, `None` if the
+/// normalized old_str is still not found.
+///
+/// Supports 1-to-many normalizations (e.g. `…` → `...`) by building a byte-
+/// position mapping from the normalized characters back to original byte
+/// ranges.
+///
+/// Uses Rust's built-in [`str::find`] (Two-Way algorithm) for O(n + m)
+/// substring search instead of a naive O(n × m) character-by-character scan.
+fn unicode_normalized_replace(
+    content: &str,
+    old_str: &str,
+    new_str: &str,
+    replace_all: bool,
+) -> Option<(String, usize)> {
+    let norm_old = normalize_unicode_to_ascii(old_str);
+
+    if norm_old.is_empty() {
+        return None;
+    }
+
+    // Cheap pre-check: normalize content without building the mapping.
+    // If the pattern doesn't appear in the normalized content at all,
+    // skip the heavier mapping allocation.
+    let norm_content_quick = normalize_unicode_to_ascii(content);
+    if !norm_content_quick.contains(&norm_old) {
+        return None;
+    }
+    drop(norm_content_quick);
+
+    // Pattern is present — build the full mapping.
+    let norm_content = normalize_with_byte_mapping(content);
+
+    // Use Rust's optimized string search (Two-Way algorithm, O(n + m)).
+    // Matches are collected as (orig_byte_start, orig_byte_end) pairs.
+    let norm_old_byte_len = norm_old.len();
+    let mut match_orig_ranges: Vec<(usize, usize)> = Vec::new();
+
+    if replace_all {
+        let mut search_byte = 0usize;
+        while search_byte + norm_old_byte_len <= norm_content.text.len() {
+            if let Some(rel) = norm_content.text[search_byte..].find(&norm_old) {
+                let match_start = search_byte + rel;
+                let match_end = match_start + norm_old_byte_len;
+
+                if let (Some(orig_start), Some(orig_end)) = (
+                    norm_content.orig_byte_at(match_start),
+                    norm_content.orig_byte_at(match_end),
+                ) {
+                    match_orig_ranges.push((orig_start, orig_end));
+                }
+                search_byte = match_end;
+            } else {
+                break;
+            }
+        }
+    } else if let Some(match_start) = norm_content.text.find(&norm_old) {
+        let match_end = match_start + norm_old_byte_len;
+
+        if let (Some(orig_start), Some(orig_end)) = (
+            norm_content.orig_byte_at(match_start),
+            norm_content.orig_byte_at(match_end),
+        ) {
+            match_orig_ranges.push((orig_start, orig_end));
+        }
+    }
+
+    if match_orig_ranges.is_empty() {
+        return None;
+    }
+
+    let replaced_count = match_orig_ranges.len();
+
+    // Build the result by splicing in new_str at each matched byte range.
+    let mut result = String::with_capacity(content.len());
+    let mut prev_byte_end = 0usize;
+
+    for &(orig_start, orig_end) in &match_orig_ranges {
+        result.push_str(&content[prev_byte_end..orig_start]);
+        result.push_str(new_str);
+        prev_byte_end = orig_end;
+    }
+    result.push_str(&content[prev_byte_end..]);
+
+    Some((result, replaced_count))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---------------------------------------------------------------
+    // normalize_unicode_char / normalize_unicode_to_ascii
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_normalize_straight_quotes_unchanged() {
+        assert_eq!(normalize_unicode_to_ascii("it's fine"), "it's fine");
+    }
+
+    #[test]
+    fn test_normalize_curly_single_quotes() {
+        // U+2018 LEFT SINGLE QUOTATION MARK
+        assert_eq!(normalize_unicode_to_ascii("it\u{2018}s"), "it's");
+        // U+2019 RIGHT SINGLE QUOTATION MARK
+        assert_eq!(normalize_unicode_to_ascii("shouldn\u{2019}t"), "shouldn't");
+    }
+
+    #[test]
+    fn test_normalize_curly_double_quotes() {
+        // U+201C / U+201D
+        assert_eq!(
+            normalize_unicode_to_ascii("\u{201C}hello\u{201D}"),
+            "\"hello\""
+        );
+    }
+
+    #[test]
+    fn test_normalize_en_dash() {
+        assert_eq!(normalize_unicode_to_ascii("a\u{2013}b"), "a-b");
+    }
+
+    #[test]
+    fn test_normalize_em_dash() {
+        assert_eq!(normalize_unicode_to_ascii("a\u{2014}b"), "a-b");
+    }
+
+    #[test]
+    fn test_normalize_figure_dash() {
+        assert_eq!(normalize_unicode_to_ascii("a\u{2012}b"), "a-b");
+    }
+
+    #[test]
+    fn test_normalize_hyphen_unicode() {
+        // U+2010 HYPHEN
+        assert_eq!(normalize_unicode_to_ascii("a\u{2010}b"), "a-b");
+    }
+
+    #[test]
+    fn test_normalize_nbsp() {
+        assert_eq!(
+            normalize_unicode_to_ascii("hello\u{00A0}world"),
+            "hello world"
+        );
+    }
+
+    #[test]
+    fn test_normalize_preserves_char_count_for_1to1() {
+        // Only 1-to-1 mappings in this input — char count preserved
+        let input = "\u{201C}shouldn\u{2019}t\u{201D} \u{2013} done";
+        let normalized = normalize_unicode_to_ascii(input);
+        assert_eq!(input.chars().count(), normalized.chars().count());
+    }
+
+    #[test]
+    fn test_normalize_ellipsis_expands() {
+        // Ellipsis is 1-to-3 mapping
+        assert_eq!(normalize_unicode_to_ascii("wait\u{2026}"), "wait...");
+        // Char count grows: 5 input chars → 7 output chars
+        assert_eq!("wait\u{2026}".chars().count(), 5);
+        assert_eq!(
+            normalize_unicode_to_ascii("wait\u{2026}").chars().count(),
+            7
+        );
+    }
+
+    #[test]
+    fn test_normalize_pure_ascii_passthrough() {
+        let ascii = "The quick brown fox jumps over the lazy dog. 0123456789 !@#$%^&*()";
+        assert_eq!(normalize_unicode_to_ascii(ascii), ascii);
+    }
+
+    #[test]
+    fn test_normalize_bullet() {
+        assert_eq!(normalize_unicode_to_ascii("\u{2022} item"), "* item");
+    }
+
+    #[test]
+    fn test_normalize_non_breaking_hyphen() {
+        assert_eq!(
+            normalize_unicode_to_ascii("non\u{2011}breaking"),
+            "non-breaking"
+        );
+    }
+
+    #[test]
+    fn test_normalize_guillemets() {
+        assert_eq!(
+            normalize_unicode_to_ascii("\u{00AB}quoted\u{00BB}"),
+            "\"quoted\""
+        );
+    }
+
+    #[test]
+    fn test_normalize_fullwidth_apostrophe() {
+        assert_eq!(normalize_unicode_to_ascii("it\u{FF07}s"), "it's");
+    }
+
+    #[test]
+    fn test_normalize_mixed_unicode_and_ascii() {
+        let input = "It\u{2019}s a \u{201C}test\u{201D} \u{2013} really";
+        let expected = "It's a \"test\" - really";
+        assert_eq!(normalize_unicode_to_ascii(input), expected);
+    }
+
+    // ---------------------------------------------------------------
+    // normalize_with_byte_mapping
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_byte_mapping_ascii() {
+        let m = normalize_with_byte_mapping("abc");
+        assert_eq!(m.text, "abc");
+        assert_eq!(m.char_boundaries, vec![0, 1, 2, 3]); // includes sentinel
+        assert_eq!(m.norm_byte_to_orig_byte, vec![0, 1, 2, 3]); // includes sentinel
+    }
+
+    #[test]
+    fn test_byte_mapping_ellipsis() {
+        // … is 3 bytes in UTF-8, maps to 3 normalized chars "..."
+        let m = normalize_with_byte_mapping("x\u{2026}y");
+        assert_eq!(m.text, "x...y");
+        // char boundaries: x=0, .=1, .=2, .=3, y=4, sentinel=5
+        assert_eq!(m.char_boundaries, vec![0, 1, 2, 3, 4, 5]);
+        // 'x' at orig 0, all three '.' at orig 1 (start of …), 'y' at orig 4, sentinel=5
+        assert_eq!(m.norm_byte_to_orig_byte, vec![0, 1, 1, 1, 4, 5]);
+    }
+
+    #[test]
+    fn test_byte_mapping_curly_quote() {
+        // U+2019 is 3 bytes in UTF-8
+        let m = normalize_with_byte_mapping("a\u{2019}b");
+        assert_eq!(m.text, "a'b");
+        assert_eq!(m.char_boundaries, vec![0, 1, 2, 3]);
+        assert_eq!(m.norm_byte_to_orig_byte, vec![0, 1, 4, 5]);
+    }
+
+    #[test]
+    fn test_byte_mapping_multibyte_passthrough() {
+        // 'é' (2 bytes) is NOT in the normalization map — preserved as-is
+        let m = normalize_with_byte_mapping("café");
+        assert_eq!(m.text, "café");
+        // c=0, a=1, f=2, é=3 (norm byte), sentinel=5 (norm byte, since é is 2 bytes)
+        assert_eq!(m.char_boundaries, vec![0, 1, 2, 3, 5]);
+        // c→0, a→1, f→2, é→3, sentinel→5 (orig len)
+        assert_eq!(m.norm_byte_to_orig_byte, vec![0, 1, 2, 3, 5]);
+    }
+
+    // ---------------------------------------------------------------
+    // unicode_normalized_replace — exact match still works
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_normalized_replace_exact_ascii() {
+        let content = "hello world";
+        let result = unicode_normalized_replace(content, "world", "rust", false);
+        assert_eq!(result, Some(("hello rust".to_string(), 1)));
+    }
+
+    #[test]
+    fn test_normalized_replace_no_match() {
+        let content = "hello world";
+        assert_eq!(
+            unicode_normalized_replace(content, "xyz", "abc", false),
+            None
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // unicode_normalized_replace — curly quote fallback
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_normalized_replace_curly_apostrophe() {
+        // File has curly quote, LLM sends straight quote
+        let content = "Infrastructure shouldn\u{2019}t be this hard.";
+        let old_str = "Infrastructure shouldn't be this hard.";
+        let new_str = "Infra is easy.";
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert_eq!(result, Some(("Infra is easy.".to_string(), 1)));
+    }
+
+    #[test]
+    fn test_normalized_replace_preserves_surrounding_content() {
+        let content = "before shouldn\u{2019}t after";
+        let old_str = "shouldn't";
+        let new_str = "REPLACED";
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert_eq!(result, Some(("before REPLACED after".to_string(), 1)));
+    }
+
+    #[test]
+    fn test_normalized_replace_curly_double_quotes() {
+        let content = "She said \u{201C}hello\u{201D} loudly";
+        let old_str = "\"hello\"";
+        let new_str = "\"hi\"";
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert_eq!(result, Some(("She said \"hi\" loudly".to_string(), 1)));
+    }
+
+    #[test]
+    fn test_normalized_replace_en_dash() {
+        let content = "pages 10\u{2013}20 of the book";
+        let old_str = "10-20";
+        let new_str = "10-30";
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert_eq!(result, Some(("pages 10-30 of the book".to_string(), 1)));
+    }
+
+    #[test]
+    fn test_normalized_replace_em_dash() {
+        let content = "word\u{2014}another word";
+        let old_str = "word-another";
+        let new_str = "one-two";
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert_eq!(result, Some(("one-two word".to_string(), 1)));
+    }
+
+    #[test]
+    fn test_normalized_replace_nbsp_to_space() {
+        let content = "hello\u{00A0}world";
+        let old_str = "hello world";
+        let new_str = "hi there";
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert_eq!(result, Some(("hi there".to_string(), 1)));
+    }
+
+    // ---------------------------------------------------------------
+    // unicode_normalized_replace — ellipsis (1-to-many mapping)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_normalized_replace_ellipsis_in_content() {
+        // File has … (1 char), LLM sends ... (3 chars)
+        let content = "wait\u{2026} what?";
+        let old_str = "wait... what?";
+        let new_str = "oh!";
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert_eq!(result, Some(("oh!".to_string(), 1)));
+    }
+
+    #[test]
+    fn test_normalized_replace_ellipsis_in_old_str() {
+        // File has ... (3 chars), LLM sends … (1 char, normalizes to ...)
+        let content = "wait... what?";
+        let old_str = "wait\u{2026} what?";
+        let new_str = "oh!";
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert_eq!(result, Some(("oh!".to_string(), 1)));
+    }
+
+    #[test]
+    fn test_normalized_replace_ellipsis_preserves_surroundings() {
+        let content = "before\u{2026}after";
+        let old_str = "...";
+        let new_str = "---";
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert_eq!(result, Some(("before---after".to_string(), 1)));
+    }
+
+    #[test]
+    fn test_normalized_replace_ellipsis_replace_all() {
+        let content = "one\u{2026}two\u{2026}three";
+        let old_str = "...";
+        let new_str = " ";
+        let result = unicode_normalized_replace(content, old_str, new_str, true);
+        assert_eq!(result, Some(("one two three".to_string(), 2)));
+    }
+
+    #[test]
+    fn test_normalized_replace_ellipsis_with_other_unicode() {
+        // Mix of ellipsis and curly quotes
+        let content = "She said \u{201C}wait\u{2026}\u{201D}";
+        let old_str = "\"wait...\"";
+        let new_str = "\"go!\"";
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert_eq!(result, Some(("She said \"go!\"".to_string(), 1)));
+    }
+
+    // ---------------------------------------------------------------
+    // unicode_normalized_replace — additional Unicode chars
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_normalized_replace_figure_dash() {
+        let content = "pages 10\u{2012}20";
+        let old_str = "10-20";
+        let new_str = "10-30";
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert_eq!(result, Some(("pages 10-30".to_string(), 1)));
+    }
+
+    #[test]
+    fn test_normalized_replace_unicode_hyphen() {
+        let content = "non\u{2010}breaking";
+        let old_str = "non-breaking";
+        let new_str = "unbreakable";
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert_eq!(result, Some(("unbreakable".to_string(), 1)));
+    }
+
+    #[test]
+    fn test_normalized_replace_fullwidth_apostrophe() {
+        let content = "it\u{FF07}s fine";
+        let old_str = "it's fine";
+        let new_str = "all good";
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert_eq!(result, Some(("all good".to_string(), 1)));
+    }
+
+    // ---------------------------------------------------------------
+    // unicode_normalized_replace — replace_all
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_normalized_replace_all_multiple() {
+        let content = "shouldn\u{2019}t and shouldn\u{2019}t again";
+        let old_str = "shouldn't";
+        let new_str = "should not";
+        let result = unicode_normalized_replace(content, old_str, new_str, true);
+        assert_eq!(
+            result,
+            Some(("should not and should not again".to_string(), 2))
+        );
+    }
+
+    #[test]
+    fn test_normalized_replace_all_false_stops_at_first() {
+        let content = "shouldn\u{2019}t and shouldn\u{2019}t again";
+        let old_str = "shouldn't";
+        let new_str = "should not";
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert_eq!(
+            result,
+            Some(("should not and shouldn\u{2019}t again".to_string(), 1))
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // unicode_normalized_replace — multiple different Unicode chars
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_normalized_replace_mixed_unicode() {
+        // File has: curly quotes + en-dash
+        let content = "\u{201C}10\u{2013}20\u{201D}";
+        let old_str = "\"10-20\"";
+        let new_str = "range";
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert_eq!(result, Some(("range".to_string(), 1)));
+    }
+
+    #[test]
+    fn test_normalized_replace_readme_scenario() {
+        // The exact scenario from the bug: file has U+2019 in "shouldn't"
+        // and U+2013 en-dashes elsewhere. LLM normalizes to ASCII.
+        let content = concat!(
+            "Infrastructure shouldn\u{2019}t be this hard.\n",
+            "- `--disable-secret-redaction` \u{2013} **not recommended**\n",
+            "- `--privacy-mode` \u{2013} redacts additional data\n",
+        );
+
+        // LLM sends old_str with the first line only (ASCII apostrophe)
+        let old_str = "Infrastructure shouldn't be this hard.";
+        let new_str = "Infrastructure is easy.";
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert!(result.is_some());
+        let (new_content, count) = result.unwrap();
+        assert_eq!(count, 1);
+        assert!(new_content.starts_with("Infrastructure is easy.\n"));
+        // Rest of the file (with en-dashes) should be untouched
+        assert!(new_content.contains("\u{2013}"));
+    }
+
+    // ---------------------------------------------------------------
+    // unicode_normalized_replace — edge cases
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_normalized_replace_empty_old_str() {
+        assert_eq!(unicode_normalized_replace("content", "", "x", false), None);
+    }
+
+    #[test]
+    fn test_normalized_replace_empty_content() {
+        assert_eq!(unicode_normalized_replace("", "hello", "x", false), None);
+    }
+
+    #[test]
+    fn test_normalized_replace_entire_content() {
+        let content = "shouldn\u{2019}t";
+        let old_str = "shouldn't";
+        let new_str = "should not";
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert_eq!(result, Some(("should not".to_string(), 1)));
+    }
+
+    #[test]
+    fn test_normalized_replace_at_start() {
+        let content = "\u{201C}hello\u{201D} world";
+        let old_str = "\"hello\"";
+        let new_str = "\"hi\"";
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert_eq!(result, Some(("\"hi\" world".to_string(), 1)));
+    }
+
+    #[test]
+    fn test_normalized_replace_at_end() {
+        let content = "world \u{201C}hello\u{201D}";
+        let old_str = "\"hello\"";
+        let new_str = "\"hi\"";
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert_eq!(result, Some(("world \"hi\"".to_string(), 1)));
+    }
+
+    #[test]
+    fn test_normalized_replace_no_false_positive_on_ascii() {
+        // When both content and old_str are pure ASCII and don't match,
+        // the normalized path should also return None.
+        assert_eq!(
+            unicode_normalized_replace("hello world", "goodbye", "x", false),
+            None
+        );
+    }
+
+    #[test]
+    fn test_normalized_replace_preserves_other_unicode() {
+        // Unicode that is NOT in the normalization map should be preserved
+        let content = "café shouldn\u{2019}t break";
+        let old_str = "shouldn't";
+        let new_str = "should not";
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert_eq!(result, Some(("café should not break".to_string(), 1)));
+    }
+
+    #[test]
+    fn test_normalized_replace_adjacent_unicode_chars() {
+        // Multiple unicode chars right next to each other
+        let content = "\u{201C}\u{2019}\u{2013}\u{201D}";
+        let old_str = "\"'-\"";
+        let new_str = "X";
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert_eq!(result, Some(("X".to_string(), 1)));
+    }
+
+    #[test]
+    fn test_normalized_replace_only_unicode_differs() {
+        // Content and old_str are identical except for one Unicode char
+        let content = "a\u{00A0}b"; // non-breaking space
+        let old_str = "a b"; // regular space
+        let new_str = "a_b";
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert_eq!(result, Some(("a_b".to_string(), 1)));
+    }
+
+    #[test]
+    fn test_normalized_replace_large_multiline() {
+        // Simulates a realistic str_replace with a large multi-line old_str
+        let content = concat!(
+            "# Title\n\n",
+            "Some text before.\n\n",
+            "Infrastructure shouldn\u{2019}t be this hard. Stakpak lets developers secure, deploy, and run infra.\n\n",
+            "## Features\n\n",
+            "- Feature 1 \u{2013} description\n",
+            "- Feature 2 \u{2013} description\n",
+            "\nMore text after.\n",
+        );
+
+        let old_str = concat!(
+            "Infrastructure shouldn't be this hard. Stakpak lets developers secure, deploy, and run infra.\n\n",
+            "## Features\n\n",
+            "- Feature 1 - description\n",
+            "- Feature 2 - description\n",
+        );
+
+        let new_str = "## Simplified\n\nJust works.\n";
+
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert!(result.is_some());
+        let (new_content, count) = result.unwrap();
+        assert_eq!(count, 1);
+        assert!(new_content.contains("# Title"));
+        assert!(new_content.contains("Some text before."));
+        assert!(new_content.contains("## Simplified\n\nJust works.\n"));
+        assert!(new_content.contains("More text after."));
+        // Original unicode chars that were NOT in old_str are preserved
+        assert!(!new_content.contains("\u{2019}"));
+        assert!(!new_content.contains("\u{2013}"));
+    }
+
+    #[test]
+    fn test_normalized_replace_all_non_overlapping() {
+        let content = "a\u{2013}b c\u{2013}d";
+        let old_str = "-";
+        // This should match the normalized dashes
+        let new_str = "=";
+        let result = unicode_normalized_replace(content, old_str, new_str, true);
+        assert_eq!(result, Some(("a=b c=d".to_string(), 2)));
+    }
+
+    // ---------------------------------------------------------------
+    // unicode_normalized_replace — ellipsis in multi-line realistic scenario
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_normalized_replace_ellipsis_multiline() {
+        let content = concat!("Loading\u{2026}\n", "Please wait\u{2026}\n", "Done!\n",);
+        let old_str = concat!("Loading...\n", "Please wait...\n",);
+        let new_str = "Loaded!\n";
+        let result = unicode_normalized_replace(content, old_str, new_str, false);
+        assert!(result.is_some());
+        let (new_content, count) = result.unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(new_content, "Loaded!\nDone!\n");
+    }
+
+    #[test]
+    fn test_normalized_replace_multiple_ellipsis_replace_all() {
+        let content = "a\u{2026}b\u{2026}c";
+        let old_str = "...";
+        let new_str = "***";
+        let result = unicode_normalized_replace(content, old_str, new_str, true);
+        assert_eq!(result, Some(("a***b***c".to_string(), 2)));
     }
 }


### PR DESCRIPTION
## Description

Fix two classes of bugs in secret restoration and add Unicode-normalized fallback matching for the `str_replace` tool.

## Changes Made

### Secret Restoration (`libs/mcp/proxy/src/server/mod.rs`)

- **Fix JSON corruption:** Replace serialize→string-replace→parse with a recursive JSON value tree walker (`restore_secrets_in_json_value`). Secrets containing `"`, `\`, or newlines no longer break JSON serialization.
- **Fix chain replacement:** Add `restore_secrets_single_pass` — a forward-scanning placeholder resolver that never re-scans replacement output. Prevents secret A's value (which contains secret B's redaction key) from being double-replaced.
- **Collapse nested if:** Satisfy clippy `collapsible_if` lint.

### Unicode Normalized str_replace (`libs/mcp/server/src/local_tools.rs`)

- **Add fallback matching:** When exact match fails, normalize both file content and `old_str` to ASCII equivalents (curly quotes → straight, en-dashes → hyphens, ellipsis → `...`, etc.) and retry.
- **Support 1-to-many mappings:** `…` (1 char) normalizes to `...` (3 chars) with byte-level position mapping back to the original.
- **O(n+m) search:** Use `str::find` (Two-Way algorithm) instead of naive O(n×m) char-by-char scan. Convert byte offsets via `binary_search` on char boundaries.
- **Avoid double scanning:** Derive `replace_all` count from result length difference instead of a separate `.matches().count()` pass.
- **Cheap pre-check:** Normalize without building the full mapping first; skip allocation when normalized pattern still doesn't match.
- **Expanded Unicode coverage:** Add `U+2010` (hyphen), `U+2012` (figure dash), `U+FF07` (fullwidth apostrophe).
- **No `expect()`:** Use fallible `Option`-returning helper to satisfy clippy `expect_used` deny.

## Testing

- 39 proxy tests (secret restoration, single-pass scanner, chain prevention, edge cases)
- 53 local_tools tests (normalization, byte mapping, ellipsis expansion, Unicode replacement, realistic scenarios)
- All 92 tests pass

- [x] All tests pass locally (`cargo test -p stakpak-mcp-proxy -p stakpak-mcp-server`)
- [x] No clippy warnings (`cargo clippy --all-targets -- -D warnings`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Tested on macOS

## Breaking Changes
None