### PR TITLE
Pre-pull sandbox container images in background at session start

### DIFF
--- a/cli/src/commands/auto_update.rs
+++ b/cli/src/commands/auto_update.rs
@@ -292,6 +292,7 @@ async fn update_binary_atomic(
         base_url: base_url.to_string(),
         targets: vec![target.to_string()],
         version: Some(version.clone()),
+        silent: false,
     };
 
     // 3. Get current executable path

--- a/libs/mcp/server/src/subagent_tools.rs
+++ b/libs/mcp/server/src/subagent_tools.rs
@@ -8,6 +8,7 @@ use rmcp::{
 };
 use serde::Deserialize;
 use serde_json::json;
+use stakpak_shared::container::agent_image;
 use stakpak_shared::local_store::LocalStore;
 use tracing::error;
 use uuid::Uuid;
@@ -482,8 +483,7 @@ NOTES:
 
         // If sandbox mode is enabled, wrap the command in warden
         if enable_sandbox {
-            // Use standard stakpak image (no special warden image needed with wrap)
-            let stakpak_image = format!("ghcr.io/stakpak/agent:v{}", env!("CARGO_PKG_VERSION"));
+            let stakpak_image = agent_image();
 
             let mut warden_command = format!("{} warden wrap {}", current_exe, stakpak_image);
 


### PR DESCRIPTION
## What

When `--enable-subagents` is active, silently pre-pull the agent and warden sidecar Docker images in the background during session initialization. This eliminates the cold-start latency when the first sandboxed subagent is spawned.

## How

The warmup runs as a detached `tokio::spawn` task right after MCP init:

1. **Warden auto-update** — calls `get_warden_plugin_path(silent: true)` which resolves/downloads the latest warden binary without printing to stderr
2. **Version detection** — runs `warden version` on the now-current binary to get the pinned sidecar tag
3. **Parallel pull** — `docker pull --quiet` for both images concurrently, stdout/stderr nulled

All failures are swallowed — Docker not installed, network issues, missing images — nothing disrupts the TUI. The task is fully detached (JoinHandle dropped), so it never blocks session startup.

## Refactors

- **Centralized image references** — `libs/shared/src/container.rs` is now the single source of truth:
  - `agent_image()` → `ghcr.io/stakpak/agent:v{CARGO_PKG_VERSION}`
  - `warden_sidecar_image(v)` → `ghcr.io/stakpak/warden-sidecar:{v}`
  - `detect_warden_version(path)` → parses `warden version` output
- **Silent plugin auto-update** — added `silent: bool` to `PluginConfig`, gates all `eprintln!` calls
- **Versioned sidecar tag** — pins to `v{warden_version}` instead of `:latest`
- Removed all hardcoded `ghcr.io/stakpak/agent` format strings from `cli/` and `libs/mcp/server/`

## Files changed

| File | Change |
|------|--------|
| `libs/shared/src/container.rs` | Image constants + version detection |
| `cli/src/utils/plugins.rs` | `silent` field on `PluginConfig` |
| `cli/src/commands/warden.rs` | `get_warden_plugin_path(silent)`, use `agent_image()` |
| `cli/src/commands/agent/run/mode_interactive.rs` | `spawn_sandbox_image_prepull()` |
| `libs/mcp/server/src/subagent_tools.rs` | Use `agent_image()` |
| `cli/src/commands/auto_update.rs` | Add `silent: false` to existing PluginConfig |

## Testing

```bash
# Watch pulls happen at startup
docker events --filter event=pull &
stakpak --enable-subagents

# Cold start test
docker rmi ghcr.io/stakpak/agent:v0.3.40 ghcr.io/stakpak/warden-sidecar:v0.1.15
stakpak --enable-subagents
# Images reappear within seconds, TUI is clean

# Verify no-op without flag
docker rmi ghcr.io/stakpak/agent:v0.3.40
stakpak  # no --enable-subagents, image stays missing
```