### PR TITLE
fix(ci): re-enable aarch64 musl build with clang for jemalloc C11 atomics

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -89,6 +89,16 @@ jobs:
         if: endsWith(matrix.target, 'linux-musl') && !matrix.docker
         run: sudo apt-get update && sudo apt-get install -y musl-tools
 
+      - name: Docker cargo cache
+        if: matrix.docker
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo-docker/registry
+            ~/.cargo-docker/git
+          key: docker-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: docker-cargo-${{ matrix.target }}-
+
       # Alpine Linux is musl-native — GCC has full C11 atomics support
       # without the broken musl-gcc wrapper that Ubuntu's musl-tools uses.
       # This is the same approach Turso uses for libsql aarch64-musl builds.
@@ -101,6 +111,8 @@ jobs:
             --user 0:0
             -v ${{ github.workspace }}:/build
             -w /build
+            -v /home/runner/.cargo-docker/registry:/usr/local/cargo/registry
+            -v /home/runner/.cargo-docker/git:/usr/local/cargo/git
           run: |
             apk add --no-cache gcc musl-dev
             cargo build --release --target ${{ matrix.target }} ${{ matrix.features }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,6 +28,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Docker cargo cache
+        if: matrix.docker
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo-docker/registry
+            ~/.cargo-docker/git
+          key: docker-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: docker-cargo-${{ matrix.target }}-
+
       # Alpine Linux is musl-native — GCC has full C11 atomics support
       # without the broken musl-gcc wrapper that Ubuntu's musl-tools uses.
       - name: Build and test in Alpine container
@@ -39,6 +49,8 @@ jobs:
             --user 0:0
             -v ${{ github.workspace }}:/build
             -w /build
+            -v /home/runner/.cargo-docker/registry:/usr/local/cargo/registry
+            -v /home/runner/.cargo-docker/git:/usr/local/cargo/git
           run: |
             apk add --no-cache gcc musl-dev
             cargo build --release --target ${{ matrix.target }} ${{ matrix.features }}


### PR DESCRIPTION
## Description

Re-enables the aarch64 Linux musl build that was disabled due to jemalloc 5.3.0 failing to compile. The root cause was `musl-gcc` using `-nostdinc` which hides GCC's `<stdatomic.h>`, so jemalloc's configure couldn't detect C11 atomics.

## Changes Made

- **Use `CC=clang` for musl builds** — clang ships built-in `<stdatomic.h>` support, completely avoiding the musl-gcc header stripping issue
- **Replace dynamic bash conditionals with matrix variables** — `features` and `cc` are now declared per matrix entry instead of computed via `if [[ *linux-musl* ]]` shell checks, eliminating platform-specific shell code from the build step
- **Re-enable `aarch64-unknown-linux-musl`** in the build matrix on `ubuntu-22.04-arm`
- **Add `stakpak-linux-aarch64`** artifact to release uploads
- **Add `build-test.yml`** — a lightweight workflow (manual dispatch + PR trigger) for testing aarch64 musl builds in isolation

## Testing

- [ ] Run `build-test.yml` via workflow_dispatch to validate aarch64 musl + jemalloc + clang compiles
- [ ] Verify x86_64 musl build still passes (also uses clang now)
- [ ] Verify macOS and Windows builds are unaffected (no `features`/`cc` matrix vars)

## Breaking Changes

None