### PR TITLE
refactor(storage): add versioned database migrations system

### DIFF
--- a/libs/api/src/local/migrations/mod.rs
+++ b/libs/api/src/local/migrations/mod.rs
@@ -1,0 +1,216 @@
+//! Database migrations
+//!
+//! Each migration has a unique version number and is applied in order.
+//! Applied migrations are tracked in the `_migrations` table.
+//!
+//! Migrations support both `apply` and `rollback` operations via async functions.
+
+use libsql::Connection;
+use std::future::Future;
+use std::pin::Pin;
+
+mod v001_initial_schema;
+mod v002_nullable_columns;
+
+/// Async migration function type
+pub type MigrationFn =
+    fn(&Connection) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>>;
+
+/// A database migration with apply and rollback functions
+pub struct Migration {
+    /// Unique version number (must be sequential)
+    pub version: u32,
+    /// Human-readable description
+    pub description: &'static str,
+    /// Function to apply the migration
+    pub apply: MigrationFn,
+    /// Function to rollback the migration
+    pub rollback: MigrationFn,
+}
+
+/// All migrations in order
+pub fn all_migrations() -> Vec<Migration> {
+    vec![
+        v001_initial_schema::migration(),
+        v002_nullable_columns::migration(),
+    ]
+}
+
+/// Apply all pending migrations
+pub async fn apply_all(conn: &Connection) -> Result<Vec<u32>, String> {
+    init_migrations_table(conn).await?;
+
+    let applied = get_applied_versions(conn).await?;
+    let mut newly_applied = Vec::new();
+
+    for migration in all_migrations() {
+        if applied.contains(&migration.version) {
+            continue;
+        }
+
+        apply_migration(conn, &migration).await?;
+        newly_applied.push(migration.version);
+    }
+
+    Ok(newly_applied)
+}
+
+/// Rollback the last applied migration
+pub async fn rollback_last(conn: &Connection) -> Result<Option<u32>, String> {
+    let applied = get_applied_versions(conn).await?;
+
+    if let Some(&last_version) = applied.last() {
+        let migrations = all_migrations();
+        if let Some(migration) = migrations.iter().find(|m| m.version == last_version) {
+            rollback_migration(conn, migration).await?;
+            return Ok(Some(last_version));
+        }
+    }
+
+    Ok(None)
+}
+
+/// Rollback to a specific version (keeps that version, removes newer ones)
+pub async fn rollback_to(conn: &Connection, target_version: u32) -> Result<Vec<u32>, String> {
+    let applied = get_applied_versions(conn).await?;
+    let migrations = all_migrations();
+    let mut rolled_back = Vec::new();
+
+    for &version in applied.iter().rev() {
+        if version <= target_version {
+            break;
+        }
+
+        if let Some(migration) = migrations.iter().find(|m| m.version == version) {
+            rollback_migration(conn, migration).await?;
+            rolled_back.push(version);
+        }
+    }
+
+    Ok(rolled_back)
+}
+
+/// Get current migration version (0 if none applied)
+pub async fn current_version(conn: &Connection) -> Result<u32, String> {
+    let applied = get_applied_versions(conn).await?;
+    Ok(applied.last().copied().unwrap_or(0))
+}
+
+/// Get list of applied migration versions
+pub async fn get_applied_versions(conn: &Connection) -> Result<Vec<u32>, String> {
+    let mut rows = conn
+        .query(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='_migrations'",
+            (),
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+    if rows.next().await.map_err(|e| e.to_string())?.is_none() {
+        return Ok(Vec::new());
+    }
+    drop(rows);
+
+    let mut applied: Vec<u32> = Vec::new();
+    let mut rows = conn
+        .query("SELECT version FROM _migrations ORDER BY version", ())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    while let Ok(Some(row)) = rows.next().await {
+        if let Ok(version) = row.get::<u32>(0) {
+            applied.push(version);
+        }
+    }
+
+    Ok(applied)
+}
+
+/// Get migration status
+pub async fn status(conn: &Connection) -> Result<MigrationStatus, String> {
+    let applied = get_applied_versions(conn).await?;
+    let all = all_migrations();
+
+    let pending: Vec<u32> = all
+        .iter()
+        .filter(|m| !applied.contains(&m.version))
+        .map(|m| m.version)
+        .collect();
+
+    Ok(MigrationStatus { applied, pending })
+}
+
+pub struct MigrationStatus {
+    pub applied: Vec<u32>,
+    pub pending: Vec<u32>,
+}
+
+// ============================================================================
+// Internal
+// ============================================================================
+
+async fn init_migrations_table(conn: &Connection) -> Result<(), String> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS _migrations (
+            version INTEGER PRIMARY KEY,
+            description TEXT NOT NULL,
+            applied_at TEXT NOT NULL
+        )",
+        (),
+    )
+    .await
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+async fn apply_migration(conn: &Connection, migration: &Migration) -> Result<(), String> {
+    conn.execute("PRAGMA foreign_keys=OFF", ())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    (migration.apply)(conn).await?;
+
+    conn.execute(
+        "INSERT INTO _migrations (version, description, applied_at) VALUES (?, ?, datetime('now'))",
+        (migration.version, migration.description),
+    )
+    .await
+    .map_err(|e| e.to_string())?;
+
+    conn.execute("PRAGMA foreign_keys=ON", ())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(())
+}
+
+async fn rollback_migration(conn: &Connection, migration: &Migration) -> Result<(), String> {
+    conn.execute("PRAGMA foreign_keys=OFF", ())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    (migration.rollback)(conn).await?;
+
+    conn.execute(
+        "DELETE FROM _migrations WHERE version = ?",
+        [migration.version],
+    )
+    .await
+    .map_err(|e| e.to_string())?;
+
+    conn.execute("PRAGMA foreign_keys=ON", ())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(())
+}
+
+// ============================================================================
+// Public API for storage.rs
+// ============================================================================
+
+/// Run all pending migrations
+pub async fn run_migrations(conn: &Connection) -> Result<(), String> {
+    apply_all(conn).await?;
+    Ok(())
+}

--- a/libs/api/src/local/migrations/v001_initial_schema.rs
+++ b/libs/api/src/local/migrations/v001_initial_schema.rs
@@ -1,0 +1,80 @@
+//! v001: Initial schema
+//!
+//! Creates the sessions and checkpoints tables with the original schema.
+
+use super::Migration;
+use libsql::Connection;
+use std::future::Future;
+use std::pin::Pin;
+
+pub fn migration() -> Migration {
+    Migration {
+        version: 1,
+        description: "Initial schema",
+        apply,
+        rollback,
+    }
+}
+
+fn apply(conn: &Connection) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>> {
+    Box::pin(async move {
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS sessions (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                agent_id TEXT NOT NULL,
+                visibility TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )",
+            (),
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS checkpoints (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                status TEXT NOT NULL,
+                execution_depth INTEGER NOT NULL,
+                parent_id TEXT,
+                state TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                FOREIGN KEY(session_id) REFERENCES sessions(id),
+                FOREIGN KEY(parent_id) REFERENCES checkpoints(id)
+            )",
+            (),
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_checkpoints_session_id ON checkpoints(session_id)",
+            (),
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+        Ok(())
+    })
+}
+
+fn rollback(conn: &Connection) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>> {
+    Box::pin(async move {
+        conn.execute("DROP INDEX IF EXISTS idx_checkpoints_session_id", ())
+            .await
+            .map_err(|e| e.to_string())?;
+
+        conn.execute("DROP TABLE IF EXISTS checkpoints", ())
+            .await
+            .map_err(|e| e.to_string())?;
+
+        conn.execute("DROP TABLE IF EXISTS sessions", ())
+            .await
+            .map_err(|e| e.to_string())?;
+
+        Ok(())
+    })
+}

--- a/libs/api/src/local/migrations/v002_nullable_columns.rs
+++ b/libs/api/src/local/migrations/v002_nullable_columns.rs
@@ -1,0 +1,168 @@
+//! v002: Add nullable columns and make some columns nullable
+//!
+//! - sessions: add status, cwd columns; make agent_id nullable
+//! - checkpoints: make status, execution_depth nullable
+
+use super::Migration;
+use libsql::Connection;
+use std::future::Future;
+use std::pin::Pin;
+
+pub fn migration() -> Migration {
+    Migration {
+        version: 2,
+        description: "Add status/cwd columns, make agent_id/status/execution_depth nullable",
+        apply,
+        rollback,
+    }
+}
+
+fn apply(conn: &Connection) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>> {
+    Box::pin(async move {
+        // Migrate sessions table
+        conn.execute("ALTER TABLE sessions RENAME TO _sessions_old", ())
+            .await
+            .map_err(|e| e.to_string())?;
+
+        conn.execute(
+            "CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                agent_id TEXT,
+                visibility TEXT NOT NULL DEFAULT 'PRIVATE',
+                status TEXT DEFAULT 'ACTIVE',
+                cwd TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )",
+            (),
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+        conn.execute(
+            "INSERT INTO sessions (id, title, agent_id, visibility, status, cwd, created_at, updated_at)
+             SELECT id, title, agent_id, visibility, 'ACTIVE', NULL, created_at, updated_at
+             FROM _sessions_old",
+            (),
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+        conn.execute("DROP TABLE _sessions_old", ())
+            .await
+            .map_err(|e| e.to_string())?;
+
+        // Migrate checkpoints table
+        conn.execute("ALTER TABLE checkpoints RENAME TO _checkpoints_old", ())
+            .await
+            .map_err(|e| e.to_string())?;
+
+        conn.execute(
+            "CREATE TABLE checkpoints (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                status TEXT,
+                execution_depth INTEGER,
+                parent_id TEXT,
+                state TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                FOREIGN KEY(session_id) REFERENCES sessions(id),
+                FOREIGN KEY(parent_id) REFERENCES checkpoints(id)
+            )",
+            (),
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+        conn.execute(
+            "INSERT INTO checkpoints (id, session_id, status, execution_depth, parent_id, state, created_at, updated_at)
+             SELECT id, session_id, status, execution_depth, parent_id, state, created_at, updated_at
+             FROM _checkpoints_old",
+            (),
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+        conn.execute("DROP TABLE _checkpoints_old", ())
+            .await
+            .map_err(|e| e.to_string())?;
+
+        Ok(())
+    })
+}
+
+fn rollback(conn: &Connection) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>> {
+    Box::pin(async move {
+        // Rollback sessions table
+        conn.execute("ALTER TABLE sessions RENAME TO _sessions_old", ())
+            .await
+            .map_err(|e| e.to_string())?;
+
+        conn.execute(
+            "CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                agent_id TEXT NOT NULL,
+                visibility TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )",
+            (),
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+        conn.execute(
+            "INSERT INTO sessions (id, title, agent_id, visibility, created_at, updated_at)
+             SELECT id, title, COALESCE(agent_id, ''), visibility, created_at, updated_at
+             FROM _sessions_old",
+            (),
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+        conn.execute("DROP TABLE _sessions_old", ())
+            .await
+            .map_err(|e| e.to_string())?;
+
+        // Rollback checkpoints table
+        conn.execute("ALTER TABLE checkpoints RENAME TO _checkpoints_old", ())
+            .await
+            .map_err(|e| e.to_string())?;
+
+        conn.execute(
+            "CREATE TABLE checkpoints (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                status TEXT NOT NULL,
+                execution_depth INTEGER NOT NULL,
+                parent_id TEXT,
+                state TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                FOREIGN KEY(session_id) REFERENCES sessions(id),
+                FOREIGN KEY(parent_id) REFERENCES checkpoints(id)
+            )",
+            (),
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+        conn.execute(
+            "INSERT INTO checkpoints (id, session_id, status, execution_depth, parent_id, state, created_at, updated_at)
+             SELECT id, session_id, COALESCE(status, ''), COALESCE(execution_depth, 0), parent_id, state, created_at, updated_at
+             FROM _checkpoints_old",
+            (),
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+        conn.execute("DROP TABLE _checkpoints_old", ())
+            .await
+            .map_err(|e| e.to_string())?;
+
+        Ok(())
+    })
+}

--- a/libs/api/src/local/mod.rs
+++ b/libs/api/src/local/mod.rs
@@ -11,6 +11,7 @@ use stakpak_shared::models::llm::LLMModel;
 // Sub-modules
 pub(crate) mod context_managers;
 pub mod hooks;
+pub mod migrations;
 pub mod storage;
 
 #[cfg(test)]


### PR DESCRIPTION
## Description
Add a proper database migrations system with versioned migrations, apply/rollback support, and state tracking.

## Changes Made
- Add `migrations` module under `libs/api/src/local/`
- `mod.rs`: Migration runner with `apply_all()`, `rollback_last()`, `rollback_to()`, `status()`, and `current_version()` functions
- `v001_initial_schema.rs`: Creates sessions and checkpoints tables with original schema
- `v002_nullable_columns.rs`: Migrates to make `agent_id`, `status`, `execution_depth` nullable; adds `status` and `cwd` columns to sessions
- Track applied migrations in `_migrations` table with version, description, and timestamp
- Replace inline schema code in `storage.rs` with migration system
- Each migration supports both `apply` and `rollback` via async functions

## Testing
- [x] All tests pass locally
- [x] Added tests for migration apply, rollback, and rollback_to
- [x] Tested on macOS

## Breaking Changes
None - existing databases are automatically migrated on startup.