### PR TITLE
ci: add missing crate publish steps for agent-core, gateway, server

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -207,6 +207,9 @@ jobs:
           publish_package stakpak-mcp-client
           publish_package stakpak-mcp-server
           publish_package stakpak-mcp-proxy
+          publish_package stakpak-agent-core
+          publish_package stakpak-gateway
+          publish_package stakpak-server
           publish_package stakpak-tui
           # Finally publish the main CLI crate
           publish_package stakpak


### PR DESCRIPTION
## Problem

The release workflow was missing `publish_package` calls for 3 crates:
- `stakpak-agent-core`
- `stakpak-gateway`
- `stakpak-server`

This would cause dependent crates (e.g., `stakpak-tui`, `stakpak`) to fail publishing when they reference these as dependencies on crates.io.

## Fix

Add the missing publish steps in the correct dependency order (before `stakpak-tui` and the main CLI crate).