### PR TITLE
perf(ci): cache Docker target dir in build-and-release workflow

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -99,6 +99,14 @@ jobs:
           key: docker-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: docker-cargo-${{ matrix.target }}-
 
+      - name: Docker build cache (target dir)
+        if: matrix.docker
+        uses: actions/cache@v4
+        with:
+          path: target/
+          key: docker-target-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: docker-target-${{ matrix.target }}-
+
       # Alpine is required for aarch64-musl: Ubuntu's musl-gcc wrapper lacks
       # C11 atomics support needed by jemalloc and libsql-ffi on ARM.
       - name: Build and test in Alpine container


### PR DESCRIPTION
## Summary
- Add a second actions/cache step for the target directory in build-and-release workflow when docker matrix jobs run.
- Cache keys include target triple and Cargo.lock hash, with a target-specific restore prefix.

## Why
Docker matrix jobs were restoring Cargo registry/git caches but still recompiling artifacts from scratch. Caching target reduces redundant compile time.

## Testing
- Workflow YAML change only (no Rust source changes).
- Verified commit includes only .github/workflows/build-and-release.yml.