### PR TITLE
feat(stakai): add User-Agent header to Stakpak provider

### DIFF
--- a/libs/ai/src/providers/stakpak/provider.rs
+++ b/libs/ai/src/providers/stakpak/provider.rs
@@ -52,6 +52,10 @@ impl Provider for StakpakProvider {
         headers.insert("Authorization", format!("Bearer {}", self.config.api_key));
         headers.insert("Content-Type", "application/json");
 
+        if let Some(user_agent) = &self.config.user_agent {
+            headers.insert("User-Agent", user_agent.clone());
+        }
+
         if let Some(custom) = custom_headers {
             headers.merge_with(custom);
         }

--- a/libs/ai/src/providers/stakpak/types.rs
+++ b/libs/ai/src/providers/stakpak/types.rs
@@ -12,6 +12,8 @@ pub struct StakpakProviderConfig {
     pub api_key: String,
     /// Base URL (default: https://apiv2.stakpak.dev)
     pub base_url: String,
+    /// User-Agent header (e.g., "Stakpak/1.0.0")
+    pub user_agent: Option<String>,
 }
 
 impl StakpakProviderConfig {
@@ -20,6 +22,7 @@ impl StakpakProviderConfig {
         Self {
             api_key: api_key.into(),
             base_url: "https://apiv2.stakpak.dev".to_string(),
+            user_agent: None,
         }
     }
 
@@ -28,11 +31,21 @@ impl StakpakProviderConfig {
         self.base_url = base_url.into();
         self
     }
+
+    /// Set User-Agent header
+    pub fn with_user_agent(mut self, user_agent: impl Into<String>) -> Self {
+        self.user_agent = Some(user_agent.into());
+        self
+    }
 }
 
 impl Default for StakpakProviderConfig {
     fn default() -> Self {
-        Self::new(std::env::var("STAKPAK_API_KEY").unwrap_or_else(|_| String::new()))
+        Self {
+            api_key: std::env::var("STAKPAK_API_KEY").unwrap_or_else(|_| String::new()),
+            base_url: "https://apiv2.stakpak.dev".to_string(),
+            user_agent: None,
+        }
     }
 }
 

--- a/libs/shared/src/models/stakai_adapter.rs
+++ b/libs/shared/src/models/stakai_adapter.rs
@@ -533,7 +533,8 @@ fn build_provider_registry_direct(config: &LLMProviderConfig) -> Result<Provider
                 if api_key.is_empty() {
                     continue;
                 }
-                let mut stakpak_config = StakpakProviderConfig::new(api_key.clone());
+                let mut stakpak_config = StakpakProviderConfig::new(api_key.clone())
+                    .with_user_agent(format!("Stakpak/{}", env!("CARGO_PKG_VERSION")));
                 if let Some(endpoint) = api_endpoint {
                     stakpak_config = stakpak_config.with_base_url(endpoint.clone());
                 }


### PR DESCRIPTION
## Description
Adds User-Agent header support to the Stakpak inference provider, allowing the server to identify CLI client requests.

## Changes Made
- Add `user_agent` field to `StakpakProviderConfig`
- Add `with_user_agent()` builder method
- Set User-Agent header in `build_headers()` when configured
- Configure CLI to send `Stakpak/{version}` user agent

## Testing
- [x] All tests pass locally
- [x] Code formatted with `cargo fmt`
- [x] No clippy warnings

## Breaking Changes
None