### PR TITLE
fix: close file handle before exec in executor tests to prevent ETXTBSY on musl

### DIFF
--- a/cli/src/commands/daemon/executor.rs
+++ b/cli/src/commands/daemon/executor.rs
@@ -198,9 +198,13 @@ mod tests {
     #[cfg(unix)]
     fn create_script(dir: &Path, name: &str, content: &str) -> std::path::PathBuf {
         let script_path = dir.join(name);
-        let mut file = File::create(&script_path).expect("Failed to create script");
-        file.write_all(content.as_bytes())
-            .expect("Failed to write script");
+        {
+            let mut file = File::create(&script_path).expect("Failed to create script");
+            file.write_all(content.as_bytes())
+                .expect("Failed to write script");
+            file.sync_all().expect("Failed to sync script");
+            // file is dropped (closed) here before we try to execute it
+        }
 
         #[cfg(unix)]
         {


### PR DESCRIPTION
## Description
Fix "Text file busy" (ETXTBSY / os error 26) failure in `test_script_exit_1` on the Linux musl CI target (`ubuntu-22.04, x86_64-unknown-linux-musl`).

## Changes Made
- Wrapped `File::create` + `write_all` in the `create_script` test helper inside an inner block so the file descriptor is explicitly dropped (closed) before `set_permissions` and any subsequent `exec()` calls.
- Added `sync_all()` to ensure all data is flushed to disk before closing.

## Why
On Linux (especially with musl libc), the kernel rejects `exec()` on files that still have an open write file descriptor, producing `ETXTBSY`. The previous code relied on the `File` handle being dropped at function end, but the fd was still logically open when `set_permissions` ran, and the race between close and exec is more pronounced on musl.

## Testing
- [x] All 9 executor tests pass locally (`cargo test --bin stakpak -- commands::daemon::executor::tests`)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] Tested on Linux musl CI (this PR)

## Breaking Changes
None