### PR TITLE
fix: remove SPACING_MARKER from subagent context formatting

### DIFF
--- a/libs/shared/src/models/subagent.rs
+++ b/libs/shared/src/models/subagent.rs
@@ -60,10 +60,7 @@ impl SubagentConfigs {
                 .collect::<Vec<String>>()
                 .join("\n");
 
-            format!(
-                "SPACING_MARKER\n# Available Subagents:\nSPACING_MARKER\n{}",
-                subagents_text
-            )
+            format!("# Available Subagents:\n\n{}", subagents_text)
         }
     }
 }


### PR DESCRIPTION
SPACING_MARKER is a TUI-only display directive that was incorrectly embedded in format_for_context() which generates content sent to the LLM. This caused the marker to appear in the TUI and be saved in context.

Removed the markers from the format string, keeping only the actual content.