### PR TITLE
fix: rename mrkdwn_text to markdown_text in Slack send message

### DIFF
--- a/libs/api/src/client/provider.rs
+++ b/libs/api/src/client/provider.rs
@@ -531,7 +531,7 @@ impl AgentProvider for AgentClient {
         if let Some(api) = &self.stakpak_api {
             api.slack_send_message(&crate::stakpak::SlackSendMessageRequest {
                 channel: input.channel.clone(),
-                mrkdwn_text: input.mrkdwn_text.clone(),
+                markdown_text: input.markdown_text.clone(),
                 thread_ts: input.thread_ts.clone(),
             })
             .await

--- a/libs/api/src/models.rs
+++ b/libs/api/src/models.rs
@@ -424,7 +424,7 @@ pub struct SlackReadRepliesRequest {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct SlackSendMessageRequest {
     pub channel: String,
-    pub mrkdwn_text: String,
+    pub markdown_text: String,
     pub thread_ts: Option<String>,
 }
 

--- a/libs/api/src/stakpak/models.rs
+++ b/libs/api/src/stakpak/models.rs
@@ -264,7 +264,7 @@ pub struct SlackReadRepliesRequest {
 #[derive(Debug, Serialize)]
 pub struct SlackSendMessageRequest {
     pub channel: String,
-    pub mrkdwn_text: String,
+    pub markdown_text: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thread_ts: Option<String>,
 }

--- a/libs/mcp/server/src/integrations/slack.rs
+++ b/libs/mcp/server/src/integrations/slack.rs
@@ -63,7 +63,7 @@ pub struct SlackSendMessage {
                        Not supported: HTML, Markdown tables, headings, underline, multi-column layouts. \
                        For table-like output, use aligned monospace text in a code block. Use plain text if unsure."
     )]
-    pub mrkdwn_text: String,
+    pub markdown_text: String,
     #[schemars(
         description = "Optional Slack thread 'ts'. When provided, posts the message as a reply in that thread; otherwise posts a new top-level message."
     )]
@@ -74,7 +74,7 @@ impl From<SlackSendMessage> for ApiSlackSendMessageRequest {
     fn from(req: SlackSendMessage) -> Self {
         Self {
             channel: req.channel,
-            mrkdwn_text: req.mrkdwn_text,
+            markdown_text: req.markdown_text,
             thread_ts: req.thread_ts,
         }
     }


### PR DESCRIPTION
## Problem
The Slack send message tool was failing with validation error:
```
Validation error: missing field `markdown_text`
```

## Root Cause
Field name mismatch between agent and API:
- **API expects:** `markdown_text`
- **Agent sends:** `mrkdwn_text`

## Fix
Renamed the field from `mrkdwn_text` to `markdown_text` in:
- `libs/mcp/server/src/integrations/slack.rs`
- `libs/api/src/stakpak/models.rs`
- `libs/api/src/models.rs`
- `libs/api/src/client/provider.rs`

## Testing
- [x] `cargo build` passes