### PR TITLE
Fix CLI SpawnError OS 26 

### DIFF
--- a/cli/src/commands/watch/executor.rs
+++ b/cli/src/commands/watch/executor.rs
@@ -189,6 +189,8 @@ mod tests {
     #[cfg(unix)]
     use std::io::Write;
     #[cfg(unix)]
+    use std::thread;
+    #[cfg(unix)]
     use tempfile::tempdir;
 
     #[cfg(unix)]
@@ -205,6 +207,7 @@ mod tests {
             file.sync_all().expect("Failed to sync script");
             // file is dropped (closed) here before we try to execute it
         }
+        thread::sleep(Duration::from_millis(100)); // allow OS to release file, avoid "Text file busy"
 
         #[cfg(unix)]
         {


### PR DESCRIPTION
# Error
Tests commands::watch::executor::tests::test_large_output and commands::watch::executor::tests::test_script_exit_1 panic with SpawnError("Text file busy (os error 26)") because the script is executed immediately after being created.

# Fix
In create_script (in cli/src/commands/watch/executor.rs), after writing and syncing the script and closing the file handle, add a short delay (thread::sleep(Duration::from_millis(100))) before returning the script path. This gives the OS time to release the file so it can be executed without "Text file busy".
