### PR TITLE
fix(gemini): SSE streaming, thought_signature preservation, and usage reporting

### DIFF
--- a/cli/src/commands/agent/run/mode_interactive.rs
+++ b/cli/src/commands/agent/run/mode_interactive.rs
@@ -1389,6 +1389,7 @@ mod tests {
                 name: "test_tool".to_string(),
                 arguments: "{}".to_string(),
             },
+            metadata: None,
         };
 
         let messages = vec![ChatMessage {
@@ -1411,6 +1412,7 @@ mod tests {
                 name: "test_tool".to_string(),
                 arguments: "{}".to_string(),
             },
+            metadata: None,
         };
 
         let messages = vec![
@@ -1440,6 +1442,7 @@ mod tests {
                 name: "test_tool".to_string(),
                 arguments: "{}".to_string(),
             },
+            metadata: None,
         };
         let tool_call_2 = ToolCall {
             id: "tool_2".to_string(),
@@ -1448,6 +1451,7 @@ mod tests {
                 name: "test_tool_2".to_string(),
                 arguments: "{}".to_string(),
             },
+            metadata: None,
         };
 
         let messages = vec![
@@ -1480,6 +1484,7 @@ mod tests {
                 name: "test_tool".to_string(),
                 arguments: "{}".to_string(),
             },
+            metadata: None,
         }];
 
         assert!(has_pending_tool_calls(&messages, &tools_queue));
@@ -1502,6 +1507,7 @@ mod tests {
                 name: "test_tool".to_string(),
                 arguments: "{}".to_string(),
             },
+            metadata: None,
         };
 
         let messages = vec![ChatMessage {
@@ -1524,6 +1530,7 @@ mod tests {
                 name: "test_tool".to_string(),
                 arguments: "{}".to_string(),
             },
+            metadata: None,
         };
 
         let messages = vec![
@@ -1554,6 +1561,7 @@ mod tests {
                 name: "test_tool".to_string(),
                 arguments: "{}".to_string(),
             },
+            metadata: None,
         };
         let tool_call_2 = ToolCall {
             id: "tool_2".to_string(),
@@ -1562,6 +1570,7 @@ mod tests {
                 name: "test_tool_2".to_string(),
                 arguments: "{}".to_string(),
             },
+            metadata: None,
         };
 
         let messages = vec![
@@ -1619,6 +1628,7 @@ mod tests {
                 name: "old_tool".to_string(),
                 arguments: "{}".to_string(),
             },
+            metadata: None,
         };
         let tool_call_new = ToolCall {
             id: "tool_new".to_string(),
@@ -1627,6 +1637,7 @@ mod tests {
                 name: "new_tool".to_string(),
                 arguments: "{}".to_string(),
             },
+            metadata: None,
         };
 
         let messages = vec![

--- a/cli/src/commands/agent/run/stream.rs
+++ b/cli/src/commands/agent/run/stream.rs
@@ -49,6 +49,10 @@ impl ToolCallAccumulator {
                         tool_call.function.arguments.push_str(args);
                     }
                 }
+                // Merge metadata (later deltas can carry metadata, e.g. ToolCallEnd)
+                if delta.metadata.is_some() {
+                    tool_call.metadata = delta.metadata.clone();
+                }
             }
             None => {
                 // Create new tool call
@@ -79,6 +83,7 @@ impl ToolCallAccumulator {
                     name: String::new(),
                     arguments: String::new(),
                 },
+                metadata: None,
             });
         }
 
@@ -90,6 +95,7 @@ impl ToolCallAccumulator {
                 name: func.and_then(|f| f.name.clone()).unwrap_or_default(),
                 arguments: func.and_then(|f| f.arguments.clone()).unwrap_or_default(),
             },
+            metadata: delta.metadata.clone(),
         });
     }
 
@@ -286,6 +292,7 @@ mod tests {
                         id,
                         r#type: Some("function".to_string()),
                         function: Some(FunctionCallDelta { name, arguments }),
+                        metadata: None,
                     }]),
                 },
                 finish_reason: None,

--- a/libs/ai/examples/tool_calling_streaming.rs
+++ b/libs/ai/examples/tool_calling_streaming.rs
@@ -104,6 +104,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 id,
                 name,
                 arguments,
+                ..
             } => {
                 println!("\n✅ Tool call completed:");
                 println!("  ID: {}", id);

--- a/libs/ai/src/providers/anthropic/convert.rs
+++ b/libs/ai/src/providers/anthropic/convert.rs
@@ -522,6 +522,7 @@ pub fn from_anthropic_response_with_warnings(
                 id: id.clone(),
                 name: name.clone(),
                 arguments: input.clone(),
+                metadata: None,
             })),
             _ => None,
         })

--- a/libs/ai/src/providers/anthropic/stream.rs
+++ b/libs/ai/src/providers/anthropic/stream.rs
@@ -375,6 +375,7 @@ mod tests {
             id,
             name,
             arguments,
+            ..
         } = &results[0]
         {
             assert_eq!(id, "toolu_01ABC123");
@@ -495,6 +496,7 @@ mod tests {
             id,
             name,
             arguments,
+            ..
         } = &results[0]
         {
             assert_eq!(id, "toolu_first");
@@ -521,6 +523,7 @@ mod tests {
             id,
             name,
             arguments,
+            ..
         } = &results[0]
         {
             assert_eq!(id, "toolu_second");
@@ -662,6 +665,7 @@ mod tests {
             id,
             name,
             arguments,
+            ..
         } = &results[0]
         {
             assert_eq!(id, "toolu_empty");

--- a/libs/ai/src/providers/gemini/provider.rs
+++ b/libs/ai/src/providers/gemini/provider.rs
@@ -45,10 +45,17 @@ impl GeminiProvider {
         } else {
             "generateContent"
         };
-        format!(
-            "{}models/{}:{}?key={}",
-            self.config.base_url, model, action, self.config.api_key
-        )
+        if stream {
+            format!(
+                "{}models/{}:{}?alt=sse&key={}",
+                self.config.base_url, model, action, self.config.api_key
+            )
+        } else {
+            format!(
+                "{}models/{}:{}?key={}",
+                self.config.base_url, model, action, self.config.api_key
+            )
+        }
     }
 }
 

--- a/libs/ai/src/providers/gemini/types.rs
+++ b/libs/ai/src/providers/gemini/types.rs
@@ -92,6 +92,11 @@ pub struct GeminiPart {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub function_response: Option<GeminiFunctionResponse>,
+
+    /// Opaque thought signature for Gemini thinking mode.
+    /// Must be preserved and echoed back on the Part level.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thought_signature: Option<String>,
 }
 
 /// Gemini function call
@@ -273,6 +278,7 @@ pub enum GeminiHarmBlockThreshold {
 
 /// Gemini response
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct GeminiResponse {
     pub candidates: Option<Vec<GeminiCandidate>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -285,6 +291,7 @@ pub struct GeminiResponse {
 
 /// Gemini candidate
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct GeminiCandidate {
     pub content: Option<GeminiContent>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -329,6 +336,10 @@ pub struct GeminiUsageMetadata {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total_token_count: Option<u32>,
+
+    /// Token count for model thinking/reasoning (when thinking mode is enabled)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thoughts_token_count: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prompt_tokens_details: Option<Vec<GeminiTokenDetail>>,

--- a/libs/ai/src/providers/openai/convert.rs
+++ b/libs/ai/src/providers/openai/convert.rs
@@ -308,6 +308,7 @@ fn parse_message_content(msg: &ChatMessage) -> Result<Vec<ResponseContent>> {
                 name: tc.function.name.clone(),
                 arguments: serde_json::from_str(&tc.function.arguments)
                     .unwrap_or_else(|_| json!({})),
+                metadata: None,
             }));
         }
     }
@@ -592,6 +593,7 @@ pub fn from_responses_response(resp: ResponsesResponse) -> Result<GenerateRespon
                     id: call_id.clone(),
                     name: name.clone(),
                     arguments: serde_json::from_str(arguments).unwrap_or_else(|_| json!({})),
+                    metadata: None,
                 }));
             }
             ResponsesOutputItem::Reasoning { .. } => {

--- a/libs/ai/src/providers/openai/stream.rs
+++ b/libs/ai/src/providers/openai/stream.rs
@@ -616,6 +616,7 @@ mod tests {
             id,
             name,
             arguments,
+            ..
         } = &events[0]
         {
             assert_eq!(id, "call_abc123");
@@ -687,6 +688,7 @@ mod tests {
             id,
             name,
             arguments,
+            ..
         } = &events[0]
         {
             assert_eq!(id, "call_first");
@@ -701,6 +703,7 @@ mod tests {
             id,
             name,
             arguments,
+            ..
         } = &events[1]
         {
             assert_eq!(id, "call_second");

--- a/libs/ai/src/providers/stakpak/provider.rs
+++ b/libs/ai/src/providers/stakpak/provider.rs
@@ -227,6 +227,7 @@ fn parse_stakpak_message(msg: &super::types::StakpakMessage) -> Result<Vec<Respo
                 name: tc.function.name.clone(),
                 arguments: serde_json::from_str(&tc.function.arguments)
                     .unwrap_or_else(|_| json!({})),
+                metadata: None,
             }));
         }
     }

--- a/libs/ai/src/types/message.rs
+++ b/libs/ai/src/types/message.rs
@@ -267,6 +267,10 @@ pub enum ContentPart {
         /// Provider-specific options (e.g., cache control)
         #[serde(skip_serializing_if = "Option::is_none")]
         provider_options: Option<ContentPartProviderOptions>,
+        /// Opaque provider-specific metadata (e.g., Gemini thought_signature).
+        /// Must be preserved and echoed back in subsequent requests.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        metadata: Option<serde_json::Value>,
     },
     /// Tool/function call result
     ToolResult {
@@ -318,6 +322,7 @@ impl ContentPart {
             name: name.into(),
             arguments,
             provider_options: None,
+            metadata: None,
         }
     }
 
@@ -357,12 +362,14 @@ impl ContentPart {
                 id,
                 name,
                 arguments,
+                metadata,
                 ..
             } => Self::ToolCall {
                 id,
                 name,
                 arguments,
                 provider_options,
+                metadata,
             },
             Self::ToolResult {
                 tool_call_id,
@@ -394,12 +401,14 @@ impl ContentPart {
                 id,
                 name,
                 arguments,
+                metadata,
                 ..
             } => Self::ToolCall {
                 id,
                 name,
                 arguments,
                 provider_options,
+                metadata,
             },
             Self::ToolResult {
                 tool_call_id,

--- a/libs/ai/src/types/response.rs
+++ b/libs/ai/src/types/response.rs
@@ -135,6 +135,10 @@ pub struct ToolCall {
     pub name: String,
     /// Arguments as JSON
     pub arguments: Value,
+    /// Opaque provider-specific metadata (e.g., Gemini thought_signature).
+    /// Must be preserved and echoed back in subsequent requests.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
 }
 
 /// Input token details with cache information

--- a/libs/ai/src/types/stream.rs
+++ b/libs/ai/src/types/stream.rs
@@ -106,6 +106,7 @@ impl Stream for GenerateStream {
                     id,
                     name,
                     arguments,
+                    ..
                 } => {
                     // Update the tool call with final name and arguments
                     if let Some(tc) = this
@@ -228,6 +229,9 @@ pub enum StreamEvent {
         name: String,
         /// Complete arguments as JSON
         arguments: Value,
+        /// Opaque provider-specific metadata (e.g., Gemini thought_signature)
+        #[serde(skip_serializing_if = "Option::is_none")]
+        metadata: Option<Value>,
     },
 
     /// Generation finished
@@ -289,6 +293,22 @@ impl StreamEvent {
             id: id.into(),
             name: name.into(),
             arguments,
+            metadata: None,
+        }
+    }
+
+    /// Create a tool call end event with metadata
+    pub fn tool_call_end_with_metadata(
+        id: impl Into<String>,
+        name: impl Into<String>,
+        arguments: Value,
+        metadata: Option<Value>,
+    ) -> Self {
+        Self::ToolCallEnd {
+            id: id.into(),
+            name: name.into(),
+            arguments,
+            metadata,
         }
     }
 

--- a/libs/api/src/local/context_managers/file_scratchpad_context_manager.rs
+++ b/libs/api/src/local/context_managers/file_scratchpad_context_manager.rs
@@ -638,6 +638,7 @@ mod tests {
                         })
                         .to_string(),
                     },
+                    metadata: None,
                 }]),
                 tool_call_id: None,
                 name: None,
@@ -658,6 +659,7 @@ mod tests {
                         })
                         .to_string(),
                     },
+                    metadata: None,
                 }]),
                 tool_call_id: None,
                 name: None,
@@ -789,6 +791,7 @@ mod tests {
                         })
                         .to_string(),
                     },
+                    metadata: None,
                 }]),
                 tool_call_id: None,
                 name: None,
@@ -811,6 +814,7 @@ mod tests {
                         })
                         .to_string(),
                     },
+                    metadata: None,
                 }]),
                 tool_call_id: None,
                 name: None,

--- a/libs/api/src/local/context_managers/task_board_context_manager.rs
+++ b/libs/api/src/local/context_managers/task_board_context_manager.rs
@@ -142,6 +142,7 @@ mod tests {
                     name: "test_tool".to_string(),
                     arguments: "{}".to_string(),
                 },
+                metadata: None,
             }]),
             ..Default::default()
         }
@@ -238,6 +239,7 @@ mod tests {
                         name: "t".to_string(),
                         arguments: "{}".to_string(),
                     },
+                    metadata: None,
                 }]),
                 ..Default::default()
             },
@@ -300,6 +302,7 @@ mod tests {
                         name: "t".to_string(),
                         arguments: "{}".to_string(),
                     },
+                    metadata: None,
                 }]),
                 ..Default::default()
             },
@@ -315,6 +318,7 @@ mod tests {
                         name: "t".to_string(),
                         arguments: "{}".to_string(),
                     },
+                    metadata: None,
                 }]),
                 ..Default::default()
             },
@@ -426,6 +430,7 @@ mod tests {
                         name: "t".to_string(),
                         arguments: "{}".to_string(),
                     },
+                    metadata: None,
                 }]),
                 ..Default::default()
             },

--- a/libs/api/src/models.rs
+++ b/libs/api/src/models.rs
@@ -465,7 +465,13 @@ impl From<&LLMOutput> for ChatMessage {
             let calls: Vec<ToolCall> = items
                 .iter()
                 .filter_map(|item| {
-                    if let LLMMessageTypedContent::ToolCall { id, name, args } = item {
+                    if let LLMMessageTypedContent::ToolCall {
+                        id,
+                        name,
+                        args,
+                        metadata,
+                    } = item
+                    {
                         Some(ToolCall {
                             id: id.clone(),
                             r#type: "function".to_string(),
@@ -473,6 +479,7 @@ impl From<&LLMOutput> for ChatMessage {
                                 name: name.clone(),
                                 arguments: args.to_string(),
                             },
+                            metadata: metadata.clone(),
                         })
                     } else {
                         None

--- a/libs/shared/src/models/integrations/openai.rs
+++ b/libs/shared/src/models/integrations/openai.rs
@@ -516,6 +516,9 @@ pub struct ToolCall {
     pub id: String,
     pub r#type: String,
     pub function: FunctionCall,
+    /// Opaque provider-specific metadata (e.g., Gemini thought_signature)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
 }
 
 /// Function call details
@@ -727,6 +730,9 @@ pub struct ToolCallDelta {
     pub id: Option<String>,
     pub r#type: Option<String>,
     pub function: Option<FunctionCallDelta>,
+    /// Opaque provider-specific metadata (e.g., Gemini thought_signature)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -765,7 +771,12 @@ impl From<LLMMessage> for ChatMessage {
                                 image_url: None,
                             });
                         }
-                        LLMMessageTypedContent::ToolCall { id, name, args } => {
+                        LLMMessageTypedContent::ToolCall {
+                            id,
+                            name,
+                            args,
+                            metadata,
+                        } => {
                             tool_call_parts.push(ToolCall {
                                 id,
                                 r#type: "function".to_string(),
@@ -773,6 +784,7 @@ impl From<LLMMessage> for ChatMessage {
                                     name,
                                     arguments: args.to_string(),
                                 },
+                                metadata,
                             });
                         }
                         LLMMessageTypedContent::ToolResult { content, .. } => {
@@ -878,6 +890,7 @@ impl From<ChatMessage> for LLMMessage {
                     id: tool_call.id,
                     name: tool_call.function.name,
                     args,
+                    metadata: tool_call.metadata,
                 });
             }
         }
@@ -948,6 +961,7 @@ impl From<GenerationDelta> for ChatMessageDelta {
                         name: tool_use.name,
                         arguments: tool_use.input,
                     }),
+                    metadata: tool_use.metadata,
                 }]),
             },
             _ => ChatMessageDelta {
@@ -1120,6 +1134,7 @@ mod tests {
                     name: "get_weather".to_string(),
                     arguments: r#"{"location": "Paris"}"#.to_string(),
                 },
+                metadata: None,
             }]),
             tool_call_id: None,
             usage: None,
@@ -1143,7 +1158,7 @@ mod tests {
 
                 // Second part should be tool call
                 match &parts[1] {
-                    LLMMessageTypedContent::ToolCall { id, name, args } => {
+                    LLMMessageTypedContent::ToolCall { id, name, args, .. } => {
                         assert_eq!(id, "call_abc123");
                         assert_eq!(name, "get_weather");
                         assert_eq!(args["location"], "Paris");

--- a/libs/shared/src/models/llm.rs
+++ b/libs/shared/src/models/llm.rs
@@ -450,6 +450,9 @@ pub enum LLMMessageTypedContent {
         name: String,
         #[serde(alias = "input")]
         args: serde_json::Value,
+        /// Opaque provider-specific metadata (e.g., Gemini thought_signature).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        metadata: Option<serde_json::Value>,
     },
     #[serde(rename = "tool_result")]
     ToolResult {
@@ -624,6 +627,9 @@ pub struct GenerationDeltaToolUse {
     pub name: Option<String>,
     pub input: Option<String>,
     pub index: usize,
+    /// Opaque provider-specific metadata (e.g., Gemini thought_signature)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
 }
 
 #[cfg(test)]

--- a/tui/src/services/approval_bar.rs
+++ b/tui/src/services/approval_bar.rs
@@ -542,6 +542,7 @@ mod tests {
                 name: name.to_string(),
                 arguments: args.to_string(),
             },
+            metadata: None,
         }
     }
 

--- a/tui/src/services/changeset.rs
+++ b/tui/src/services/changeset.rs
@@ -501,6 +501,7 @@ mod tests {
                         name: "stakpak__create".to_string(),
                         arguments: "{}".to_string(),
                     },
+                    metadata: None,
                 }),
         );
 

--- a/tui/src/services/handlers/shell.rs
+++ b/tui/src/services/handlers/shell.rs
@@ -1016,6 +1016,7 @@ pub fn shell_command_to_tool_call_result(
             name,
             arguments: args,
         },
+        metadata: None,
     };
     ToolCallResult {
         call,

--- a/tui/src/services/message.rs
+++ b/tui/src/services/message.rs
@@ -2295,6 +2295,7 @@ mod tests {
                     name: "test".to_string(),
                     arguments: input.to_string(),
                 },
+                metadata: None,
             };
 
             let result = extract_full_command_arguments(&tool_call);


### PR DESCRIPTION
## Description

Fixes three interconnected issues with the Gemini API integration:

1. **Usage/token counts showing "N/A"** — streaming used raw JSON array format without `alt=sse`, and `GeminiResponse`/`GeminiCandidate` were missing `#[serde(rename_all = "camelCase")]` so `usageMetadata` and `finishReason` were silently dropped during deserialization.

2. **`thought_signature` not echoed back** — Gemini's thinking mode requires `thoughtSignature` to be preserved from response and sent back on subsequent `functionCall` parts. Added an opaque `metadata` field threaded through the entire pipeline: `StreamEvent → GenerationDelta → ChatMessageDelta → ToolCallAccumulator → ToolCall → ChatMessage → LLMMessage → GeminiPart`.

3. **`function_response.response` must be a JSON object** — Gemini requires `google.protobuf.Struct` for function responses. Non-object values (strings, arrays, etc.) are now wrapped in `{"result": ...}`.

## Changes Made

### SSE Streaming & Usage
- Add `alt=sse` query parameter to streaming endpoint URL
- Replace JSON array parser with line-based SSE parser (`data: {json}` events)
- Add `#[serde(rename_all = "camelCase")]` to `GeminiResponse` and `GeminiCandidate`
- Add `thoughts_token_count` to `GeminiUsageMetadata`
- Use `Usage::with_details()` with full `InputTokenDetails`/`OutputTokenDetails` in both streaming and non-streaming paths

### thought_signature Preservation
- Add `thought_signature: Option<String>` to `GeminiPart`
- Add `metadata: Option<Value>` to `ToolCall`, `ContentPart::ToolCall`, `StreamEvent::ToolCallEnd`, `LLMMessageTypedContent::ToolCall`, `GenerationDeltaToolUse`, and `ToolCallDelta`
- Thread metadata through all conversion and streaming accumulation layers
- Extract `thought_signature` from metadata back onto `GeminiPart` when building requests

### function_response Fix
- Wrap non-object `function_response.response` values in `{"result": value}`

### Other
- Refactor provider listing to use provider registry instead of hardcoded list

## Testing

- [x] All tests pass (`cargo test --workspace` — 730 tests)
- [x] No clippy warnings (`cargo clippy --all-targets`)
- [x] Code formatted (`cargo fmt`)
- [x] Tested on macOS with Gemini API — usage displays correctly, thought_signature echoed back successfully

## Breaking Changes
None — `metadata` fields are `Option` and skipped when `None`.