### PR TITLE
Add ask_user tool for structured user prompts

### DIFF
--- a/cli/src/commands/agent/run/mode_interactive.rs
+++ b/cli/src/commands/agent/run/mode_interactive.rs
@@ -522,6 +522,71 @@ pub async fn run_interactive(
                         }
                     }
                     OutputEvent::AcceptTool(tool_call) => {
+                        // Check if this is the ask_user tool - handle it specially
+                        let tool_name = tool_call
+                            .function
+                            .name
+                            .strip_prefix("stakpak__")
+                            .unwrap_or(&tool_call.function.name);
+                        if tool_name == "ask_user" {
+                            // Parse the questions from the tool call arguments
+                            match serde_json::from_str::<serde_json::Value>(
+                                &tool_call.function.arguments,
+                            ) {
+                                Ok(args) => {
+                                    if let Some(questions_value) = args.get("questions") {
+                                        match serde_json::from_value::<
+                                            Vec<
+                                                stakpak_shared::models::integrations::openai::AskUserQuestion,
+                                            >,
+                                        >(
+                                            questions_value.clone()
+                                        ) {
+                                            Ok(questions) => {
+                                                // Send the popup event to TUI
+                                                send_input_event(
+                                                    &input_tx,
+                                                    InputEvent::ShowAskUserPopup(
+                                                        tool_call.clone(),
+                                                        questions,
+                                                    ),
+                                                )
+                                                .await?;
+                                                // Don't continue - wait for AskUserResponse
+                                                continue;
+                                            }
+                                            Err(e) => {
+                                                // Failed to parse questions - return error result
+                                                messages.push(tool_result(
+                                                    tool_call.id.clone(),
+                                                    format!(
+                                                        "Failed to parse questions: {}",
+                                                        e
+                                                    ),
+                                                ));
+                                            }
+                                        }
+                                    } else {
+                                        // No questions field - return error result
+                                        messages.push(tool_result(
+                                            tool_call.id.clone(),
+                                            "Missing 'questions' field in ask_user arguments"
+                                                .to_string(),
+                                        ));
+                                    }
+                                }
+                                Err(e) => {
+                                    // Failed to parse arguments - return error result
+                                    messages.push(tool_result(
+                                        tool_call.id.clone(),
+                                        format!("Failed to parse ask_user arguments: {}", e),
+                                    ));
+                                }
+                            }
+                            // If we get here, there was an error - continue to next iteration
+                            continue;
+                        }
+
                         send_input_event(
                             &input_tx,
                             InputEvent::StartLoadingOperation(LoadingOperation::ToolExecution),
@@ -1005,6 +1070,19 @@ pub async fn run_interactive(
                         .await?;
                         continue;
                     }
+                    OutputEvent::AskUserResponse(tool_call_result) => {
+                        // User responded to ask_user popup - add the result to messages
+                        messages.push(tool_result(
+                            tool_call_result.call.id.clone(),
+                            tool_call_result.result.clone(),
+                        ));
+
+                        // Display the result in the TUI
+                        send_input_event(&input_tx, InputEvent::ToolResult(tool_call_result))
+                            .await?;
+
+                        // Continue to send to API
+                    }
                 }
 
                 // Skip sending to API if there are pending tool calls without tool_results
@@ -1231,8 +1309,37 @@ pub async fn run_interactive(
                             tools_queue.extend(tool_calls.clone());
 
                             // Send the first tool call to show in UI
+                            // But auto-approve ask_user tool
                             if !tools_queue.is_empty() {
                                 let tool_call = tools_queue.remove(0);
+                                let tool_name = tool_call
+                                    .function
+                                    .name
+                                    .strip_prefix("stakpak__")
+                                    .unwrap_or(&tool_call.function.name);
+
+                                if tool_name == "ask_user" {
+                                    // Auto-approve ask_user - parse and show popup directly
+                                    if let Ok(args) = serde_json::from_str::<serde_json::Value>(
+                                        &tool_call.function.arguments,
+                                    )
+                                        && let Some(questions_value) = args.get("questions")
+                                        && let Ok(questions) = serde_json::from_value::<
+                                            Vec<stakpak_shared::models::integrations::openai::AskUserQuestion>,
+                                        >(questions_value.clone())
+                                    {
+                                        send_input_event(
+                                            &input_tx,
+                                            InputEvent::ShowAskUserPopup(
+                                                tool_call.clone(),
+                                                questions,
+                                            ),
+                                        )
+                                        .await?;
+                                        continue;
+                                    }
+                                    // If parsing failed, fall through to normal flow
+                                }
                                 send_tool_call(&input_tx, &tool_call).await?;
                                 continue;
                             }

--- a/libs/shared/src/models/integrations/openai.rs
+++ b/libs/shared/src/models/integrations/openai.rs
@@ -616,6 +616,68 @@ pub struct TaskPauseInfo {
 }
 
 // =============================================================================
+// Ask User Types (for interactive user prompts)
+// =============================================================================
+
+/// A question for the ask_user tool
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AskUserQuestion {
+    /// Unique identifier for this question
+    pub id: String,
+    /// Short label for tab display (max ~15 chars recommended)
+    pub label: String,
+    /// Full question text to display
+    pub question: String,
+    /// Predefined answer options
+    pub options: Vec<AskUserOption>,
+    /// Whether to allow custom text input (default: true)
+    #[serde(default = "default_true")]
+    pub allow_custom: bool,
+    /// Whether this question must be answered (default: true)
+    #[serde(default = "default_true")]
+    pub required: bool,
+}
+
+/// An answer option for a question
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AskUserOption {
+    /// Value to return to LLM when selected
+    pub value: String,
+    /// Display label for the option
+    pub label: String,
+    /// Optional description shown below the label
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// User's answer to a question
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AskUserAnswer {
+    /// Question ID this answers
+    pub question_id: String,
+    /// Selected option value OR custom text
+    pub answer: String,
+    /// Whether this was a custom answer (typed by user)
+    pub is_custom: bool,
+}
+
+/// Result of the ask_user tool
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AskUserResult {
+    /// All answers provided by the user
+    pub answers: Vec<AskUserAnswer>,
+    /// Whether the user completed all questions (false if cancelled)
+    pub completed: bool,
+    /// Reason for incompletion (if cancelled)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+// =============================================================================
 // Chat Completion Types (used by TUI)
 // =============================================================================
 
@@ -1262,5 +1324,239 @@ mod tests {
             }
             _ => panic!("Expected List content"),
         }
+    }
+
+    // =============================================================================
+    // AskUser Types Tests
+    // =============================================================================
+
+    #[test]
+    fn test_ask_user_question_serialization() {
+        let question = AskUserQuestion {
+            id: "env".to_string(),
+            label: "Environment".to_string(),
+            question: "Which environment should I deploy to?".to_string(),
+            options: vec![
+                AskUserOption {
+                    value: "dev".to_string(),
+                    label: "Development".to_string(),
+                    description: Some("For testing changes".to_string()),
+                },
+                AskUserOption {
+                    value: "prod".to_string(),
+                    label: "Production".to_string(),
+                    description: None,
+                },
+            ],
+            allow_custom: true,
+            required: true,
+        };
+
+        let json = serde_json::to_string(&question).unwrap();
+        assert!(json.contains("\"id\":\"env\""));
+        assert!(json.contains("\"label\":\"Environment\""));
+        assert!(json.contains("\"value\":\"dev\""));
+        assert!(json.contains("\"description\":\"For testing changes\""));
+        // description: None should be skipped
+        assert!(!json.contains("\"description\":null"));
+    }
+
+    #[test]
+    fn test_ask_user_question_deserialization_with_defaults() {
+        // Test that allow_custom and required default to true when not specified
+        let json = r#"{
+            "id": "test",
+            "label": "Test",
+            "question": "Is this a test?",
+            "options": []
+        }"#;
+
+        let question: AskUserQuestion = serde_json::from_str(json).unwrap();
+        assert_eq!(question.id, "test");
+        assert!(question.allow_custom, "allow_custom should default to true");
+        assert!(question.required, "required should default to true");
+    }
+
+    #[test]
+    fn test_ask_user_question_deserialization_explicit_false() {
+        let json = r#"{
+            "id": "test",
+            "label": "Test",
+            "question": "Is this a test?",
+            "options": [],
+            "allow_custom": false,
+            "required": false
+        }"#;
+
+        let question: AskUserQuestion = serde_json::from_str(json).unwrap();
+        assert!(!question.allow_custom);
+        assert!(!question.required);
+    }
+
+    #[test]
+    fn test_ask_user_answer_serialization() {
+        let answer = AskUserAnswer {
+            question_id: "env".to_string(),
+            answer: "production".to_string(),
+            is_custom: false,
+        };
+
+        let json = serde_json::to_string(&answer).unwrap();
+        assert!(json.contains("\"question_id\":\"env\""));
+        assert!(json.contains("\"answer\":\"production\""));
+        assert!(json.contains("\"is_custom\":false"));
+    }
+
+    #[test]
+    fn test_ask_user_answer_custom_input() {
+        let answer = AskUserAnswer {
+            question_id: "feedback".to_string(),
+            answer: "User typed this custom response".to_string(),
+            is_custom: true,
+        };
+
+        let json = serde_json::to_string(&answer).unwrap();
+        assert!(json.contains("\"is_custom\":true"));
+        assert!(json.contains("User typed this custom response"));
+    }
+
+    #[test]
+    fn test_ask_user_result_completed() {
+        let result = AskUserResult {
+            answers: vec![
+                AskUserAnswer {
+                    question_id: "q1".to_string(),
+                    answer: "a1".to_string(),
+                    is_custom: false,
+                },
+                AskUserAnswer {
+                    question_id: "q2".to_string(),
+                    answer: "custom answer".to_string(),
+                    is_custom: true,
+                },
+            ],
+            completed: true,
+            reason: None,
+        };
+
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(json.contains("\"completed\":true"));
+        // reason: None should be skipped
+        assert!(!json.contains("\"reason\""));
+        assert!(json.contains("\"question_id\":\"q1\""));
+        assert!(json.contains("\"question_id\":\"q2\""));
+    }
+
+    #[test]
+    fn test_ask_user_result_cancelled() {
+        let result = AskUserResult {
+            answers: vec![],
+            completed: false,
+            reason: Some("User cancelled the question prompt.".to_string()),
+        };
+
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(json.contains("\"completed\":false"));
+        assert!(json.contains("\"reason\":\"User cancelled the question prompt.\""));
+        assert!(json.contains("\"answers\":[]"));
+    }
+
+    #[test]
+    fn test_ask_user_result_deserialization() {
+        let json = r#"{
+            "answers": [
+                {"question_id": "env", "answer": "dev", "is_custom": false}
+            ],
+            "completed": true
+        }"#;
+
+        let result: AskUserResult = serde_json::from_str(json).unwrap();
+        assert!(result.completed);
+        assert!(result.reason.is_none());
+        assert_eq!(result.answers.len(), 1);
+        assert_eq!(result.answers[0].question_id, "env");
+        assert_eq!(result.answers[0].answer, "dev");
+        assert!(!result.answers[0].is_custom);
+    }
+
+    #[test]
+    fn test_ask_user_option_without_description() {
+        let option = AskUserOption {
+            value: "yes".to_string(),
+            label: "Yes".to_string(),
+            description: None,
+        };
+
+        let json = serde_json::to_string(&option).unwrap();
+        // description should be omitted entirely when None
+        assert!(!json.contains("description"));
+        assert!(json.contains("\"value\":\"yes\""));
+        assert!(json.contains("\"label\":\"Yes\""));
+    }
+
+    #[test]
+    fn test_ask_user_unicode_handling() {
+        // Test that Unicode characters are handled correctly
+        let question = AskUserQuestion {
+            id: "lang".to_string(),
+            label: "言語".to_string(), // Japanese for "language"
+            question: "どの言語を使用しますか？".to_string(),
+            options: vec![
+                AskUserOption {
+                    value: "ja".to_string(),
+                    label: "日本語".to_string(),
+                    description: Some("Japanese language".to_string()),
+                },
+                AskUserOption {
+                    value: "emoji".to_string(),
+                    label: "🚀 Rocket".to_string(),
+                    description: Some("With emoji 🎉".to_string()),
+                },
+            ],
+            allow_custom: true,
+            required: true,
+        };
+
+        // Serialize and deserialize to verify round-trip
+        let json = serde_json::to_string(&question).unwrap();
+        let parsed: AskUserQuestion = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.label, "言語");
+        assert_eq!(parsed.question, "どの言語を使用しますか？");
+        assert_eq!(parsed.options[0].label, "日本語");
+        assert_eq!(parsed.options[1].label, "🚀 Rocket");
+    }
+
+    #[test]
+    fn test_ask_user_types_equality() {
+        let q1 = AskUserQuestion {
+            id: "test".to_string(),
+            label: "Test".to_string(),
+            question: "Question?".to_string(),
+            options: vec![],
+            allow_custom: true,
+            required: true,
+        };
+
+        let q2 = q1.clone();
+        assert_eq!(q1, q2);
+
+        let a1 = AskUserAnswer {
+            question_id: "test".to_string(),
+            answer: "answer".to_string(),
+            is_custom: false,
+        };
+
+        let a2 = a1.clone();
+        assert_eq!(a1, a2);
+
+        let r1 = AskUserResult {
+            answers: vec![a1],
+            completed: true,
+            reason: None,
+        };
+
+        let r2 = r1.clone();
+        assert_eq!(r1, r2);
     }
 }

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -253,6 +253,23 @@ pub struct AppState {
         HashMap<String, stakpak_shared::models::integrations::openai::TaskPauseInfo>,
     /// Buffered user messages waiting to be sent after streaming completes
     pub pending_user_messages: VecDeque<PendingUserMessage>,
+
+    // ========== Ask User Popup State ==========
+    /// Whether the ask user popup is visible
+    pub show_ask_user_popup: bool,
+    /// Questions to display in the popup
+    pub ask_user_questions: Vec<stakpak_shared::models::integrations::openai::AskUserQuestion>,
+    /// User's answers (question_id -> answer)
+    pub ask_user_answers:
+        HashMap<String, stakpak_shared::models::integrations::openai::AskUserAnswer>,
+    /// Currently selected tab index (question index, or questions.len() for Submit)
+    pub ask_user_current_tab: usize,
+    /// Currently selected option index within the current question
+    pub ask_user_selected_option: usize,
+    /// Custom input text when "Type something..." is selected
+    pub ask_user_custom_input: String,
+    /// The tool call that triggered this popup (for sending result back)
+    pub ask_user_tool_call: Option<ToolCall>,
 }
 
 pub struct AppStateOptions<'a> {
@@ -513,6 +530,15 @@ impl AppState {
             auth_display_info,
             subagent_pause_info: HashMap::new(),
             init_prompt_content,
+
+            // Ask User popup initialization
+            show_ask_user_popup: false,
+            ask_user_questions: Vec::new(),
+            ask_user_answers: HashMap::new(),
+            ask_user_current_tab: 0,
+            ask_user_selected_option: 0,
+            ask_user_custom_input: String::new(),
+            ask_user_tool_call: None,
         }
     }
 

--- a/tui/src/app/events.rs
+++ b/tui/src/app/events.rs
@@ -156,6 +156,22 @@ pub enum InputEvent {
     RefreshBoardTasks,
     BoardTasksLoaded(FetchTasksResult),
     BoardTasksError(String),
+
+    // Ask User popup events
+    ShowAskUserPopup(
+        ToolCall,
+        Vec<stakpak_shared::models::integrations::openai::AskUserQuestion>,
+    ),
+    AskUserNextTab,
+    AskUserPrevTab,
+    AskUserNextOption,
+    AskUserPrevOption,
+    AskUserSelectOption,
+    AskUserCustomInputChanged(char),
+    AskUserCustomInputBackspace,
+    AskUserCustomInputDelete,
+    AskUserSubmit,
+    AskUserCancel,
 }
 
 #[derive(Debug)]
@@ -179,4 +195,6 @@ pub enum OutputEvent {
     RequestTotalUsage,
     RequestAvailableModels,
     SwitchToModel(Model),
+    /// Response from ask_user popup with the tool call and result
+    AskUserResponse(ToolCallResult),
 }

--- a/tui/src/services/ask_user_popup.rs
+++ b/tui/src/services/ask_user_popup.rs
@@ -1,0 +1,480 @@
+//! Ask User Popup Component
+//!
+//! A full-width bottom popup that allows the LLM to ask the user structured questions
+//! with predefined options and optional custom input.
+//!
+//! Design:
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────────────────────────┐
+//! │ ← □ Visibility   □ Enrollment   ✓ Payment   □ Coach Access   ✓ Submit →         │
+//! ├─────────────────────────────────────────────────────────────────────────────────┤
+//! │                                                                                 │
+//! │ Should academies be public by default (visible to all users), or should they   │
+//! │ require admin approval before being listed?                                     │
+//! │                                                                                 │
+//! │ › 1. Public by default                                                          │
+//! │      Academies are visible immediately after creation                           │
+//! │                                                                                 │
+//! │   2. Require approval                                                           │
+//! │      Admin must approve before academy appears in listings                      │
+//! │                                                                                 │
+//! │   3. Type something...                                                          │
+//! │      [Custom input field when selected]                                         │
+//! │                                                                                 │
+//! ├─────────────────────────────────────────────────────────────────────────────────┤
+//! │ Enter to select · Tab/Arrow keys to navigate · Esc to cancel                    │
+//! └─────────────────────────────────────────────────────────────────────────────────┘
+//! ```
+
+use crate::app::AppState;
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout, Margin, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+};
+use stakpak_shared::models::integrations::openai::AskUserQuestion;
+
+/// Calculate the height needed for the ask user popup
+pub fn calculate_ask_user_height(state: &AppState, terminal_width: u16) -> u16 {
+    if !state.show_ask_user_popup || state.ask_user_questions.is_empty() {
+        return 0;
+    }
+
+    // If we're on the Submit tab, show a minimal height
+    if state.ask_user_current_tab >= state.ask_user_questions.len() {
+        // Tab bar (1) + border (1) + submit message (3) + help (1) + border (1)
+        return 7;
+    }
+
+    let current_q = &state.ask_user_questions[state.ask_user_current_tab];
+    let inner_width = terminal_width.saturating_sub(4) as usize; // borders + padding
+
+    // Question text wrapped lines
+    let question_lines = textwrap::wrap(&current_q.question, inner_width).len();
+
+    // Options: each option takes 1 line for label, optionally 1 for description
+    let mut option_lines = 0;
+    for opt in &current_q.options {
+        option_lines += 1; // label line
+        if opt.description.is_some() {
+            option_lines += 1; // description line
+        }
+    }
+
+    // Custom input option (if allowed): 1 for "Type something...", 1 for input field when selected
+    let custom_lines = if current_q.allow_custom {
+        let custom_idx = current_q.options.len();
+        if state.ask_user_selected_option == custom_idx {
+            2 // "Type something..." + input field
+        } else {
+            1 // just "Type something..."
+        }
+    } else {
+        0
+    };
+
+    // Height calculation:
+    // - Tab bar: 1
+    // - Top border: 1
+    // - Empty line: 1
+    // - Question text: question_lines
+    // - Empty line: 1
+    // - Options: option_lines
+    // - Custom input: custom_lines
+    // - Empty line: 1
+    // - Help text: 1
+    // - Bottom border: 1
+    let total = 1 + 1 + 1 + question_lines + 1 + option_lines + custom_lines + 1 + 1 + 1;
+
+    // Cap at 60% of terminal height
+    let max_height = (terminal_width as f32 * 0.6) as u16;
+    (total as u16).min(max_height).max(10) // minimum 10 lines
+}
+
+/// Render the ask user popup
+pub fn render_ask_user_popup(f: &mut Frame, state: &AppState) {
+    if !state.show_ask_user_popup || state.ask_user_questions.is_empty() {
+        return;
+    }
+
+    let area = f.area();
+    let popup_height = calculate_ask_user_height(state, area.width);
+
+    // Position at bottom, full width with small margin
+    let popup_area = Rect {
+        x: area.x + 1,
+        y: area.height.saturating_sub(popup_height),
+        width: area.width.saturating_sub(2),
+        height: popup_height,
+    };
+
+    // Clear background
+    f.render_widget(Clear, popup_area);
+
+    // Main border
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+    f.render_widget(block, popup_area);
+
+    let inner = popup_area.inner(Margin::new(1, 1));
+
+    // Split: [tabs][content][help]
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // tabs
+            Constraint::Min(3),    // content
+            Constraint::Length(1), // help
+        ])
+        .split(inner);
+
+    render_tab_bar(f, state, chunks[0]);
+
+    // Check if we're on the Submit tab
+    if state.ask_user_current_tab >= state.ask_user_questions.len() {
+        render_submit_content(f, state, chunks[1]);
+    } else {
+        render_question_content(f, state, chunks[1]);
+    }
+
+    render_help_text(f, state, chunks[2]);
+}
+
+/// Render the tab bar showing all questions and Submit
+fn render_tab_bar(f: &mut Frame, state: &AppState, area: Rect) {
+    let mut spans = vec![];
+
+    // Left arrow
+    spans.push(Span::styled("← ", Style::default().fg(Color::DarkGray)));
+
+    for (i, q) in state.ask_user_questions.iter().enumerate() {
+        let is_current = i == state.ask_user_current_tab;
+        let is_answered = state.ask_user_answers.contains_key(&q.id);
+
+        let checkbox = if is_answered { "✓ " } else { "□ " };
+
+        let style = if is_current {
+            Style::default().bg(Color::Cyan).fg(Color::Black)
+        } else if is_answered {
+            Style::default().fg(Color::Cyan)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+
+        // Truncate label if too long (char-safe for UTF-8)
+        let label = if q.label.chars().count() > 15 {
+            format!("{}...", q.label.chars().take(12).collect::<String>())
+        } else {
+            q.label.clone()
+        };
+
+        spans.push(Span::styled(format!("{}{}", checkbox, label), style));
+        spans.push(Span::raw("   "));
+    }
+
+    // Submit tab
+    let is_submit_tab = state.ask_user_current_tab >= state.ask_user_questions.len();
+    let all_required_answered = check_all_required_answered(state);
+
+    let submit_style = if is_submit_tab {
+        Style::default().bg(Color::Cyan).fg(Color::Black)
+    } else if all_required_answered {
+        Style::default().fg(Color::Green)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+
+    spans.push(Span::styled("✓ Submit", submit_style));
+
+    // Right arrow
+    spans.push(Span::styled(" →", Style::default().fg(Color::DarkGray)));
+
+    f.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+/// Render the question content area
+fn render_question_content(f: &mut Frame, state: &AppState, area: Rect) {
+    let q = &state.ask_user_questions[state.ask_user_current_tab];
+    let mut lines = vec![];
+
+    // Check if this question has a previous answer
+    let previous_answer = state.ask_user_answers.get(&q.id);
+
+    // Empty line for spacing
+    lines.push(Line::from(""));
+
+    // Question text (bold, wrapped)
+    let wrapped_question = textwrap::wrap(&q.question, area.width as usize);
+    for line in wrapped_question {
+        lines.push(Line::from(Span::styled(
+            line.to_string(),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        )));
+    }
+
+    // Empty line
+    lines.push(Line::from(""));
+
+    // Options
+    for (i, opt) in q.options.iter().enumerate() {
+        let is_selected = i == state.ask_user_selected_option;
+        let is_answered = previous_answer
+            .map(|a| !a.is_custom && a.answer == opt.value)
+            .unwrap_or(false);
+
+        let prefix = if is_selected {
+            "› "
+        } else if is_answered {
+            "✓ "
+        } else {
+            "  "
+        };
+        let num = format!("{}. ", i + 1);
+
+        let style = if is_selected {
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD)
+        } else if is_answered {
+            Style::default().fg(Color::Cyan)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+
+        lines.push(Line::from(vec![
+            Span::styled(prefix, style),
+            Span::styled(num, style),
+            Span::styled(&opt.label, style),
+        ]));
+
+        if let Some(desc) = &opt.description {
+            let desc_style = if is_selected {
+                Style::default().fg(Color::Gray)
+            } else {
+                Style::default().fg(Color::DarkGray)
+            };
+            lines.push(Line::from(Span::styled(
+                format!("     {}", desc),
+                desc_style,
+            )));
+        }
+    }
+
+    // Custom input option (if allowed)
+    if q.allow_custom {
+        let custom_idx = q.options.len();
+        let is_selected = state.ask_user_selected_option == custom_idx;
+        let is_custom_answered = previous_answer.map(|a| a.is_custom).unwrap_or(false);
+
+        let prefix = if is_selected {
+            "› "
+        } else if is_custom_answered {
+            "✓ "
+        } else {
+            "  "
+        };
+        let num = format!("{}. ", custom_idx + 1);
+
+        let style = if is_selected {
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD)
+        } else if is_custom_answered {
+            Style::default().fg(Color::Cyan)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+
+        lines.push(Line::from(vec![
+            Span::styled(prefix, style),
+            Span::styled(num, style),
+            Span::styled("Type something...", style),
+        ]));
+
+        // Show input field when custom option is selected OR show previous custom answer
+        if is_selected {
+            lines.push(Line::from(vec![
+                Span::raw("     "),
+                Span::styled(
+                    &state.ask_user_custom_input,
+                    Style::default().fg(Color::White),
+                ),
+                Span::styled("│", Style::default().fg(Color::Cyan)),
+            ]));
+        } else if is_custom_answered && let Some(answer) = previous_answer {
+            lines.push(Line::from(vec![
+                Span::raw("     "),
+                Span::styled(&answer.answer, Style::default().fg(Color::Cyan)),
+            ]));
+        }
+    }
+
+    f.render_widget(Paragraph::new(lines), area);
+}
+
+/// Render the submit tab content
+fn render_submit_content(f: &mut Frame, state: &AppState, area: Rect) {
+    let mut lines = vec![];
+
+    lines.push(Line::from(""));
+
+    let all_required_answered = check_all_required_answered(state);
+
+    if all_required_answered {
+        lines.push(Line::from(Span::styled(
+            "Ready to submit your answers!",
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        )));
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Press Enter to confirm and send your responses.",
+            Style::default().fg(Color::White),
+        )));
+    } else {
+        lines.push(Line::from(Span::styled(
+            "Some required questions are not answered yet.",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )));
+        lines.push(Line::from(""));
+
+        // List unanswered required questions
+        for q in &state.ask_user_questions {
+            if q.required && !state.ask_user_answers.contains_key(&q.id) {
+                lines.push(Line::from(vec![
+                    Span::styled("  □ ", Style::default().fg(Color::Yellow)),
+                    Span::styled(&q.label, Style::default().fg(Color::White)),
+                ]));
+            }
+        }
+    }
+
+    // Summary of answers
+    if !state.ask_user_answers.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Your answers:",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )));
+
+        for q in &state.ask_user_questions {
+            if let Some(answer) = state.ask_user_answers.get(&q.id) {
+                // Truncate answer display (char-safe for UTF-8)
+                let answer_display = if answer.answer.chars().count() > 40 {
+                    format!("{}...", answer.answer.chars().take(37).collect::<String>())
+                } else {
+                    answer.answer.clone()
+                };
+                lines.push(Line::from(vec![
+                    Span::styled("  ✓ ", Style::default().fg(Color::Green)),
+                    Span::styled(format!("{}: ", q.label), Style::default().fg(Color::White)),
+                    Span::styled(
+                        answer_display,
+                        Style::default().fg(if answer.is_custom {
+                            Color::Magenta
+                        } else {
+                            Color::Cyan
+                        }),
+                    ),
+                ]));
+            }
+        }
+    }
+
+    f.render_widget(Paragraph::new(lines), area);
+}
+
+/// Render the help text at the bottom
+fn render_help_text(f: &mut Frame, state: &AppState, area: Rect) {
+    let is_submit_tab = state.ask_user_current_tab >= state.ask_user_questions.len();
+    let all_required_answered = check_all_required_answered(state);
+
+    let help = if is_submit_tab && all_required_answered {
+        Line::from(vec![
+            Span::styled("Enter", Style::default().fg(Color::DarkGray)),
+            Span::styled(" submit", Style::default().fg(Color::Green)),
+            Span::raw(" · "),
+            Span::styled("←/→", Style::default().fg(Color::DarkGray)),
+            Span::styled(" questions", Style::default().fg(Color::Cyan)),
+            Span::raw(" · "),
+            Span::styled("Esc", Style::default().fg(Color::DarkGray)),
+            Span::styled(" cancel", Style::default().fg(Color::Cyan)),
+        ])
+    } else if is_submit_tab {
+        Line::from(vec![
+            Span::styled("←/→", Style::default().fg(Color::DarkGray)),
+            Span::styled(" questions", Style::default().fg(Color::Cyan)),
+            Span::raw(" · "),
+            Span::styled("Esc", Style::default().fg(Color::DarkGray)),
+            Span::styled(" cancel", Style::default().fg(Color::Cyan)),
+        ])
+    } else {
+        // Check if custom input is selected
+        let current_q = &state.ask_user_questions[state.ask_user_current_tab];
+        let is_custom_selected =
+            current_q.allow_custom && state.ask_user_selected_option == current_q.options.len();
+
+        if is_custom_selected {
+            Line::from(vec![
+                Span::styled("Type", Style::default().fg(Color::DarkGray)),
+                Span::styled(" your answer", Style::default().fg(Color::Cyan)),
+                Span::raw(" · "),
+                Span::styled("Enter", Style::default().fg(Color::DarkGray)),
+                Span::styled(" confirm", Style::default().fg(Color::Cyan)),
+                Span::raw(" · "),
+                Span::styled("↑/↓", Style::default().fg(Color::DarkGray)),
+                Span::styled(" options", Style::default().fg(Color::Cyan)),
+                Span::raw(" · "),
+                Span::styled("Esc", Style::default().fg(Color::DarkGray)),
+                Span::styled(" cancel", Style::default().fg(Color::Cyan)),
+            ])
+        } else {
+            Line::from(vec![
+                Span::styled("Enter", Style::default().fg(Color::DarkGray)),
+                Span::styled(" select", Style::default().fg(Color::Cyan)),
+                Span::raw(" · "),
+                Span::styled("↑/↓", Style::default().fg(Color::DarkGray)),
+                Span::styled(" options", Style::default().fg(Color::Cyan)),
+                Span::raw(" · "),
+                Span::styled("←/→", Style::default().fg(Color::DarkGray)),
+                Span::styled(" questions", Style::default().fg(Color::Cyan)),
+                Span::raw(" · "),
+                Span::styled("1-9", Style::default().fg(Color::DarkGray)),
+                Span::styled(" quick select", Style::default().fg(Color::Cyan)),
+                Span::raw(" · "),
+                Span::styled("Esc", Style::default().fg(Color::DarkGray)),
+                Span::styled(" cancel", Style::default().fg(Color::Cyan)),
+            ])
+        }
+    };
+
+    f.render_widget(Paragraph::new(help), area);
+}
+
+/// Check if all required questions have been answered
+fn check_all_required_answered(state: &AppState) -> bool {
+    state
+        .ask_user_questions
+        .iter()
+        .filter(|q| q.required)
+        .all(|q| state.ask_user_answers.contains_key(&q.id))
+}
+
+/// Get the total number of options for the current question (including custom if allowed)
+pub fn get_total_options(question: &AskUserQuestion) -> usize {
+    if question.allow_custom {
+        question.options.len() + 1
+    } else {
+        question.options.len()
+    }
+}

--- a/tui/src/services/handlers/ask_user.rs
+++ b/tui/src/services/handlers/ask_user.rs
@@ -1,0 +1,880 @@
+//! Ask User Event Handlers
+//!
+//! Handles all events related to the ask_user popup including navigation,
+//! option selection, custom input, and submission.
+
+use crate::app::{AppState, OutputEvent};
+use crate::services::ask_user_popup::get_total_options;
+use stakpak_shared::models::integrations::openai::{
+    AskUserAnswer, AskUserQuestion, AskUserResult, ToolCall, ToolCallResult, ToolCallResultStatus,
+};
+use tokio::sync::mpsc::Sender;
+
+/// Show the ask user popup with the given questions
+pub fn handle_show_ask_user_popup(
+    state: &mut AppState,
+    tool_call: ToolCall,
+    questions: Vec<AskUserQuestion>,
+) {
+    if questions.is_empty() {
+        return;
+    }
+
+    state.show_ask_user_popup = true;
+    state.ask_user_questions = questions;
+    state.ask_user_answers.clear();
+    state.ask_user_current_tab = 0;
+    state.ask_user_selected_option = 0;
+    state.ask_user_custom_input.clear();
+    state.ask_user_tool_call = Some(tool_call);
+
+    // Invalidate cache to update display
+    crate::services::message::invalidate_message_lines_cache(state);
+}
+
+/// Navigate to the next tab (question or Submit)
+pub fn handle_ask_user_next_tab(state: &mut AppState) {
+    if !state.show_ask_user_popup {
+        return;
+    }
+
+    let max_tab = state.ask_user_questions.len(); // questions.len() is the Submit tab
+    if state.ask_user_current_tab < max_tab {
+        state.ask_user_current_tab += 1;
+        // Reset option selection when changing tabs
+        state.ask_user_selected_option = 0;
+        state.ask_user_custom_input.clear();
+    }
+}
+
+/// Navigate to the previous tab
+pub fn handle_ask_user_prev_tab(state: &mut AppState) {
+    if !state.show_ask_user_popup {
+        return;
+    }
+
+    if state.ask_user_current_tab > 0 {
+        state.ask_user_current_tab -= 1;
+        // Reset option selection when changing tabs
+        state.ask_user_selected_option = 0;
+        state.ask_user_custom_input.clear();
+    }
+}
+
+/// Navigate to the next option within the current question
+pub fn handle_ask_user_next_option(state: &mut AppState) {
+    if !state.show_ask_user_popup {
+        return;
+    }
+
+    // Can't navigate options on Submit tab
+    if state.ask_user_current_tab >= state.ask_user_questions.len() {
+        return;
+    }
+
+    let current_q = &state.ask_user_questions[state.ask_user_current_tab];
+    let total_options = get_total_options(current_q);
+
+    if state.ask_user_selected_option < total_options.saturating_sub(1) {
+        state.ask_user_selected_option += 1;
+    }
+}
+
+/// Navigate to the previous option within the current question
+pub fn handle_ask_user_prev_option(state: &mut AppState) {
+    if !state.show_ask_user_popup {
+        return;
+    }
+
+    // Can't navigate options on Submit tab
+    if state.ask_user_current_tab >= state.ask_user_questions.len() {
+        return;
+    }
+
+    if state.ask_user_selected_option > 0 {
+        state.ask_user_selected_option -= 1;
+    }
+}
+
+/// Select the current option (or submit if on Submit tab)
+pub fn handle_ask_user_select_option(state: &mut AppState, output_tx: &Sender<OutputEvent>) {
+    if !state.show_ask_user_popup {
+        return;
+    }
+
+    // If on Submit tab, try to submit
+    if state.ask_user_current_tab >= state.ask_user_questions.len() {
+        handle_ask_user_submit(state, output_tx);
+        return;
+    }
+
+    let current_q = &state.ask_user_questions[state.ask_user_current_tab];
+    let question_id = current_q.id.clone();
+
+    // Check if custom input is selected
+    if current_q.allow_custom && state.ask_user_selected_option == current_q.options.len() {
+        // Custom input selected - save the custom answer if not empty
+        if !state.ask_user_custom_input.is_empty() {
+            let answer = AskUserAnswer {
+                question_id,
+                answer: state.ask_user_custom_input.clone(),
+                is_custom: true,
+            };
+            state.ask_user_answers.insert(current_q.id.clone(), answer);
+
+            // Auto-advance to next question or Submit
+            if state.ask_user_current_tab < state.ask_user_questions.len() {
+                state.ask_user_current_tab += 1;
+                state.ask_user_selected_option = 0;
+                state.ask_user_custom_input.clear();
+            }
+        }
+        return;
+    }
+
+    // Regular option selected
+    if let Some(opt) = current_q.options.get(state.ask_user_selected_option) {
+        let answer = AskUserAnswer {
+            question_id,
+            answer: opt.value.clone(),
+            is_custom: false,
+        };
+        state.ask_user_answers.insert(current_q.id.clone(), answer);
+
+        // Auto-advance to next question or Submit
+        if state.ask_user_current_tab < state.ask_user_questions.len() {
+            state.ask_user_current_tab += 1;
+            state.ask_user_selected_option = 0;
+            state.ask_user_custom_input.clear();
+        }
+    }
+}
+
+/// Quick select an option by number (1-9)
+pub fn handle_ask_user_quick_select(
+    state: &mut AppState,
+    num: usize,
+    output_tx: &Sender<OutputEvent>,
+) {
+    if !state.show_ask_user_popup {
+        return;
+    }
+
+    // Can't quick select on Submit tab
+    if state.ask_user_current_tab >= state.ask_user_questions.len() {
+        return;
+    }
+
+    let current_q = &state.ask_user_questions[state.ask_user_current_tab];
+    let total_options = get_total_options(current_q);
+
+    // num is 1-indexed, convert to 0-indexed
+    let option_idx = num.saturating_sub(1);
+
+    if option_idx < total_options {
+        state.ask_user_selected_option = option_idx;
+        // If it's a regular option (not custom), select it immediately
+        if option_idx < current_q.options.len() {
+            handle_ask_user_select_option(state, output_tx);
+        }
+        // If it's the custom option, just focus it (user needs to type)
+    }
+}
+
+/// Handle character input for custom answer
+pub fn handle_ask_user_custom_input_changed(state: &mut AppState, c: char) {
+    if !state.show_ask_user_popup {
+        return;
+    }
+
+    // Only accept input if on a question tab and custom option is selected
+    if state.ask_user_current_tab >= state.ask_user_questions.len() {
+        return;
+    }
+
+    let current_q = &state.ask_user_questions[state.ask_user_current_tab];
+    if current_q.allow_custom && state.ask_user_selected_option == current_q.options.len() {
+        state.ask_user_custom_input.push(c);
+    }
+}
+
+/// Handle backspace for custom answer
+pub fn handle_ask_user_custom_input_backspace(state: &mut AppState) {
+    if !state.show_ask_user_popup {
+        return;
+    }
+
+    // Only accept input if on a question tab and custom option is selected
+    if state.ask_user_current_tab >= state.ask_user_questions.len() {
+        return;
+    }
+
+    let current_q = &state.ask_user_questions[state.ask_user_current_tab];
+    if current_q.allow_custom && state.ask_user_selected_option == current_q.options.len() {
+        state.ask_user_custom_input.pop();
+    }
+}
+
+/// Handle delete (clear all) for custom answer
+pub fn handle_ask_user_custom_input_delete(state: &mut AppState) {
+    if !state.show_ask_user_popup {
+        return;
+    }
+
+    // Only accept input if on a question tab and custom option is selected
+    if state.ask_user_current_tab >= state.ask_user_questions.len() {
+        return;
+    }
+
+    let current_q = &state.ask_user_questions[state.ask_user_current_tab];
+    if current_q.allow_custom && state.ask_user_selected_option == current_q.options.len() {
+        state.ask_user_custom_input.clear();
+    }
+}
+
+/// Submit all answers
+pub fn handle_ask_user_submit(state: &mut AppState, output_tx: &Sender<OutputEvent>) {
+    if !state.show_ask_user_popup {
+        return;
+    }
+
+    // Check if all required questions are answered
+    let all_required_answered = state
+        .ask_user_questions
+        .iter()
+        .filter(|q| q.required)
+        .all(|q| state.ask_user_answers.contains_key(&q.id));
+
+    if !all_required_answered {
+        // Can't submit yet - maybe flash a warning or navigate to first unanswered
+        // For now, just find the first unanswered required question and go there
+        for (i, q) in state.ask_user_questions.iter().enumerate() {
+            if q.required && !state.ask_user_answers.contains_key(&q.id) {
+                state.ask_user_current_tab = i;
+                state.ask_user_selected_option = 0;
+                break;
+            }
+        }
+        return;
+    }
+
+    // Build the structured result as documented in the tool description
+    let answers: Vec<AskUserAnswer> = state
+        .ask_user_questions
+        .iter()
+        .filter_map(|q| state.ask_user_answers.get(&q.id).cloned())
+        .collect();
+
+    let result = AskUserResult {
+        answers,
+        completed: true,
+        reason: None,
+    };
+
+    // Serialize to JSON as documented in the tool description
+    let display_result = serde_json::to_string_pretty(&result)
+        .unwrap_or_else(|e| format!("{{\"error\": \"Failed to serialize result: {}\"}}", e));
+
+    // Send the result back
+    if let Some(tool_call) = state.ask_user_tool_call.take() {
+        let tool_result = ToolCallResult {
+            call: tool_call,
+            result: display_result,
+            status: ToolCallResultStatus::Success,
+        };
+
+        let _ = output_tx.try_send(OutputEvent::AskUserResponse(tool_result));
+    }
+
+    // Close the popup
+    close_ask_user_popup(state);
+}
+
+/// Cancel and close the popup
+pub fn handle_ask_user_cancel(state: &mut AppState, output_tx: &Sender<OutputEvent>) {
+    if !state.show_ask_user_popup {
+        return;
+    }
+
+    // Send the cancelled result back as JSON (matching the documented format)
+    if let Some(tool_call) = state.ask_user_tool_call.take() {
+        let result = AskUserResult {
+            answers: vec![],
+            completed: false,
+            reason: Some("User cancelled the question prompt.".to_string()),
+        };
+
+        let display_result = serde_json::to_string_pretty(&result)
+            .unwrap_or_else(|e| format!("{{\"error\": \"Failed to serialize result: {}\"}}", e));
+
+        let tool_result = ToolCallResult {
+            call: tool_call,
+            result: display_result,
+            status: ToolCallResultStatus::Cancelled,
+        };
+
+        let _ = output_tx.try_send(OutputEvent::AskUserResponse(tool_result));
+    }
+
+    // Close the popup
+    close_ask_user_popup(state);
+}
+
+/// Close the popup and reset state
+fn close_ask_user_popup(state: &mut AppState) {
+    state.show_ask_user_popup = false;
+    state.ask_user_questions.clear();
+    state.ask_user_answers.clear();
+    state.ask_user_current_tab = 0;
+    state.ask_user_selected_option = 0;
+    state.ask_user_custom_input.clear();
+    state.ask_user_tool_call = None;
+
+    // Invalidate cache to update display
+    crate::services::message::invalidate_message_lines_cache(state);
+}
+
+/// Check if the current question has custom input selected
+pub fn is_custom_input_selected(state: &AppState) -> bool {
+    if !state.show_ask_user_popup {
+        return false;
+    }
+
+    if state.ask_user_current_tab >= state.ask_user_questions.len() {
+        return false;
+    }
+
+    let current_q = &state.ask_user_questions[state.ask_user_current_tab];
+    current_q.allow_custom && state.ask_user_selected_option == current_q.options.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::AppStateOptions;
+    use stakai::Model;
+    use stakpak_shared::models::integrations::openai::{AskUserOption, FunctionCall};
+    use tokio::sync::mpsc;
+
+    /// Helper to create a minimal AppState for testing
+    fn create_test_state() -> AppState {
+        AppState::new(AppStateOptions {
+            latest_version: None,
+            redact_secrets: false,
+            privacy_mode: false,
+            is_git_repo: false,
+            auto_approve_tools: None,
+            allowed_tools: None,
+            input_tx: None,
+            model: Model::default(),
+            editor_command: None,
+            auth_display_info: (None, None, None),
+            board_agent_id: None,
+            init_prompt_content: None,
+        })
+    }
+
+    /// Helper to create test questions
+    fn create_test_questions() -> Vec<AskUserQuestion> {
+        vec![
+            AskUserQuestion {
+                id: "env".to_string(),
+                label: "Environment".to_string(),
+                question: "Which environment?".to_string(),
+                options: vec![
+                    AskUserOption {
+                        value: "dev".to_string(),
+                        label: "Development".to_string(),
+                        description: Some("For testing".to_string()),
+                    },
+                    AskUserOption {
+                        value: "prod".to_string(),
+                        label: "Production".to_string(),
+                        description: None,
+                    },
+                ],
+                allow_custom: true,
+                required: true,
+            },
+            AskUserQuestion {
+                id: "confirm".to_string(),
+                label: "Confirm".to_string(),
+                question: "Are you sure?".to_string(),
+                options: vec![
+                    AskUserOption {
+                        value: "yes".to_string(),
+                        label: "Yes".to_string(),
+                        description: None,
+                    },
+                    AskUserOption {
+                        value: "no".to_string(),
+                        label: "No".to_string(),
+                        description: None,
+                    },
+                ],
+                allow_custom: false,
+                required: true,
+            },
+        ]
+    }
+
+    /// Helper to create a test tool call
+    fn create_test_tool_call() -> ToolCall {
+        ToolCall {
+            id: "call_test123".to_string(),
+            r#type: "function".to_string(),
+            function: FunctionCall {
+                name: "ask_user".to_string(),
+                arguments: "{}".to_string(),
+            },
+            metadata: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_show_ask_user_popup() {
+        let mut state = create_test_state();
+        let questions = create_test_questions();
+        let tool_call = create_test_tool_call();
+
+        assert!(!state.show_ask_user_popup);
+        assert!(state.ask_user_questions.is_empty());
+
+        handle_show_ask_user_popup(&mut state, tool_call.clone(), questions.clone());
+
+        assert!(state.show_ask_user_popup);
+        assert_eq!(state.ask_user_questions.len(), 2);
+        assert_eq!(state.ask_user_current_tab, 0);
+        assert_eq!(state.ask_user_selected_option, 0);
+        assert!(state.ask_user_tool_call.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_show_ask_user_popup_empty_questions() {
+        let mut state = create_test_state();
+        let tool_call = create_test_tool_call();
+
+        handle_show_ask_user_popup(&mut state, tool_call, vec![]);
+
+        // Should not show popup with empty questions
+        assert!(!state.show_ask_user_popup);
+    }
+
+    #[tokio::test]
+    async fn test_tab_navigation() {
+        let mut state = create_test_state();
+        let questions = create_test_questions();
+        let tool_call = create_test_tool_call();
+
+        handle_show_ask_user_popup(&mut state, tool_call, questions);
+
+        // Start at tab 0
+        assert_eq!(state.ask_user_current_tab, 0);
+
+        // Navigate to next tab
+        handle_ask_user_next_tab(&mut state);
+        assert_eq!(state.ask_user_current_tab, 1);
+
+        // Navigate to Submit tab (index 2 for 2 questions)
+        handle_ask_user_next_tab(&mut state);
+        assert_eq!(state.ask_user_current_tab, 2);
+
+        // Can't go beyond Submit
+        handle_ask_user_next_tab(&mut state);
+        assert_eq!(state.ask_user_current_tab, 2);
+
+        // Navigate back
+        handle_ask_user_prev_tab(&mut state);
+        assert_eq!(state.ask_user_current_tab, 1);
+
+        handle_ask_user_prev_tab(&mut state);
+        assert_eq!(state.ask_user_current_tab, 0);
+
+        // Can't go before first question
+        handle_ask_user_prev_tab(&mut state);
+        assert_eq!(state.ask_user_current_tab, 0);
+    }
+
+    #[tokio::test]
+    async fn test_option_navigation() {
+        let mut state = create_test_state();
+        let questions = create_test_questions();
+        let tool_call = create_test_tool_call();
+
+        handle_show_ask_user_popup(&mut state, tool_call, questions);
+
+        // First question has 2 options + custom = 3 total
+        assert_eq!(state.ask_user_selected_option, 0);
+
+        handle_ask_user_next_option(&mut state);
+        assert_eq!(state.ask_user_selected_option, 1);
+
+        handle_ask_user_next_option(&mut state);
+        assert_eq!(state.ask_user_selected_option, 2); // custom option
+
+        // Can't go beyond last option
+        handle_ask_user_next_option(&mut state);
+        assert_eq!(state.ask_user_selected_option, 2);
+
+        // Navigate back
+        handle_ask_user_prev_option(&mut state);
+        assert_eq!(state.ask_user_selected_option, 1);
+
+        handle_ask_user_prev_option(&mut state);
+        assert_eq!(state.ask_user_selected_option, 0);
+
+        // Can't go before first option
+        handle_ask_user_prev_option(&mut state);
+        assert_eq!(state.ask_user_selected_option, 0);
+    }
+
+    #[tokio::test]
+    async fn test_option_navigation_no_custom() {
+        let mut state = create_test_state();
+        let questions = create_test_questions();
+        let tool_call = create_test_tool_call();
+
+        handle_show_ask_user_popup(&mut state, tool_call, questions);
+
+        // Navigate to second question (no custom option)
+        handle_ask_user_next_tab(&mut state);
+        assert_eq!(state.ask_user_current_tab, 1);
+        assert_eq!(state.ask_user_selected_option, 0);
+
+        // Second question has 2 options only (no custom)
+        handle_ask_user_next_option(&mut state);
+        assert_eq!(state.ask_user_selected_option, 1);
+
+        // Can't go beyond (no custom option)
+        handle_ask_user_next_option(&mut state);
+        assert_eq!(state.ask_user_selected_option, 1);
+    }
+
+    #[tokio::test]
+    async fn test_select_predefined_option() {
+        let mut state = create_test_state();
+        let questions = create_test_questions();
+        let tool_call = create_test_tool_call();
+        let (output_tx, _output_rx) = mpsc::channel(10);
+
+        handle_show_ask_user_popup(&mut state, tool_call, questions);
+
+        // Select first option (dev)
+        handle_ask_user_select_option(&mut state, &output_tx);
+
+        // Should have recorded the answer
+        assert!(state.ask_user_answers.contains_key("env"));
+        let answer = &state.ask_user_answers["env"];
+        assert_eq!(answer.answer, "dev");
+        assert!(!answer.is_custom);
+
+        // Should auto-advance to next question
+        assert_eq!(state.ask_user_current_tab, 1);
+    }
+
+    #[tokio::test]
+    async fn test_select_custom_option() {
+        let mut state = create_test_state();
+        let questions = create_test_questions();
+        let tool_call = create_test_tool_call();
+        let (output_tx, _output_rx) = mpsc::channel(10);
+
+        handle_show_ask_user_popup(&mut state, tool_call, questions);
+
+        // Navigate to custom option (index 2)
+        handle_ask_user_next_option(&mut state);
+        handle_ask_user_next_option(&mut state);
+        assert_eq!(state.ask_user_selected_option, 2);
+
+        // Type custom input
+        handle_ask_user_custom_input_changed(&mut state, 's');
+        handle_ask_user_custom_input_changed(&mut state, 't');
+        handle_ask_user_custom_input_changed(&mut state, 'a');
+        handle_ask_user_custom_input_changed(&mut state, 'g');
+        handle_ask_user_custom_input_changed(&mut state, 'i');
+        handle_ask_user_custom_input_changed(&mut state, 'n');
+        handle_ask_user_custom_input_changed(&mut state, 'g');
+
+        assert_eq!(state.ask_user_custom_input, "staging");
+
+        // Select the custom option
+        handle_ask_user_select_option(&mut state, &output_tx);
+
+        // Should have recorded custom answer
+        assert!(state.ask_user_answers.contains_key("env"));
+        let answer = &state.ask_user_answers["env"];
+        assert_eq!(answer.answer, "staging");
+        assert!(answer.is_custom);
+    }
+
+    #[tokio::test]
+    async fn test_custom_input_backspace() {
+        let mut state = create_test_state();
+        let questions = create_test_questions();
+        let tool_call = create_test_tool_call();
+
+        handle_show_ask_user_popup(&mut state, tool_call, questions);
+
+        // Navigate to custom option
+        handle_ask_user_next_option(&mut state);
+        handle_ask_user_next_option(&mut state);
+
+        // Type and then backspace
+        handle_ask_user_custom_input_changed(&mut state, 'a');
+        handle_ask_user_custom_input_changed(&mut state, 'b');
+        handle_ask_user_custom_input_changed(&mut state, 'c');
+        assert_eq!(state.ask_user_custom_input, "abc");
+
+        handle_ask_user_custom_input_backspace(&mut state);
+        assert_eq!(state.ask_user_custom_input, "ab");
+
+        handle_ask_user_custom_input_backspace(&mut state);
+        handle_ask_user_custom_input_backspace(&mut state);
+        assert_eq!(state.ask_user_custom_input, "");
+
+        // Backspace on empty is safe
+        handle_ask_user_custom_input_backspace(&mut state);
+        assert_eq!(state.ask_user_custom_input, "");
+    }
+
+    #[tokio::test]
+    async fn test_custom_input_delete_clears_all() {
+        let mut state = create_test_state();
+        let questions = create_test_questions();
+        let tool_call = create_test_tool_call();
+
+        handle_show_ask_user_popup(&mut state, tool_call, questions);
+
+        // Navigate to custom option
+        handle_ask_user_next_option(&mut state);
+        handle_ask_user_next_option(&mut state);
+
+        // Type some input
+        handle_ask_user_custom_input_changed(&mut state, 't');
+        handle_ask_user_custom_input_changed(&mut state, 'e');
+        handle_ask_user_custom_input_changed(&mut state, 's');
+        handle_ask_user_custom_input_changed(&mut state, 't');
+        assert_eq!(state.ask_user_custom_input, "test");
+
+        // Delete clears everything
+        handle_ask_user_custom_input_delete(&mut state);
+        assert_eq!(state.ask_user_custom_input, "");
+    }
+
+    #[tokio::test]
+    async fn test_is_custom_input_selected() {
+        let mut state = create_test_state();
+        let questions = create_test_questions();
+        let tool_call = create_test_tool_call();
+
+        // Not selected when popup not shown
+        assert!(!is_custom_input_selected(&state));
+
+        handle_show_ask_user_popup(&mut state, tool_call, questions);
+
+        // Not selected at option 0
+        assert!(!is_custom_input_selected(&state));
+
+        // Navigate to custom option
+        handle_ask_user_next_option(&mut state);
+        handle_ask_user_next_option(&mut state);
+        assert!(is_custom_input_selected(&state));
+
+        // Navigate to second question (no custom)
+        handle_ask_user_next_tab(&mut state);
+        state.ask_user_selected_option = 1; // Last option
+        assert!(!is_custom_input_selected(&state)); // Second question has no custom
+    }
+
+    #[tokio::test]
+    async fn test_submit_with_all_required_answered() {
+        let mut state = create_test_state();
+        let questions = create_test_questions();
+        let tool_call = create_test_tool_call();
+        let (output_tx, mut output_rx) = mpsc::channel(10);
+
+        handle_show_ask_user_popup(&mut state, tool_call, questions);
+
+        // Answer both required questions
+        state.ask_user_answers.insert(
+            "env".to_string(),
+            AskUserAnswer {
+                question_id: "env".to_string(),
+                answer: "dev".to_string(),
+                is_custom: false,
+            },
+        );
+        state.ask_user_answers.insert(
+            "confirm".to_string(),
+            AskUserAnswer {
+                question_id: "confirm".to_string(),
+                answer: "yes".to_string(),
+                is_custom: false,
+            },
+        );
+
+        // Go to Submit tab
+        state.ask_user_current_tab = 2;
+
+        // Submit
+        handle_ask_user_submit(&mut state, &output_tx);
+
+        // Popup should be closed
+        assert!(!state.show_ask_user_popup);
+        assert!(state.ask_user_questions.is_empty());
+        assert!(state.ask_user_answers.is_empty());
+
+        // Should have sent response
+        let event = output_rx.try_recv().unwrap();
+        match event {
+            OutputEvent::AskUserResponse(result) => {
+                assert_eq!(result.status, ToolCallResultStatus::Success);
+                // Result should be valid JSON
+                let parsed: AskUserResult = serde_json::from_str(&result.result).unwrap();
+                assert!(parsed.completed);
+                assert!(parsed.reason.is_none());
+                assert_eq!(parsed.answers.len(), 2);
+            }
+            _ => panic!("Expected AskUserResponse event"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_submit_blocked_without_required() {
+        let mut state = create_test_state();
+        let questions = create_test_questions();
+        let tool_call = create_test_tool_call();
+        let (output_tx, mut output_rx) = mpsc::channel(10);
+
+        handle_show_ask_user_popup(&mut state, tool_call, questions);
+
+        // Only answer first question
+        state.ask_user_answers.insert(
+            "env".to_string(),
+            AskUserAnswer {
+                question_id: "env".to_string(),
+                answer: "dev".to_string(),
+                is_custom: false,
+            },
+        );
+
+        // Go to Submit tab
+        state.ask_user_current_tab = 2;
+
+        // Try to submit
+        handle_ask_user_submit(&mut state, &output_tx);
+
+        // Should NOT have sent response
+        assert!(output_rx.try_recv().is_err());
+
+        // Should navigate to first unanswered required question
+        assert_eq!(state.ask_user_current_tab, 1); // Second question
+        assert!(state.show_ask_user_popup); // Popup still open
+    }
+
+    #[tokio::test]
+    async fn test_cancel() {
+        let mut state = create_test_state();
+        let questions = create_test_questions();
+        let tool_call = create_test_tool_call();
+        let (output_tx, mut output_rx) = mpsc::channel(10);
+
+        handle_show_ask_user_popup(&mut state, tool_call, questions);
+
+        // Cancel
+        handle_ask_user_cancel(&mut state, &output_tx);
+
+        // Popup should be closed
+        assert!(!state.show_ask_user_popup);
+
+        // Should have sent cancelled response
+        let event = output_rx.try_recv().unwrap();
+        match event {
+            OutputEvent::AskUserResponse(result) => {
+                assert_eq!(result.status, ToolCallResultStatus::Cancelled);
+                // Result should be valid JSON
+                let parsed: AskUserResult = serde_json::from_str(&result.result).unwrap();
+                assert!(!parsed.completed);
+                assert!(parsed.reason.is_some());
+                assert!(parsed.reason.unwrap().contains("cancelled"));
+            }
+            _ => panic!("Expected AskUserResponse event"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_quick_select() {
+        let mut state = create_test_state();
+        let questions = create_test_questions();
+        let tool_call = create_test_tool_call();
+        let (output_tx, _output_rx) = mpsc::channel(10);
+
+        handle_show_ask_user_popup(&mut state, tool_call, questions);
+
+        // Quick select option 2 (index 1 = "prod")
+        handle_ask_user_quick_select(&mut state, 2, &output_tx);
+
+        // Should have selected and submitted
+        assert!(state.ask_user_answers.contains_key("env"));
+        let answer = &state.ask_user_answers["env"];
+        assert_eq!(answer.answer, "prod");
+    }
+
+    #[tokio::test]
+    async fn test_quick_select_custom_just_focuses() {
+        let mut state = create_test_state();
+        let questions = create_test_questions();
+        let tool_call = create_test_tool_call();
+        let (output_tx, _output_rx) = mpsc::channel(10);
+
+        handle_show_ask_user_popup(&mut state, tool_call, questions);
+
+        // Quick select option 3 (custom option)
+        handle_ask_user_quick_select(&mut state, 3, &output_tx);
+
+        // Should just focus, not submit (need to type first)
+        assert!(!state.ask_user_answers.contains_key("env"));
+        assert_eq!(state.ask_user_selected_option, 2); // Custom option
+    }
+
+    #[tokio::test]
+    async fn test_handlers_no_op_when_popup_not_visible() {
+        let mut state = create_test_state();
+        let (output_tx, _output_rx) = mpsc::channel::<OutputEvent>(10);
+
+        // All these should be no-ops when popup is not visible
+        handle_ask_user_next_tab(&mut state);
+        handle_ask_user_prev_tab(&mut state);
+        handle_ask_user_next_option(&mut state);
+        handle_ask_user_prev_option(&mut state);
+        handle_ask_user_select_option(&mut state, &output_tx);
+        handle_ask_user_custom_input_changed(&mut state, 'x');
+        handle_ask_user_custom_input_backspace(&mut state);
+        handle_ask_user_custom_input_delete(&mut state);
+        handle_ask_user_submit(&mut state, &output_tx);
+        handle_ask_user_cancel(&mut state, &output_tx);
+
+        // State should be unchanged
+        assert!(!state.show_ask_user_popup);
+        assert!(state.ask_user_questions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_option_navigation_on_submit_tab_no_op() {
+        let mut state = create_test_state();
+        let questions = create_test_questions();
+        let tool_call = create_test_tool_call();
+
+        handle_show_ask_user_popup(&mut state, tool_call, questions);
+
+        // Navigate to Submit tab
+        state.ask_user_current_tab = 2;
+
+        // Option navigation should be no-op on Submit tab
+        handle_ask_user_next_option(&mut state);
+        assert_eq!(state.ask_user_selected_option, 0);
+
+        handle_ask_user_prev_option(&mut state);
+        assert_eq!(state.ask_user_selected_option, 0);
+    }
+}

--- a/tui/src/services/message.rs
+++ b/tui/src/services/message.rs
@@ -2193,6 +2193,21 @@ pub fn extract_truncated_command_arguments(tool_call: &ToolCall, sign: Option<St
         return format!("{}{} ({} tools)", desc, sandbox_tag, tools_count);
     }
 
+    // For ask_user, show question labels
+    if tool_name == "ask_user"
+        && let Ok(ref args) = arguments
+        && let Some(questions) = args.get("questions").and_then(|v| v.as_array())
+    {
+        let labels: Vec<&str> = questions
+            .iter()
+            .filter_map(|q| q.get("label").and_then(|l| l.as_str()))
+            .collect();
+        if !labels.is_empty() {
+            return format!("questions: {}", labels.join(", "));
+        }
+        return format!("{} question(s)", questions.len());
+    }
+
     const KEYWORDS: [&str; 6] = ["path", "file", "uri", "url", "command", "keywords"];
 
     if let Ok(arguments) = arguments {
@@ -2482,6 +2497,7 @@ pub fn get_command_type_name(tool_call: &ToolCall) -> String {
                 format!("Subagent: {}", desc)
             }
         }
+        "ask_user" => "Ask User".to_string(),
         _ => {
             // Convert function name to title case
             crate::utils::strip_tool_name(&tool_call.function.name)

--- a/tui/src/services/mod.rs
+++ b/tui/src/services/mod.rs
@@ -1,4 +1,5 @@
 pub mod approval_bar;
+pub mod ask_user_popup;
 pub mod auto_approve;
 pub mod bash_block;
 pub mod board_tasks;


### PR DESCRIPTION
## Summary

Implements an interactive `ask_user` tool that allows the LLM to ask users structured questions with predefined options and optional custom input. This enables better UX for gathering user preferences, clarifying requirements, and making decisions during agent execution.

## Features

### User Experience
- **Multi-question support** — Navigate between questions using Tab or arrow keys
- **Predefined options** — Each option has a value (returned to LLM), label (displayed), and optional description
- **Custom text input** — Optionally allow users to type their own answer
- **Required vs optional** — Questions can be marked as required; submit is blocked until all required questions are answered
- **Quick-select** — Press 1-9 to quickly select an option
- **Auto-approve** — The `ask_user` tool bypasses normal tool approval (asking to approve a question before asking it would be redundant)

### Technical
- **JSON response format** — Structured `AskUserResult` with `answers`, `completed`, and `reason` fields for reliable LLM parsing
- **Graceful headless fallback** — Returns `INTERACTIVE_REQUIRED` error in async/headless mode
- **UTF-8 safe** — All string truncation uses char-based slicing, not byte indices

## Demo

```
┌─────────────────────────────────────────────────────────────────────────────────┐
│ ← □ Environment   □ Confirm   ✓ Submit →                                        │
├─────────────────────────────────────────────────────────────────────────────────┤
│                                                                                 │
│ Which environment should I deploy to?                                           │
│                                                                                 │
│ › 1. Development                                                                │
│      For testing changes                                                        │
│                                                                                 │
│   2. Production                                                                 │
│      Live environment                                                           │
│                                                                                 │
│   3. Type something...                                                          │
│                                                                                 │
├─────────────────────────────────────────────────────────────────────────────────┤
│ Enter select · ↑/↓ options · ←/→ questions · 1-9 quick select · Esc cancel      │
└─────────────────────────────────────────────────────────────────────────────────┘
```

## Tool Schema

```json
{
  "questions": [
    {
      "id": "env",
      "label": "Environment",
      "question": "Which environment should I deploy to?",
      "options": [
        {"value": "dev", "label": "Development", "description": "For testing"},
        {"value": "prod", "label": "Production", "description": "Live environment"}
      ],
      "allow_custom": true,
      "required": true
    }
  ]
}
```

## Response Format

```json
{
  "answers": [
    {"question_id": "env", "answer": "dev", "is_custom": false}
  ],
  "completed": true,
  "reason": null
}
```

## Files Changed

| File | Purpose |
|------|---------|
| `libs/mcp/server/src/local_tools.rs` | MCP tool definition with schema |
| `libs/shared/src/models/integrations/openai.rs` | Data types (`AskUserQuestion`, `AskUserOption`, `AskUserAnswer`, `AskUserResult`) |
| `tui/src/services/ask_user_popup.rs` | TUI popup component (ratatui) |
| `tui/src/services/handlers/ask_user.rs` | Event handlers and state management |
| `tui/src/app.rs` | AppState fields for popup state |
| `tui/src/app/events.rs` | Input/Output event variants |
| `tui/src/services/handlers/mod.rs` | Event routing to ask_user handlers |
| `tui/src/services/message.rs` | Tool call display formatting |
| `tui/src/view.rs` | Popup rendering integration |
| `cli/src/commands/agent/run/mode_interactive.rs` | Agent loop integration + auto-approve |

## Testing

**28 tests added:**

- **11 serialization tests** (`libs/shared`) — Round-trip serialization, default values, Unicode handling
- **17 handler tests** (`tui`) — Navigation, selection, submit/cancel, edge cases

```
cargo test --package stakpak-shared --package stakpak-tui --lib -- ask_user

test result: ok. 28 passed; 0 failed; 0 ignored
```

## Use Cases

- Gathering deployment preferences (environment, region, replicas)
- Clarifying ambiguous instructions before executing
- Getting user confirmation for risky operations
- Collecting configuration choices during setup wizards
- Any scenario where the LLM needs structured input from the user