### PR TITLE
fix: add gke-gcloud-auth-plugin to gcloud wrapper & remove predefined schedule tiers from init prompt

### DIFF
--- a/scripts/gcloud-wrapper.sh
+++ b/scripts/gcloud-wrapper.sh
@@ -25,6 +25,9 @@ if [[ ! -x "$GCLOUD_BIN" ]]; then
     
     "$GCLOUD_DIR/install.sh" --quiet --usage-reporting=false --path-update=false --command-completion=false
     
+    # gke-gcloud-auth-plugin is required for kubectl to authenticate with GKE clusters
+    "$GCLOUD_BIN" components install gke-gcloud-auth-plugin --quiet
+    
     echo "✅ Google Cloud CLI installed successfully" >&2
 fi
 


### PR DESCRIPTION
## Changes

### 1. gcloud wrapper: install `gke-gcloud-auth-plugin` (`scripts/gcloud-wrapper.sh`)

`kubectl` needs `gke-gcloud-auth-plugin` to authenticate with GKE clusters. The wrapper was installing the gcloud SDK but not the auth plugin, causing failures when sandboxed subagents tried to run `kubectl` commands against GKE.

Added `gcloud components install gke-gcloud-auth-plugin --quiet` to the first-use install flow.

**Tested:** Built the container image and ran `gcloud version` inside it — plugin installs cleanly (v0.5.11) alongside the SDK.

### 2. init.v3.md: replace predefined schedule tiers with discovery-driven approach

The old Tier 1/Tier 2 schedule tables (health-check every 15min, backup-verify daily at 6am, plus 10 templated Tier 2 schedules) were too prescriptive. The agent would propose the same generic schedules regardless of what it actually discovered.

**Before:** Pick from a menu of predefined schedules with hardcoded cron expressions and "When to Propose" conditions.

**After:** Agent analyzes its discovery findings through 5 lenses (critical, fragile, drifting, expiring, invisible) and designs schedules tailored to the specific environment. Each proposed schedule must reference a concrete finding and justify its frequency.

Only `apps-refresh` remains as a mandatory schedule (APPS.md must stay current).