### PR TITLE
perf(ci): optimize CI workflow for speed and reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,35 +8,37 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_BUILD_JOBS: 2
+  CARGO_PROFILE_DEV_DEBUG: 0
+  CARGO_PROFILE_TEST_DEBUG: 0
 
 jobs:
   rust-ci:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache Cargo Dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ./target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+      - name: Configure swap
+        run: |
+          sudo swapoff -a
+          sudo fallocate -l 8G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
 
-      - name: Check
-        run: cargo check --verbose --all-targets
+      - uses: Swatinem/rust-cache@v2
 
       - name: Format Check
         run: cargo fmt -- --check
 
       - name: Lint
-        run: cargo clippy
+        run: cargo clippy --all-targets --workspace
 
-      - name: Build
-        run: cargo build --verbose
+      - name: Compile Tests
+        run: cargo test --workspace --no-run --verbose
 
-      - name: Test
+      - name: Run Tests
+        timeout-minutes: 10
         run: cargo test --workspace --verbose


### PR DESCRIPTION
## Description
Optimizes the GitHub Actions CI workflow to reduce build times, prevent OOM failures, and improve caching.

## Changes Made
- **Swap configuration**: Adds 8GB swap space to prevent out-of-memory kills during Rust compilation on GitHub-hosted runners
- **Better caching**: Replaces manual `actions/cache` with `Swatinem/rust-cache@v2` for smarter, automatic cargo caching
- **Build tuning**: Sets `CARGO_INCREMENTAL=0`, limits build jobs to 2, and disables debug info for dev/test profiles to reduce memory usage
- **Streamlined pipeline**: Removes redundant `cargo check` and `cargo build` steps; uses `cargo test --no-run` for compilation verification followed by `cargo test` for execution
- **Broader linting**: Expands `cargo clippy` to include `--all-targets --workspace` for full coverage
- **Timeouts**: Adds 30-minute job timeout and 10-minute test timeout to prevent hung builds

## Testing
- [x] YAML syntax validated
- [x] `cargo fmt --check` passes locally
- [ ] CI workflow runs successfully on this branch

## Breaking Changes
None