### PR TITLE
fix(mcp-server): normalize tool inputs and harden search_docs validation

### DIFF
--- a/libs/mcp/server/src/remote_tools.rs
+++ b/libs/mcp/server/src/remote_tools.rs
@@ -31,27 +31,174 @@ pub struct GenerateCodeRequest {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(untagged)]
+pub enum KeywordInput {
+    String(String),
+    List(Vec<String>),
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct SearchDocsRequest {
     #[schemars(
-        description = "Space-separated keywords (e.g., 'kubernetes ingress nginx ssl'). Use hyphens for compound terms like 'cloud-native'."
+        description = "Search keywords. Preferred format: array of strings (e.g., [\"kubernetes\", \"ingress\", \"nginx\", \"latest\"]). Backward compatible legacy format: a space-separated string (e.g., \"kubernetes ingress nginx latest\")."
     )]
-    pub keywords: String,
+    pub keywords: KeywordInput,
     #[schemars(
-        description = "Space-separated keywords to exclude from the search results (e.g., 'deprecated legacy'). This is useful for filtering out documentation sources that are not relevant to the query."
+        description = "Optional keywords to exclude. Preferred format: array of strings (e.g., [\"deprecated\", \"legacy\"]). Backward compatible legacy format: a space-separated string."
     )]
-    pub exclude_keywords: Option<String>,
+    pub exclude_keywords: Option<KeywordInput>,
     #[schemars(description = "The maximum number of results to return (default: 5, max: 5)")]
     pub limit: Option<u32>,
 }
 
-impl From<SearchDocsRequest> for ApiSearchDocsRequest {
-    fn from(req: SearchDocsRequest) -> Self {
-        Self {
-            keywords: req.keywords,
-            exclude_keywords: req.exclude_keywords,
-            limit: req.limit,
-        }
+fn normalize_keyword_input(input: KeywordInput) -> Vec<String> {
+    match input {
+        KeywordInput::String(value) => value
+            .split_whitespace()
+            .map(std::string::ToString::to_string)
+            .collect(),
+        KeywordInput::List(values) => values,
     }
+    .into_iter()
+    .map(|keyword| keyword.trim().to_string())
+    .filter(|keyword| !keyword.is_empty())
+    .collect()
+}
+
+fn normalize_optional_keyword_input(input: Option<KeywordInput>) -> Option<Vec<String>> {
+    input.and_then(|value| {
+        let normalized = normalize_keyword_input(value);
+        if normalized.is_empty() {
+            None
+        } else {
+            Some(normalized)
+        }
+    })
+}
+
+const MAX_SEARCH_DOCS_KEYWORDS: usize = 32;
+const MAX_SEARCH_DOCS_KEYWORD_LEN: usize = 128;
+const MAX_SEARCH_DOCS_QUERY_LEN: usize = 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SearchDocsValidationError {
+    EmptyKeywords,
+    TooManyKeywords {
+        field: &'static str,
+        actual: usize,
+        max: usize,
+    },
+    KeywordTooLong {
+        field: &'static str,
+        actual: usize,
+        max: usize,
+    },
+    QueryTooLong {
+        field: &'static str,
+        actual: usize,
+        max: usize,
+    },
+}
+
+fn validate_search_docs_keywords(
+    field: &'static str,
+    keywords: &[String],
+) -> Result<(), SearchDocsValidationError> {
+    if keywords.len() > MAX_SEARCH_DOCS_KEYWORDS {
+        return Err(SearchDocsValidationError::TooManyKeywords {
+            field,
+            actual: keywords.len(),
+            max: MAX_SEARCH_DOCS_KEYWORDS,
+        });
+    }
+
+    if let Some(actual) = keywords
+        .iter()
+        .map(|keyword| keyword.chars().count())
+        .max()
+        .filter(|actual| *actual > MAX_SEARCH_DOCS_KEYWORD_LEN)
+    {
+        return Err(SearchDocsValidationError::KeywordTooLong {
+            field,
+            actual,
+            max: MAX_SEARCH_DOCS_KEYWORD_LEN,
+        });
+    }
+
+    let actual = keywords
+        .iter()
+        .map(|keyword| keyword.chars().count())
+        .sum::<usize>()
+        + keywords.len().saturating_sub(1);
+    if actual > MAX_SEARCH_DOCS_QUERY_LEN {
+        return Err(SearchDocsValidationError::QueryTooLong {
+            field,
+            actual,
+            max: MAX_SEARCH_DOCS_QUERY_LEN,
+        });
+    }
+
+    Ok(())
+}
+
+fn build_search_docs_api_request(
+    request: SearchDocsRequest,
+) -> Result<ApiSearchDocsRequest, SearchDocsValidationError> {
+    let keywords = normalize_keyword_input(request.keywords);
+    if keywords.is_empty() {
+        return Err(SearchDocsValidationError::EmptyKeywords);
+    }
+
+    validate_search_docs_keywords("keywords", &keywords)?;
+
+    let exclude_keywords = normalize_optional_keyword_input(request.exclude_keywords);
+    if let Some(exclude_keywords_ref) = exclude_keywords.as_ref() {
+        validate_search_docs_keywords("exclude_keywords", exclude_keywords_ref)?;
+    }
+
+    Ok(ApiSearchDocsRequest {
+        keywords: keywords.join(" "),
+        exclude_keywords: exclude_keywords.map(|items| items.join(" ")),
+        limit: request.limit,
+    })
+}
+
+fn search_docs_validation_error_payload(
+    error: SearchDocsValidationError,
+) -> (&'static str, String) {
+    match error {
+        SearchDocsValidationError::EmptyKeywords => (
+            "INVALID_SEARCH_DOCS_KEYWORDS",
+            "keywords must contain at least one non-empty term (array format preferred)."
+                .to_string(),
+        ),
+        SearchDocsValidationError::TooManyKeywords { field, actual, max } => (
+            "INVALID_SEARCH_DOCS_KEYWORD_COUNT",
+            format!(
+                "{} contains {} keywords, but the maximum is {}.",
+                field, actual, max
+            ),
+        ),
+        SearchDocsValidationError::KeywordTooLong { field, actual, max } => (
+            "INVALID_SEARCH_DOCS_KEYWORD_LENGTH",
+            format!(
+                "{} contains a keyword with length {}, but the maximum is {} characters.",
+                field, actual, max
+            ),
+        ),
+        SearchDocsValidationError::QueryTooLong { field, actual, max } => (
+            "INVALID_SEARCH_DOCS_QUERY_LENGTH",
+            format!(
+                "{} joined query length is {}, but the maximum is {} characters.",
+                field, actual, max
+            ),
+        ),
+    }
+}
+
+fn search_docs_validation_error_result(error: SearchDocsValidationError) -> CallToolResult {
+    let (code, message) = search_docs_validation_error_payload(error);
+    CallToolResult::error(vec![Content::text(code), Content::text(message)])
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -107,286 +254,23 @@ pub struct LocalCodeSearchRequest {
 
 #[tool_router(router = tool_router_remote, vis = "pub")]
 impl ToolContainer {
-    //     #[tool(
-    //         description = "Advanced Generate/Edit devops configurations and infrastructure as code with suggested file names using a given prompt. If save_files is true, the generated files will be saved to the filesystem. The printed shell output will redact any secrets, will be replaced with a placeholder [REDACTED_SECRET:rule-id:short-hash]
-    // IMPORTANT: When breaking down large projects into multiple generation steps, always include previously generated files in the 'context' parameter to maintain coherent references and consistent structure across all generated files."
-    //     )]
-    //     pub async fn generate_code(
-    //         &self,
-    //         Parameters(GenerateCodeRequest {
-    //             prompt,
-    //             save_files,
-    //             context,
-    //         }): Parameters<GenerateCodeRequest>,
-    //     ) -> Result<CallToolResult, McpError> {
-    //         let output_format = if save_files.unwrap_or(false) {
-    //             "json"
-    //         } else {
-    //             "markdown"
-    //         };
-
-    //         // Convert context paths to Vec<Document>
-    //         let context_documents = if let Some(context_paths) = context {
-    //             context_paths
-    //                 .into_iter()
-    //                 .map(|path| {
-    //                     let uri = format!("file://{}", path);
-    //                     match std::fs::read_to_string(&path) {
-    //                         Ok(content) => {
-    //                             // Redact secrets in the file content
-    //                             let redacted_content = self
-    //                                 .get_secret_manager()
-    //                                 .redact_and_store_secrets(&content, Some(&path));
-    //                             SimpleDocument {
-    //                                 uri,
-    //                                 content: redacted_content,
-    //                             }
-    //                         }
-    //                         Err(e) => {
-    //                             warn!("Failed to read context file {}: {}", path, e);
-    //                             // Add empty document with error message
-    //                             SimpleDocument {
-    //                                 uri,
-    //                                 content: format!("Error reading file: {}", e),
-    //                             }
-    //                         }
-    //                     }
-    //                 })
-    //                 .collect::<Vec<_>>()
-    //         } else {
-    //             Vec::new()
-    //         };
-
-    //         let client = match self.get_client() {
-    //             Some(client) => client,
-    //             None => {
-    //                 return Ok(CallToolResult::error(vec![
-    //                     Content::text("CLIENT_NOT_FOUND"),
-    //                     Content::text("Client not found"),
-    //                 ]));
-    //             }
-    //         };
-
-    //         let response = match client
-    //             .call_mcp_tool(&ToolsCallParams {
-    //                 name: "generate_code".to_string(),
-    //                 arguments: json!({
-    //                     "prompt": prompt,
-    //                     "context": context_documents,
-    //                     "output_format": output_format,
-    //                 }),
-    //             })
-    //             .await
-    //         {
-    //             Ok(response) => response,
-    //             Err(e) => {
-    //                 return Ok(CallToolResult::error(vec![
-    //                     Content::text("GENERATE_CODE_ERROR"),
-    //                     Content::text(format!("Failed to generate code: {}", e)),
-    //                 ]));
-    //             }
-    //         };
-
-    //         if save_files.unwrap_or(false) {
-    //             let mut result_report = String::new();
-
-    //             let response_text = response
-    //                 .iter()
-    //                 .map(|r| {
-    //                     if let Some(RawTextContent { text }) = r.as_text() {
-    //                         text.clone()
-    //                     } else {
-    //                         "".to_string()
-    //                     }
-    //                 })
-    //                 .collect::<Vec<_>>()
-    //                 .join("");
-
-    //             let generation_result: GenerationResult = match serde_json::from_str(&response_text) {
-    //                 Ok(result) => result,
-    //                 Err(e) => {
-    //                     error!("Failed to parse generation result: {}", e);
-    //                     return Ok(CallToolResult::error(vec![
-    //                         Content::text("GENERATION_PARSE_ERROR"),
-    //                         Content::text(format!("Failed to parse generation result: {}", e)),
-    //                     ]));
-    //                 }
-    //             };
-
-    //             let mut new_files: Vec<String> = Vec::new();
-    //             let mut failed_edits = Vec::new();
-
-    //             for edit in generation_result.edits.unwrap_or_default() {
-    //                 let file_path = Path::new(
-    //                     edit.document_uri
-    //                         .strip_prefix("file:///")
-    //                         .or_else(|| edit.document_uri.strip_prefix("file://"))
-    //                         .unwrap_or(&edit.document_uri),
-    //                 );
-
-    //                 // Create parent directories if they don't exist
-    //                 if let Some(parent) = file_path.parent() {
-    //                     if !parent.exists() {
-    //                         if let Err(e) = fs::create_dir_all(parent) {
-    //                             error!("Failed to create directory {}: {}", parent.display(), e);
-    //                             failed_edits.push(format!(
-    //                                 "Failed to create directory {} for file {}: {}\nEdit content:\n{}",
-    //                                 parent.display(),
-    //                                 file_path.display(),
-    //                                 e,
-    //                                 edit
-    //                             ));
-    //                             continue;
-    //                         }
-    //                     }
-    //                 }
-
-    //                 // Check if file exists, if not create it
-    //                 if !file_path.exists() {
-    //                     match fs::File::create(file_path) {
-    //                         Ok(_) => {
-    //                             new_files.push(file_path.to_str().unwrap_or_default().to_string());
-    //                         }
-    //                         Err(e) => {
-    //                             error!("Failed to create file {}: {}", file_path.display(), e);
-    //                             failed_edits.push(format!(
-    //                                 "Failed to create file {}: {}\nEdit content:\n{}",
-    //                                 file_path.display(),
-    //                                 e,
-    //                                 edit
-    //                             ));
-    //                             continue;
-    //                         }
-    //                     }
-    //                 }
-
-    //                 let redacted_edit = self
-    //                     .get_secret_manager()
-    //                     .redact_and_store_secrets(&edit.to_string(), file_path.to_str());
-
-    //                 if edit.old_str.is_empty() {
-    //                     // This is an addition to a file (appending content)
-    //                     match fs::OpenOptions::new().append(true).open(file_path) {
-    //                         Ok(mut file) => {
-    //                             if let Err(e) = file.write_all(edit.new_str.as_bytes()) {
-    //                                 error!("Failed to append to file {}: {}", file_path.display(), e);
-    //                                 failed_edits.push(format!(
-    //                                     "Failed to append content to file {}: {}\nEdit content:\n{}",
-    //                                     file_path.display(),
-    //                                     e,
-    //                                     redacted_edit
-    //                                 ));
-    //                                 continue;
-    //                             }
-    //                             result_report.push_str(&format!("{}\n\n", redacted_edit));
-    //                         }
-    //                         Err(e) => {
-    //                             error!(
-    //                                 "Failed to open file for appending {}: {}",
-    //                                 file_path.display(),
-    //                                 e
-    //                             );
-    //                             failed_edits.push(format!(
-    //                                 "Failed to open file {} for appending: {}\nEdit content:\n{}",
-    //                                 file_path.display(),
-    //                                 e,
-    //                                 redacted_edit
-    //                             ));
-    //                             continue;
-    //                         }
-    //                     }
-    //                 } else {
-    //                     // This is a modification to a file (replacing content)
-    //                     // Read the current file content
-    //                     let current_content = match fs::read_to_string(file_path) {
-    //                         Ok(content) => content,
-    //                         Err(e) => {
-    //                             error!("Failed to read file {}: {}", file_path.display(), e);
-    //                             failed_edits.push(format!(
-    //                                 "Failed to read file {} for content replacement: {}\nEdit content:\n{}",
-    //                                 file_path.display(),
-    //                                 e,
-    //                                 edit
-    //                             ));
-    //                             continue;
-    //                         }
-    //                     };
-
-    //                     // Verify that the file contains the old string
-    //                     if !current_content.contains(&edit.old_str) {
-    //                         error!(
-    //                             "Search string not found in file {}, skipping edit: \n{}",
-    //                             file_path.display(),
-    //                             edit
-    //                         );
-    //                         failed_edits.push(format!(
-    //                             "Search string not found in file {} - the file content may have changed or the search string is incorrect.\nEdit content:\n{}",
-    //                             file_path.display(),
-    //                             edit
-    //                         ));
-    //                         continue;
-    //                     }
-
-    //                     // Replace old content with new content
-    //                     let updated_content = current_content.replace(&edit.old_str, &edit.new_str);
-    //                     match fs::write(file_path, updated_content) {
-    //                         Ok(_) => {
-    //                             result_report.push_str(&format!("{}\n\n", redacted_edit));
-    //                         }
-    //                         Err(e) => {
-    //                             error!("Failed to write to file {}: {}", file_path.display(), e);
-    //                             failed_edits.push(format!(
-    //                                 "Failed to write updated content to file {}: {}\nEdit content:\n{}",
-    //                                 file_path.display(),
-    //                                 e,
-    //                                 redacted_edit
-    //                             ));
-    //                             continue;
-    //                         }
-    //                     }
-    //                 }
-    //             }
-
-    //             // Build the final result report
-    //             let mut final_report = String::new();
-
-    //             if !new_files.is_empty() {
-    //                 final_report.push_str(&format!("Created files: {}\n\n", new_files.join(", ")));
-    //             }
-
-    //             if !result_report.is_empty() {
-    //                 final_report.push_str("Successfully applied edits:\n");
-    //                 final_report.push_str(&result_report);
-    //             }
-
-    //             if !failed_edits.is_empty() {
-    //                 final_report.push_str("\n❌ Failed Edits:\n");
-    //                 for (i, failed_edit) in failed_edits.iter().enumerate() {
-    //                     final_report.push_str(&format!("{}. {}\n", i + 1, failed_edit));
-    //                 }
-    //                 final_report.push_str("\nPlease review the failed edits above and take appropriate action to resolve the issues.\n");
-    //             }
-
-    //             Ok(CallToolResult::success(vec![Content::text(final_report)]))
-    //         } else {
-    //             Ok(CallToolResult::success(response))
-    //         }
-    //     }
-
     #[tool(
         description = "Web search for technical documentation. This includes documentation for tools, cloud providers, development frameworks, release notes, and other technical resources. searches against the url, title, description, and content of documentation chunks.
 KEYWORD FORMAT REQUIREMENTS:
-- Keywords should be provided as space-separated strings
+- Preferred format: JSON array of strings
+- Backward compatibility: legacy space-separated keyword strings are still accepted
 - Use hyphens for compound terms (e.g., 'cloud-native', 'service-mesh')
-- keywords must include version numbers if specified by the user , if not specified, use the  keyword *latest*
+- Include explicit version terms when the user specifies one; otherwise add 'latest'
 
 CORRECT EXAMPLES:
-✅ keywords: 'kubernetes ingress nginx ssl'
-✅ keywords: 'docker multi-stage build'
+✅ keywords: [\"stakpak\", \"cli\", \"latest\"]
+✅ keywords: [\"kubernetes\", \"ingress\", \"nginx\", \"ssl\"]
+✅ keywords: [\"docker\", \"multi-stage\", \"build\"]
+✅ legacy keywords: \"kubernetes ingress nginx ssl\"
 
 QUERY STRATEGY GUIDANCE:
-- For more fine-grained queries: Use many keywords in a single call to get highly targeted results (e.g., 'kubernetes ingress nginx ssl tls' for a specific SSL setup question)
-- For broader knowledge gathering: Break down your query into multiple parallel calls with fewer keywords each to cover more ground (e.g., separate calls for 'kubernetes networking', 'kubernetes storage', 'kubernetes security' instead of cramming all topics into one call)
+- For more fine-grained queries: Use many keywords in a single call to get highly targeted results (e.g., [\"kubernetes\", \"ingress\", \"nginx\", \"ssl\", \"tls\"] for a specific SSL setup question)
+- For broader knowledge gathering: Break down your query into multiple parallel calls with fewer keywords each to cover more ground (e.g., separate calls for [\"kubernetes\", \"networking\"], [\"kubernetes\", \"storage\"], [\"kubernetes\", \"security\"] instead of cramming all topics into one call)
 
 If your goal requires understanding multiple distinct topics or technologies, make separate search calls rather than combining all keywords into one overly-specific search that may miss relevant documentation."
     )]
@@ -395,6 +279,11 @@ If your goal requires understanding multiple distinct topics or technologies, ma
         Parameters(mut request): Parameters<SearchDocsRequest>,
     ) -> Result<CallToolResult, McpError> {
         request.limit = request.limit.map(|l| l.min(5)).or(Some(5));
+
+        let api_request = match build_search_docs_api_request(request) {
+            Ok(req) => req,
+            Err(error) => return Ok(search_docs_validation_error_result(error)),
+        };
 
         let client = match self.get_client() {
             Some(client) => client,
@@ -406,7 +295,7 @@ If your goal requires understanding multiple distinct topics or technologies, ma
             }
         };
 
-        let response = match client.search_docs(&request.into()).await {
+        let response = match client.search_docs(&api_request).await {
             Ok(response) => response,
             Err(e) => {
                 return Ok(CallToolResult::error(vec![
@@ -512,230 +401,203 @@ If your goal requires understanding multiple distinct topics or technologies, ma
 
         Ok(CallToolResult::success(response))
     }
+}
 
-    //     #[tool(description = "Search for local code blocks using multiple keywords.
-    // IMPORTANT: this tool ONLY search through local Terraform, Kubernetes, Dockerfile, and Github Actions code.
-    // This tool searches through the locally indexed code blocks using text matching against names, types, content, and file paths. Blocks matching multiple keywords are ranked higher in the results. It can also show dependencies and dependents of matching blocks. If no index is found, it will build one first.")]
-    //     pub async fn local_code_search(
-    //         &self,
-    //         Parameters(LocalCodeSearchRequest {
-    //             keywords,
-    //             limit,
-    //             show_dependencies,
-    //         }): Parameters<LocalCodeSearchRequest>,
-    //     ) -> Result<CallToolResult, McpError> {
-    //         // First check indexing status
-    //         if let Ok(status_str) = LocalStore::read_session_data("indexing_status.json")
-    //             && !status_str.is_empty()
-    //             && let Ok(status) = serde_json::from_str::<IndexingStatus>(&status_str)
-    //             && !status.indexed
-    //         {
-    //             return Ok(CallToolResult::success(vec![Content::text(format!(
-    //                 "❌ Local code search is not available: {}\n\nTo enable local code search for large projects, restart the CLI with the --index-big-project flag:\n\nstakpak --index-big-project",
-    //                 status.reason
-    //             ))]));
-    //         }
+#[cfg(test)]
+mod tests {
+    use super::{
+        MAX_SEARCH_DOCS_KEYWORD_LEN, MAX_SEARCH_DOCS_KEYWORDS, SearchDocsRequest,
+        SearchDocsValidationError, build_search_docs_api_request, normalize_keyword_input,
+        normalize_optional_keyword_input, search_docs_validation_error_payload,
+    };
 
-    //         let index_str = match LocalStore::read_session_data("code_index.json") {
-    //             Ok(data) => data,
-    //             Err(e) => {
-    //                 error!("Failed to read code index: {}", e);
-    //                 return Ok(CallToolResult::error(vec![
-    //                     Content::text("CODE_INDEX_READ_ERROR"),
-    //                     Content::text(format!(
-    //                         "Failed to read code index - the project may not be indexed yet or indexing may have been skipped: {}",
-    //                         e
-    //                     )),
-    //                 ]));
-    //             }
-    //         };
+    #[test]
+    fn search_docs_accepts_legacy_string_keywords() {
+        let request: SearchDocsRequest = serde_json::from_value(serde_json::json!({
+            "keywords": "stakpak cli latest",
+            "exclude_keywords": "deprecated legacy"
+        }))
+        .expect("legacy string keyword format should deserialize");
 
-    //         if index_str.is_empty() {
-    //             return Ok(CallToolResult::success(vec![Content::text(
-    //                 "❌ Local code search is not available: No code index found.\n\nThis usually means:\n1. The project is too large and indexing was skipped (use --index-big-project flag)\n2. No supported files were found in this directory\n3. The project hasn't been indexed yet\n\nRestart the CLI with --index-big-project if you want to index a large project.",
-    //             )]));
-    //         }
+        assert_eq!(
+            normalize_keyword_input(request.keywords),
+            vec!["stakpak", "cli", "latest"]
+        );
+        assert_eq!(
+            normalize_optional_keyword_input(request.exclude_keywords),
+            Some(vec!["deprecated".to_string(), "legacy".to_string()])
+        );
+    }
 
-    //         let index_store: CodeIndex = match serde_json::from_str(&index_str) {
-    //             Ok(index) => index,
-    //             Err(e) => {
-    //                 return Ok(CallToolResult::error(vec![
-    //                     Content::text("CODE_INDEX_PARSE_ERROR"),
-    //                     Content::text(format!("Failed to parse code index: {}", e)),
-    //                 ]));
-    //             }
-    //         };
+    #[test]
+    fn search_docs_accepts_array_keywords_and_normalizes_blanks() {
+        let request: SearchDocsRequest = serde_json::from_value(serde_json::json!({
+            "keywords": ["  stakpak  ", "", "cli", "   ", "latest"],
+            "exclude_keywords": ["", " legacy "]
+        }))
+        .expect("array keyword format should deserialize");
 
-    //         let search_limit = limit.unwrap_or(10) as usize;
-    //         let show_deps = show_dependencies.unwrap_or(false);
-    //         let keywords_lower: Vec<String> = keywords
-    //             .split_whitespace()
-    //             .map(|s| s.to_lowercase())
-    //             .collect();
+        assert_eq!(
+            normalize_keyword_input(request.keywords),
+            vec!["stakpak", "cli", "latest"]
+        );
+        assert_eq!(
+            normalize_optional_keyword_input(request.exclude_keywords),
+            Some(vec!["legacy".to_string()])
+        );
+    }
 
-    //         // Search through blocks
-    //         let mut matching_blocks = Vec::new();
+    #[test]
+    fn search_docs_preserves_empty_keywords_for_runtime_validation() {
+        let request: SearchDocsRequest =
+            serde_json::from_value(serde_json::json!({ "keywords": ["", "   "] }))
+                .expect("empty keyword arrays should deserialize for explicit validation");
 
-    //         for block in &index_store.index.blocks {
-    //             let mut score = 0u32;
-    //             let mut matched_keywords = std::collections::HashSet::new();
+        assert!(normalize_keyword_input(request.keywords).is_empty());
+    }
 
-    //             // For each keyword, check matches and accumulate scores
-    //             for keyword in &keywords_lower {
-    //                 let mut keyword_matched = false;
+    #[test]
+    fn search_docs_runtime_validation_rejects_empty_keywords() {
+        let request: SearchDocsRequest =
+            serde_json::from_value(serde_json::json!({ "keywords": ["", "   "] }))
+                .expect("request should deserialize");
 
-    //                 // Check name match
-    //                 if let Some(name) = &block.name
-    //                     && name.to_lowercase().contains(keyword)
-    //                 {
-    //                     score += 10;
-    //                     keyword_matched = true;
-    //                 }
+        let result = build_search_docs_api_request(request);
+        assert!(matches!(
+            result,
+            Err(SearchDocsValidationError::EmptyKeywords)
+        ));
+    }
 
-    //                 // Check type match
-    //                 if let Some(type_name) = &block.r#type
-    //                     && type_name.to_lowercase().contains(keyword)
-    //                 {
-    //                     score += 8;
-    //                     keyword_matched = true;
-    //                 }
+    #[test]
+    fn search_docs_runtime_builds_normalized_api_payload() {
+        let request: SearchDocsRequest = serde_json::from_value(serde_json::json!({
+            "keywords": ["  stakpak  ", "cli", "", "latest"],
+            "exclude_keywords": ["", " deprecated ", "  "]
+        }))
+        .expect("request should deserialize");
 
-    //                 // Check kind match
-    //                 if block.kind.to_lowercase().contains(keyword) {
-    //                     score += 6;
-    //                     keyword_matched = true;
-    //                 }
+        let payload = build_search_docs_api_request(request).expect("payload should build");
+        assert_eq!(payload.keywords, "stakpak cli latest");
+        assert_eq!(payload.exclude_keywords, Some("deprecated".to_string()));
+    }
 
-    //                 // Check file path match
-    //                 if block.document_uri.to_lowercase().contains(keyword) {
-    //                     score += 4;
-    //                     keyword_matched = true;
-    //                 }
+    #[test]
+    fn search_docs_runtime_drops_empty_exclude_keywords() {
+        let request: SearchDocsRequest = serde_json::from_value(serde_json::json!({
+            "keywords": "stakpak cli latest",
+            "exclude_keywords": ["", "   "]
+        }))
+        .expect("request should deserialize");
 
-    //                 // Check code content match
-    //                 if block.code.to_lowercase().contains(keyword) {
-    //                     score += 2;
-    //                     keyword_matched = true;
-    //                 }
+        let payload = build_search_docs_api_request(request).expect("payload should build");
+        assert_eq!(payload.keywords, "stakpak cli latest");
+        assert_eq!(payload.exclude_keywords, None);
+    }
 
-    //                 if keyword_matched {
-    //                     matched_keywords.insert(keyword.clone());
-    //                 }
-    //             }
+    #[test]
+    fn search_docs_runtime_rejects_too_many_keywords() {
+        let keywords: Vec<String> = (0..=MAX_SEARCH_DOCS_KEYWORDS)
+            .map(|idx| format!("k{}", idx))
+            .collect();
 
-    //             // Bonus points for matching multiple keywords
-    //             if matched_keywords.len() > 1 {
-    //                 let multi_keyword_bonus = (matched_keywords.len() - 1) as u32 * 5;
-    //                 score += multi_keyword_bonus;
-    //             }
+        let request: SearchDocsRequest = serde_json::from_value(serde_json::json!({
+            "keywords": keywords,
+        }))
+        .expect("request should deserialize");
 
-    //             if score > 0 {
-    //                 matching_blocks.push((block, score));
-    //             }
-    //         }
+        let result = build_search_docs_api_request(request);
+        assert!(matches!(
+            result,
+            Err(SearchDocsValidationError::TooManyKeywords {
+                field: "keywords",
+                ..
+            })
+        ));
+    }
 
-    //         // Sort by score descending
-    //         matching_blocks.sort_by(|a, b| b.1.cmp(&a.1));
+    #[test]
+    fn search_docs_runtime_rejects_overlong_keyword() {
+        let overlong_keyword = "x".repeat(MAX_SEARCH_DOCS_KEYWORD_LEN + 1);
+        let request: SearchDocsRequest = serde_json::from_value(serde_json::json!({
+            "keywords": [overlong_keyword],
+        }))
+        .expect("request should deserialize");
 
-    //         // Limit results
-    //         matching_blocks.truncate(search_limit);
+        let result = build_search_docs_api_request(request);
+        assert!(matches!(
+            result,
+            Err(SearchDocsValidationError::KeywordTooLong {
+                field: "keywords",
+                ..
+            })
+        ));
+    }
 
-    //         if matching_blocks.is_empty() {
-    //             return Ok(CallToolResult::success(vec![Content::text(format!(
-    //                 "No code blocks found matching keywords: {:?}",
-    //                 keywords
-    //             ))]));
-    //         }
+    #[test]
+    fn search_docs_runtime_rejects_overlong_joined_query() {
+        let token = "x".repeat(MAX_SEARCH_DOCS_KEYWORD_LEN.saturating_sub(8));
+        let keywords: Vec<String> = (0..10).map(|_| token.clone()).collect();
 
-    //         let mut result = String::new();
-    //         result.push_str(&format!(
-    //             "Found {} matching code blocks for keywords: {:?}\n\n",
-    //             matching_blocks.len(),
-    //             keywords
-    //         ));
+        let request: SearchDocsRequest = serde_json::from_value(serde_json::json!({
+            "keywords": keywords,
+        }))
+        .expect("request should deserialize");
 
-    //         for (i, (block, score)) in matching_blocks.iter().enumerate() {
-    //             let file_path = block
-    //                 .document_uri
-    //                 .strip_prefix("file://")
-    //                 .unwrap_or(&block.document_uri);
+        let result = build_search_docs_api_request(request);
+        assert!(matches!(
+            result,
+            Err(SearchDocsValidationError::QueryTooLong {
+                field: "keywords",
+                ..
+            })
+        ));
+    }
 
-    //             // result.push_str(&format!(
-    //             //     "{}. {}#L{}-L{} (Score: {})\n",
-    //             //     i + 1,
-    //             //     block
-    //             //         .document_uri
-    //             //         .strip_prefix("file:///")
-    //             //         .unwrap_or(&block.document_uri),
-    //             //     block.start_point.row + 1,
-    //             //     block.end_point.row + 1,
-    //             //     score
-    //             // ));
-    //             result.push_str(&format!("{}. {} (Score: {})\n", i + 1, file_path, score));
+    #[test]
+    fn search_docs_validation_payload_empty_keywords_mapping() {
+        let (code, message) =
+            search_docs_validation_error_payload(SearchDocsValidationError::EmptyKeywords);
+        assert_eq!(code, "INVALID_SEARCH_DOCS_KEYWORDS");
+        assert!(message.contains("at least one non-empty term"));
+    }
 
-    //             // Redact secrets in the code before displaying
-    //             let redacted_code = self
-    //                 .get_secret_manager()
-    //                 .redact_and_store_secrets(&block.code, Some(file_path));
+    #[test]
+    fn search_docs_validation_payload_count_mapping() {
+        let (code, message) =
+            search_docs_validation_error_payload(SearchDocsValidationError::TooManyKeywords {
+                field: "keywords",
+                actual: 99,
+                max: 16,
+            });
+        assert_eq!(code, "INVALID_SEARCH_DOCS_KEYWORD_COUNT");
+        assert!(message.contains("keywords contains 99 keywords"));
+        assert!(message.contains("maximum is 16"));
+    }
 
-    //             // Show code with line numbers
-    //             let code_lines: Vec<&str> = redacted_code.lines().collect();
-    //             // let start_line_num = block.start_point.row + 1;
+    #[test]
+    fn search_docs_validation_payload_keyword_len_mapping() {
+        let (code, message) =
+            search_docs_validation_error_payload(SearchDocsValidationError::KeywordTooLong {
+                field: "exclude_keywords",
+                actual: 140,
+                max: 128,
+            });
+        assert_eq!(code, "INVALID_SEARCH_DOCS_KEYWORD_LENGTH");
+        assert!(message.contains("exclude_keywords"));
+        assert!(message.contains("length 140"));
+    }
 
-    //             result.push_str("   Code:\n");
-    //             result.push_str("   ```\n");
-    //             for line in code_lines.iter() {
-    //                 // let line_num = start_line_num + i;
-    //                 // result.push_str(&format!("   {:4}: {}\n", line_num, line));
-    //                 result.push_str(&format!("   {}\n", line));
-    //             }
-    //             result.push_str("   ```\n");
-
-    //             if show_deps {
-    //                 if !block.dependencies.is_empty() {
-    //                     result.push_str(&format!(
-    //                         "   Dependencies ({}):\n",
-    //                         block.dependencies.len()
-    //                     ));
-    //                     for dep in &block.dependencies {
-    //                         // skip unsatisfied dependencies because there are still bugs with
-    //                         if !dep.satisfied {
-    //                             continue;
-    //                         }
-
-    //                         let mut min_length = usize::MAX;
-    //                         let mut shortest_reference = Vec::new();
-    //                         for selector in dep.selectors.iter() {
-    //                             for reference in selector.references.iter() {
-    //                                 if reference.len() < min_length {
-    //                                     min_length = reference.len();
-    //                                     shortest_reference = reference.clone();
-    //                                 }
-    //                             }
-    //                         }
-
-    //                         result.push_str(&format!(
-    //                             "     - {}\n",
-    //                             shortest_reference
-    //                                 .iter()
-    //                                 .map(|s| s.to_string())
-    //                                 .collect::<Vec<String>>()
-    //                                 .join("/")
-    //                         ));
-    //                     }
-    //                 }
-
-    //                 if !block.dependents.is_empty() {
-    //                     result.push_str(&format!("   Dependents ({}):\n", block.dependents.len()));
-    //                     for dep in &block.dependents {
-    //                         result.push_str(&format!("     - {}\n", dep.key));
-    //                     }
-    //                 }
-    //             }
-
-    //             result.push('\n');
-    //         }
-
-    //         Ok(CallToolResult::success(vec![Content::text(result)]))
-    //     }
+    #[test]
+    fn search_docs_validation_payload_query_len_mapping() {
+        let (code, message) =
+            search_docs_validation_error_payload(SearchDocsValidationError::QueryTooLong {
+                field: "keywords",
+                actual: 2048,
+                max: 1024,
+            });
+        assert_eq!(code, "INVALID_SEARCH_DOCS_QUERY_LENGTH");
+        assert!(message.contains("joined query length is 2048"));
+        assert!(message.contains("maximum is 1024"));
+    }
 }


### PR DESCRIPTION
## Description
Improve MCP tool input handling to avoid false remote execution attempts and make `search_docs` validation/schema behavior robust and backward compatible.

## Changes Made
- `run_command`: treat empty/whitespace `remote` and `private_key_path` as `None` via custom deserializers, while preserving non-empty password whitespace.
- `search_docs`: accept both legacy string and preferred array keyword formats via `KeywordInput`.
- Added normalization/validation pipeline for `search_docs` with explicit limits and structured error payloads.
- Updated tool descriptions and added focused unit tests for deserialization, normalization, validation, and error mapping.

## Testing
- `cargo fmt --check -- libs/mcp/server/src/local_tools.rs libs/mcp/server/src/remote_tools.rs`
- `cargo clippy -p stakpak-mcp-server --all-targets -- -D warnings`
- `cargo test -p stakpak-mcp-server remote_tools::tests -- --nocapture`
- `cargo test -p stakpak-mcp-server local_tools::tests -- --nocapture`

## Breaking Changes
None (legacy `search_docs` string input remains supported).
