### PR TITLE
fix(tui): allow typing numbers in AskUser custom input

### DIFF
--- a/tui/src/services/bash_block.rs
+++ b/tui/src/services/bash_block.rs
@@ -2797,9 +2797,6 @@ pub fn render_ask_user_block(
                     Span::styled("←/→", Style::default().fg(Color::DarkGray)),
                     Span::styled(" questions", Style::default().fg(Color::Cyan)),
                     Span::raw(" · "),
-                    Span::styled("1-9", Style::default().fg(Color::DarkGray)),
-                    Span::styled(" quick", Style::default().fg(Color::Cyan)),
-                    Span::raw(" · "),
                     Span::styled("Tab", Style::default().fg(Color::DarkGray)),
                     Span::styled(" scroll", Style::default().fg(Color::Cyan)),
                 ]

--- a/tui/src/services/handlers/mod.rs
+++ b/tui/src/services/handlers/mod.rs
@@ -252,12 +252,6 @@ pub fn update(
                     return;
                 }
                 InputEvent::InputChanged(c) => {
-                    if let Some(num) = c.to_digit(10)
-                        && (1..=9).contains(&num)
-                    {
-                        ask_user::handle_ask_user_quick_select(state, num as usize, output_tx);
-                        return;
-                    }
                     if ask_user::is_custom_input_selected(state) {
                         ask_user::handle_ask_user_custom_input_changed(state, c);
                     }


### PR DESCRIPTION
## Summary

- Remove the 1-9 quick select shortcuts from the AskUser popup
- Users can now type numbers freely in the custom input field

## Problem

When the AskUser popup appeared with a custom input option, users couldn't type numbers (0-9) because the number keys were being captured as keyboard shortcuts for quick-selecting options instead of being treated as text input.

## Solution

Remove the quick select feature entirely since it was blocking normal text input. Users can still navigate options using arrow keys and select with Enter.

## Changes

- `tui/src/services/handlers/mod.rs` - Remove quick select logic from InputChanged handler
- `tui/src/services/handlers/ask_user.rs` - Remove `handle_ask_user_quick_select` function and tests
- `tui/src/services/bash_block.rs` - Remove "1-9 quick" hint from popup footer