### PR TITLE
fix(db): add SQLite WAL pragmas to ScheduleDb and GatewayStore

### DIFF
--- a/cli/src/commands/watch/db.rs
+++ b/cli/src/commands/watch/db.rs
@@ -144,13 +144,14 @@ impl ScheduleDb {
 
     async fn configure_pragmas(&self) -> Result<(), DbError> {
         let conn = self.connection()?;
-        conn.execute("PRAGMA journal_mode = WAL", ())
+        // journal_mode returns a result row, so use query() instead of execute()
+        conn.query("PRAGMA journal_mode = WAL", ())
             .await
             .map_err(|e| DbError::Query(format!("Failed to set journal_mode: {}", e)))?;
-        conn.execute("PRAGMA busy_timeout = 5000", ())
+        conn.query("PRAGMA busy_timeout = 5000", ())
             .await
             .map_err(|e| DbError::Query(format!("Failed to set busy_timeout: {}", e)))?;
-        conn.execute("PRAGMA synchronous = NORMAL", ())
+        conn.query("PRAGMA synchronous = NORMAL", ())
             .await
             .map_err(|e| DbError::Query(format!("Failed to set synchronous: {}", e)))?;
         Ok(())

--- a/libs/gateway/src/store.rs
+++ b/libs/gateway/src/store.rs
@@ -62,13 +62,14 @@ impl GatewayStore {
 
     async fn configure_pragmas(&self) -> Result<()> {
         let conn = self.connection()?;
-        conn.execute("PRAGMA journal_mode = WAL", ())
+        // journal_mode returns a result row, so use query() instead of execute()
+        conn.query("PRAGMA journal_mode = WAL", ())
             .await
             .context("failed to set journal_mode")?;
-        conn.execute("PRAGMA busy_timeout = 5000", ())
+        conn.query("PRAGMA busy_timeout = 5000", ())
             .await
             .context("failed to set busy_timeout")?;
-        conn.execute("PRAGMA synchronous = NORMAL", ())
+        conn.query("PRAGMA synchronous = NORMAL", ())
             .await
             .context("failed to set synchronous")?;
         Ok(())


### PR DESCRIPTION
## Description

Add SQLite performance and reliability pragmas to both database stores used by autopilot.

## Changes Made

### SQLite WAL Pragmas (`ScheduleDb` + `GatewayStore`)
- **`journal_mode = WAL`** — enables concurrent reads during writes, preventing SQLITE_BUSY in the per-operation connection architecture
- **`busy_timeout = 5000`** — retries for up to 5s on lock contention instead of failing immediately
- **`synchronous = NORMAL`** — safe with WAL mode, reduces fsync overhead on writes
- Pragmas are configured before schema init/migrations in both stores

## Testing
- [x] All code compiles (`cargo check`)
- [x] No clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)

## Breaking Changes
None