### PR TITLE
fix(anthropic): harden message sequence sanitization

### DIFF
--- a/libs/ai/src/providers/anthropic/convert.rs
+++ b/libs/ai/src/providers/anthropic/convert.rs
@@ -1,10 +1,10 @@
 //! Conversion between unified types and Anthropic types
 
 use super::types::{
-    infer_max_tokens, AnthropicAuth, AnthropicCacheControl, AnthropicConfig, AnthropicContent,
-    AnthropicMessage, AnthropicMessageContent, AnthropicRequest, AnthropicResponse,
-    AnthropicSource, AnthropicSystemBlock, AnthropicSystemContent,
-    AnthropicThinkingConfig as AnthropicThinking, CLAUDE_CODE_SYSTEM_PREFIX,
+    AnthropicAuth, AnthropicCacheControl, AnthropicConfig, AnthropicContent, AnthropicMessage,
+    AnthropicMessageContent, AnthropicRequest, AnthropicResponse, AnthropicSource,
+    AnthropicSystemBlock, AnthropicSystemContent, AnthropicThinkingConfig as AnthropicThinking,
+    CLAUDE_CODE_SYSTEM_PREFIX, infer_max_tokens,
 };
 use crate::error::{Error, Result};
 use crate::types::{


### PR DESCRIPTION
## Description
Strengthens Anthropic message conversion/sanitization to prevent invalid request payloads and preserve valid context.

## Related Issues
None

## Changes Made
- Reordered message pipeline so tail cache is applied after all sequence-level mutations
- Added sequence-level sanitization pass that:
  - patches missing tool_result coverage
  - removes orphan tool_results
  - deduplicates duplicate tool_results per tool_use_id
  - removes empty-content messages
  - re-merges consecutive same-role messages
  - ensures conversation starts with a user message
- Updated trailing assistant handling:
  - preserves substantive assistant prefill
  - removes only empty/whitespace-only trailing assistant content
  - appends placeholder tool_results when trailing assistant has tool_use
- Prevented reintroducing empty text blocks when injecting placeholder tool_results
- Expanded tests for sequence sanitization, placeholder injection, dedup, orphan cleanup, trailing assistant behavior, and cache ordering expectations

## Testing
- [x] All tests pass locally
- [x] Added tests for new functionality
- [x] Tested on macOS

## Breaking Changes
None