### PR TITLE
Move profile display from footer to Context section in side panel

### DIFF
--- a/tui/src/services/side_panel.rs
+++ b/tui/src/services/side_panel.rs
@@ -69,7 +69,7 @@ pub fn render_side_panel(f: &mut Frame, state: &mut AppState, area: Rect) {
     let context_height = if context_collapsed {
         collapsed_height
     } else {
-        5 // Header + Tokens + Model + Provider
+        6 // Header + Tokens + Model + Provider + Profile
     };
 
     // Billing section is hidden when billing_info is None (local mode)
@@ -236,6 +236,13 @@ fn render_context_section(f: &mut Frame, state: &AppState, area: Rect, collapsed
         _ => "Remote".to_string(),
     };
     lines.push(make_row("Provider", provider_value, Color::DarkGray));
+
+    // Profile
+    lines.push(make_row(
+        "Profile",
+        state.current_profile_name.clone(),
+        Color::DarkGray,
+    ));
 
     let paragraph = Paragraph::new(lines);
     f.render_widget(paragraph, area);
@@ -632,29 +639,17 @@ fn render_changeset_section(f: &mut Frame, state: &AppState, area: Rect, collaps
     f.render_widget(paragraph, area);
 }
 
-/// Render the footer section with version and profile
-fn render_footer_section(f: &mut Frame, state: &AppState, area: Rect) {
+/// Render the footer section with version and shortcuts
+fn render_footer_section(f: &mut Frame, _state: &AppState, area: Rect) {
     let mut lines = Vec::new();
 
     let version = env!("CARGO_PKG_VERSION");
-    let profile = &state.current_profile_name;
-    let available_width = area.width as usize;
 
-    // Line 1: Version (left) and Profile (right)
-    let left_part = format!("{}v{}", LEFT_PADDING, version);
-    let right_part = format!("profile {} ", profile);
-    let total_content = left_part.len() + right_part.len();
-    let spacing = available_width.saturating_sub(total_content).max(1);
-
-    lines.push(Line::from(vec![
-        Span::styled(
-            format!("{}v{}", LEFT_PADDING, version),
-            Style::default().fg(Color::DarkGray),
-        ),
-        Span::raw(" ".repeat(spacing)),
-        Span::styled("profile ", Style::default().fg(Color::DarkGray)),
-        Span::styled(profile, Style::default().fg(Color::Reset)),
-    ]));
+    // Line 1: Version (left)
+    lines.push(Line::from(vec![Span::styled(
+        format!("{}v{}", LEFT_PADDING, version),
+        Style::default().fg(Color::DarkGray),
+    )]));
 
     // Empty line between version/profile and shortcuts
     lines.push(Line::from(""));


### PR DESCRIPTION
## Move profile display from footer to Context section in side panel

### Problem

The profile name was displayed in the side panel **footer** alongside the version, crammed into a single line with left/right alignment. This made it easy to miss and inconsistent with other contextual information (Tokens, Model, Provider) that lives in the **Context** section.

### Changes

**`tui/src/services/side_panel.rs`**

- Added a **"Profile"** row as the last item in the Context section (after Provider), using the same `make_row` helper for consistent formatting
- Increased `context_height` from `5` to `6` to accommodate the new row
- Removed the profile display from `render_footer_section` — the footer now only shows the version and keyboard shortcuts
- Marked `state` as unused (`_state`) in `render_footer_section` since it no longer reads `current_profile_name`

### Before

```
  ▾ Context
    Tokens              N/A
    Model               N/A
    Provider         Remote
  ▾ Tasks
    No tasks
  ...
  v0.3.17        profile default
  tab select  enter toggle
  ctrl+y hide  ctrl+g changes
```

### After

```
  ▾ Context
    Tokens              N/A
    Model               N/A
    Provider         Remote
    Profile         default

  ▾ Tasks
    No tasks
  ...
  v0.3.17
  tab select  enter toggle
  ctrl+y hide  ctrl+g changes
```

### Testing

- `cargo check` — clean
- `cargo clippy` — zero warnings
