### PR TITLE
fix: skip shell script tests on Windows

### DIFF
--- a/cli/src/commands/daemon/executor.rs
+++ b/cli/src/commands/daemon/executor.rs
@@ -184,14 +184,18 @@ pub async fn run_check_script(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
     use std::fs::{self, File};
+    #[cfg(unix)]
     use std::io::Write;
+    #[cfg(unix)]
     use tempfile::tempdir;
 
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
 
     /// Create a test script that exits with the given code.
+    #[cfg(unix)]
     fn create_script(dir: &Path, name: &str, content: &str) -> std::path::PathBuf {
         let script_path = dir.join(name);
         let mut file = File::create(&script_path).expect("Failed to create script");
@@ -210,6 +214,7 @@ mod tests {
         script_path
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_script_exit_0() {
         let dir = tempdir().expect("Failed to create temp dir");
@@ -231,6 +236,7 @@ mod tests {
         assert!(result.stdout.contains("context data"));
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_script_exit_1() {
         let dir = tempdir().expect("Failed to create temp dir");
@@ -251,6 +257,7 @@ mod tests {
         assert!(!result.timed_out);
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_script_exit_2() {
         let dir = tempdir().expect("Failed to create temp dir");
@@ -271,6 +278,7 @@ mod tests {
         assert!(!result.timed_out);
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_script_timeout() {
         let dir = tempdir().expect("Failed to create temp dir");
@@ -285,6 +293,7 @@ mod tests {
         assert!(result.exit_code.is_none());
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_capture_stderr() {
         let dir = tempdir().expect("Failed to create temp dir");
@@ -302,6 +311,7 @@ mod tests {
         assert!(result.stderr.contains("stderr message"));
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_missing_script() {
         let result =
@@ -340,6 +350,7 @@ mod tests {
         ));
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_large_output() {
         let dir = tempdir().expect("Failed to create temp dir");


### PR DESCRIPTION
## Problem

Windows CI build failing with error:
```
%1 is not a valid Win32 application. (os error 193)
```

The daemon executor tests use Unix shell scripts (`.sh` files with `#!/bin/sh` shebang) which cannot execute on Windows.

**Failed job:** https://github.com/stakpak/agent/actions/runs/21791278038/job/62870926643

## Solution

Added `#[cfg(unix)]` attribute to skip shell script tests on Windows:

- `test_script_exit_0`
- `test_script_exit_1`
- `test_script_exit_2`
- `test_script_timeout`
- `test_capture_stderr`
- `test_missing_script`
- `test_large_output`
- `create_script()` helper function and related imports

The `test_check_result_methods` test remains cross-platform as it only tests struct methods without executing scripts.

## Testing

- ✅ All 9 executor tests pass on macOS/Unix
- ✅ No compilation warnings
- On Windows, 8 tests will be skipped (only `test_check_result_methods` runs)