### PR TITLE
fix: handle HTTP error responses in stakpak streaming provider

### DIFF
--- a/libs/ai/src/providers/stakpak/provider.rs
+++ b/libs/ai/src/providers/stakpak/provider.rs
@@ -235,7 +235,7 @@ fn parse_stakpak_message(msg: &super::types::StakpakMessage) -> Result<Vec<Respo
 }
 
 /// Parse Stakpak API error and return user-friendly message
-fn parse_stakpak_error(error_text: &str, status_code: u16) -> String {
+pub(crate) fn parse_stakpak_error(error_text: &str, status_code: u16) -> String {
     // Try to parse as JSON error
     if let Ok(json) = serde_json::from_str::<serde_json::Value>(error_text)
         && let Some(error) = json.get("error")


### PR DESCRIPTION
## Description
When a user with 0 credits makes a streaming request through the stakpak provider, the server returns HTTP 429 with a JSON body containing billing error details. Previously, the `EventSource` swallowed the response body and surfaced a generic error:

```
[Error] Bad Request: InvalidAgentInput("Streaming error: Stream error: Invalid status code: 429 Too Many Requests")
```

This PR fixes the streaming error handler to read and parse the HTTP error response body, producing the correct user-friendly billing message instead.

## Changes Made
- **`libs/ai/src/providers/stakpak/stream.rs`** — Added specific match arms for `reqwest_eventsource::Error::InvalidStatusCode` (reads response body and parses via `parse_stakpak_error`) and `StreamEnded` (clean break). Follows the same pattern already used by the Anthropic provider.
- **`libs/ai/src/providers/stakpak/provider.rs`** — Changed `parse_stakpak_error` visibility from `fn` to `pub(crate) fn` so it can be reused from `stream.rs`.

## Testing
- [x] All tests pass locally (`cargo test -p stakai`)
- [x] No clippy warnings (`cargo clippy -p stakai --all-targets -- -D warnings`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Tested on macOS

## Breaking Changes
None