### PR TITLE
fix: use platform-verified TLS client for warden CA trust

### DIFF
--- a/cli/src/apikey_auth.rs
+++ b/cli/src/apikey_auth.rs
@@ -18,7 +18,10 @@ fn open_browser(url: &str) -> bool {
 async fn listen_for_callback(url: &str) -> String {
     let start_time = std::time::Instant::now();
     while start_time.elapsed() < std::time::Duration::from_secs(120) {
-        let client = reqwest::Client::new();
+        let client = stakpak_shared::tls_client::create_tls_client(
+            stakpak_shared::tls_client::TlsClientConfig::default(),
+        )
+        .unwrap_or_else(|_| reqwest::Client::new());
         let response = client.get(url).send().await;
 
         match response {

--- a/libs/shared/src/oauth/flow.rs
+++ b/libs/shared/src/oauth/flow.rs
@@ -68,7 +68,9 @@ impl OAuthFlow {
             ));
         }
 
-        let client = reqwest::Client::new();
+        let client =
+            crate::tls_client::create_tls_client(crate::tls_client::TlsClientConfig::default())
+                .unwrap_or_else(|_| reqwest::Client::new());
         let response = client
             .post(&self.config.token_url)
             .json(&serde_json::json!({
@@ -98,7 +100,9 @@ impl OAuthFlow {
 
     /// Refresh an expired access token
     pub async fn refresh_token(&self, refresh_token: &str) -> OAuthResult<TokenResponse> {
-        let client = reqwest::Client::new();
+        let client =
+            crate::tls_client::create_tls_client(crate::tls_client::TlsClientConfig::default())
+                .unwrap_or_else(|_| reqwest::Client::new());
         let response = client
             .post(&self.config.token_url)
             .json(&serde_json::json!({

--- a/libs/shared/src/oauth/providers/anthropic.rs
+++ b/libs/shared/src/oauth/providers/anthropic.rs
@@ -43,7 +43,9 @@ impl AnthropicProvider {
 
     /// Create an API key from OAuth tokens (for "console" method)
     async fn create_api_key(&self, access_token: &str) -> OAuthResult<String> {
-        let client = reqwest::Client::new();
+        let client =
+            crate::tls_client::create_tls_client(crate::tls_client::TlsClientConfig::default())
+                .unwrap_or_else(|_| reqwest::Client::new());
         let response = client
             .post("https://api.anthropic.com/api/oauth/claude_cli/create_api_key")
             .header("authorization", format!("Bearer {}", access_token))

--- a/libs/shared/src/telemetry.rs
+++ b/libs/shared/src/telemetry.rs
@@ -49,7 +49,12 @@ pub fn capture_event(
     };
 
     tokio::spawn(async move {
-        let client = reqwest::Client::new();
+        let client = match crate::tls_client::create_tls_client(
+            crate::tls_client::TlsClientConfig::default(),
+        ) {
+            Ok(c) => c,
+            Err(_) => return,
+        };
         let _ = client.post(TELEMETRY_ENDPOINT).json(&payload).send().await;
     });
 }


### PR DESCRIPTION
## Description

Fix `warden::proxy::server: TLS interception failed for <ip>:443` errors when running the CLI inside the warden container. Several HTTP call sites used bare `reqwest::Client::new()` which only trusts hardcoded Mozilla CAs (via `webpki-roots`), ignoring the warden CA certificate installed in the container's system CA store.

## Changes Made

- **`libs/shared/src/telemetry.rs`** — Replace `reqwest::Client::new()` with `create_tls_client()` (primary trigger: POSTs to `apiv2.stakpak.dev`)
- **`libs/shared/src/oauth/flow.rs`** — Replace in `exchange_code()` and `refresh_token()` with platform-verified client + fallback
- **`libs/shared/src/oauth/providers/anthropic.rs`** — Replace in `create_api_key()` with platform-verified client + fallback
- **`cli/src/apikey_auth.rs`** — Replace in `listen_for_callback()` with platform-verified client + fallback

All replacements use `crate::tls_client::create_tls_client()` which calls `rustls-platform-verifier`'s `.with_platform_verifier()` to read the OS CA store, matching how the AI provider and API clients already work.

## Root Cause

`reqwest` is configured with `features = ["rustls-tls"]`, so `Client::new()` uses `rustls` with `webpki-roots` (hardcoded Mozilla CAs). Inside the warden container, the warden CA is added to the system store via `update-ca-certificates`, but `webpki-roots` doesn't include it. When the warden MITM proxy presents a certificate signed by its CA, these clients reject the handshake.

## Testing

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -p stakpak-shared -p stakpak -- -D warnings` passes
- [x] `cargo check --all-targets` passes
- [x] Tested on macOS

## Breaking Changes

None