### PR TITLE
fix(tui): clear stuck text selection on Escape key press

### DIFF
--- a/tui/src/services/handlers/dialog.rs
+++ b/tui/src/services/handlers/dialog.rs
@@ -9,6 +9,7 @@ use crate::services::message::extract_truncated_command_arguments;
 use crate::services::message::{
     Message, MessageContent, get_command_type_name, invalidate_message_lines_cache,
 };
+use crate::services::text_selection::SelectionState;
 use ratatui::layout::Size;
 use ratatui::style::Color;
 use stakpak_shared::models::integrations::openai::ToolCall;
@@ -94,6 +95,11 @@ pub fn handle_esc_event(
     _shell_tx: &Sender<InputEvent>,
     cancel_tx: Option<tokio::sync::broadcast::Sender<()>>,
 ) {
+    // Always clear text selection on Escape (prevents stuck selections)
+    if state.selection.active {
+        state.selection = SelectionState::default();
+    }
+
     if state.show_rulebook_switcher {
         state.show_rulebook_switcher = false;
         return;

--- a/tui/src/services/handlers/popup.rs
+++ b/tui/src/services/handlers/popup.rs
@@ -9,6 +9,7 @@ use crate::services::helper_block::{push_error_message, push_styled_message, wel
 use crate::services::message::{
     Message, get_wrapped_collapsed_message_lines_cached, invalidate_message_lines_cache,
 };
+use crate::services::text_selection::SelectionState;
 use ratatui::style::{Color, Style};
 use stakai::Model;
 use stakpak_api::models::ListRuleBook;
@@ -970,6 +971,9 @@ pub fn handle_message_action_popup_close(state: &mut AppState) {
     state.message_action_popup_position = None;
     state.message_action_target_message_id = None;
     state.message_action_target_text = None;
+    // Clear any stuck text selection (popup may have intercepted drag end)
+    state.selection = SelectionState::default();
+    state.text_area.clear_selection();
 }
 
 /// Navigate within the message action popup


### PR DESCRIPTION
## Summary

- Fix bug where text selection could get stuck with no way to clear it
- Escape key now always clears any active text selection before handling other actions

## Problem

Text selection could become stuck when:
1. Drag end events were intercepted by popups (e.g., message action popup)
2. No keyboard shortcut existed to clear selection

## Solution

- Clear selection at the top of `handle_esc_event` (before popup checks)
- Clear selection when message action popup closes (handles intercepted drag events)

This ensures a single Escape press both clears selection and performs normal actions (close popups, reject tools, etc.).