### PR TITLE
fix(warden): use exact match for volume dedup to preserve workdir mount

### DIFF
--- a/libs/mcp/server/src/subagent_tools.rs
+++ b/libs/mcp/server/src/subagent_tools.rs
@@ -141,7 +141,10 @@ TOOL SELECTION (least-privilege):
 
 SANDBOX MODE (enable_sandbox=true):
 - Runs subagent in isolated Docker container via warden
-- Read-only access to working directory and cloud credentials
+- The host working directory is bind-mounted read-only at /agent inside the container
+  (the subagent's CWD will be /agent, not the original host path — use relative paths or /agent/...)
+- Cloud credentials (~/.aws, ~/.kube, ~/.ssh, etc.) are mounted under /home/agent/
+- .stakpak session data is mounted writable at /agent/.stakpak
 - Recommended when using run_command tool for untrusted operations
 - Adds ~5-10s startup overhead for container initialization
 - IMPORTANT: Sandbox subagents run AUTONOMOUSLY to completion without pausing for tool approval


### PR DESCRIPTION
## Problem

`prepare_volumes()` used `v.contains(container_path)` for dedup — a substring match. The container path `/agent` matched inside `/home/agent/...` paths, silently dropping `./:/agent:ro` and `./.stakpak:/agent/.stakpak` from every sandbox container.

**Result:** Sandboxed subagents had no access to the working directory — `/agent` was empty except for the overlay config mount.

## Fix

Compare extracted container-side paths with exact equality instead of substring matching:

```rust
// Before (broken): substring match
volumes_to_mount.iter().any(|v| v.contains(container_path))

// After (fixed): exact match on container-side path
volumes_to_mount.iter().any(|v| v.split(':').nth(1).unwrap_or(v) == container_path)
```

## Tests

4 regression tests added that fail before the fix and pass after:
- `workdir_mount_present_when_no_warden_config`
- `stakpak_session_mount_present_when_no_warden_config`
- `workdir_mount_not_dropped_by_home_agent_paths`
- `workdir_mount_deduped_when_profile_provides_it`
