### PR TITLE
feat(tui): enable text selection and copy in collapsed messages popup

### DIFF
--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -251,6 +251,11 @@ pub struct AppState {
     pub message_area_height: u16, // Height of message area (set during render for accurate event handling)
     pub hover_row: Option<u16>,   // Current mouse hover row for debugging
 
+    // ========== Collapsed Popup Geometry (for text selection in fullscreen popup) ==========
+    pub collapsed_popup_area_y: u16, // Y offset of popup content area
+    pub collapsed_popup_area_x: u16, // X offset of popup content area
+    pub collapsed_popup_area_height: u16, // Height of popup content area
+
     // ========== Input Area State ==========
     /// Stores the input area content rect for mouse click positioning
     pub input_content_area: Option<ratatui::layout::Rect>,
@@ -563,6 +568,10 @@ impl AppState {
             message_area_x: 0,
             message_area_height: 0,
             hover_row: None,
+
+            collapsed_popup_area_y: 0,
+            collapsed_popup_area_x: 0,
+            collapsed_popup_area_height: 0,
 
             // Profile switcher initialization
             show_profile_switcher: false,

--- a/tui/src/services/handlers/dialog.rs
+++ b/tui/src/services/handlers/dialog.rs
@@ -120,6 +120,7 @@ pub fn handle_esc_event(
     }
     if state.show_collapsed_messages {
         state.show_collapsed_messages = false;
+        state.selection = crate::services::text_selection::SelectionState::default();
         return;
     }
 
@@ -171,6 +172,7 @@ pub fn handle_esc(
     state.is_streaming = false;
     if state.show_collapsed_messages {
         state.show_collapsed_messages = false;
+        state.selection = crate::services::text_selection::SelectionState::default();
     } else if state.show_helper_dropdown {
         state.show_helper_dropdown = false;
     } else if state.is_dialog_open {

--- a/tui/src/services/handlers/mod.rs
+++ b/tui/src/services/handlers/mod.rs
@@ -1280,8 +1280,12 @@ pub fn update(
         }
         InputEvent::ApprovalPopupSubmit => {}
         InputEvent::MouseClick(col, row) | InputEvent::MouseDragStart(col, row) => {
-            // Check if click is on file changes popup first
-            if state.show_file_changes_popup {
+            if state.show_collapsed_messages {
+                // When collapsed popup is open, route directly to text selection
+                // (which handles popup geometry internally)
+                text_selection::handle_drag_start(state, col, row);
+            } else if state.show_file_changes_popup {
+                // Check if click is on file changes popup first
                 popup::handle_file_changes_popup_mouse_click(state, col, row);
             } else {
                 // Try side panel click first, then start text selection if in message area

--- a/tui/src/services/handlers/popup.rs
+++ b/tui/src/services/handlers/popup.rs
@@ -442,6 +442,10 @@ pub fn handle_toggle_collapsed_messages(
     message_area_height: usize,
     message_area_width: usize,
 ) {
+    // Clear any active text selection when toggling the popup
+    // (prevents stale selection from one context bleeding into the other)
+    state.selection = crate::services::text_selection::SelectionState::default();
+
     // Handle collapsed messages popup
     state.show_collapsed_messages = !state.show_collapsed_messages;
     if state.show_collapsed_messages {

--- a/tui/src/services/handlers/text_selection.rs
+++ b/tui/src/services/handlers/text_selection.rs
@@ -10,7 +10,9 @@
 
 use crate::app::AppState;
 use crate::services::message_action_popup::find_user_message_at_line;
-use crate::services::text_selection::{SelectionState, copy_to_clipboard, extract_selected_text};
+use crate::services::text_selection::{
+    SelectionState, copy_to_clipboard, extract_selected_text, extract_selected_text_from_collapsed,
+};
 use crate::services::toast::Toast;
 
 /// Check if coordinates are within the input area
@@ -32,8 +34,19 @@ fn content_col(state: &AppState, terminal_col: u16) -> u16 {
     terminal_col.saturating_sub(state.message_area_x)
 }
 
-/// Handle mouse drag start - begins text selection in message area or input area
+/// Convert terminal column to content-relative column within the collapsed popup area.
+fn popup_content_col(state: &AppState, terminal_col: u16) -> u16 {
+    terminal_col.saturating_sub(state.collapsed_popup_area_x)
+}
+
+/// Handle mouse drag start - begins text selection in message area, input area, or collapsed popup
 pub fn handle_drag_start(state: &mut AppState, col: u16, row: u16) {
+    // When collapsed messages popup is open, use popup geometry for selection
+    if state.show_collapsed_messages {
+        handle_popup_drag_start(state, col, row);
+        return;
+    }
+
     // Use the accurate message_area_height from the last render
     let message_area_height = state.message_area_height as usize;
 
@@ -91,8 +104,38 @@ pub fn handle_drag_start(state: &mut AppState, col: u16, row: u16) {
     };
 }
 
-/// Handle mouse drag - updates selection in message area or input area
+/// Handle drag start within the collapsed messages fullscreen popup
+fn handle_popup_drag_start(state: &mut AppState, col: u16, row: u16) {
+    let popup_height = state.collapsed_popup_area_height as usize;
+
+    // Check if click is within the popup content area
+    let row_in_popup = (row as usize).saturating_sub(state.collapsed_popup_area_y as usize);
+    if row < state.collapsed_popup_area_y || row_in_popup >= popup_height {
+        state.selection = SelectionState::default();
+        return;
+    }
+
+    // Convert screen row to absolute line index using popup's own scroll
+    let absolute_line = state.collapsed_messages_scroll + row_in_popup;
+    let rel_col = popup_content_col(state, col);
+
+    state.selection = SelectionState {
+        active: true,
+        start_line: Some(absolute_line),
+        start_col: Some(rel_col),
+        end_line: Some(absolute_line),
+        end_col: Some(rel_col),
+    };
+}
+
+/// Handle mouse drag - updates selection in message area, input area, or collapsed popup
 pub fn handle_drag(state: &mut AppState, col: u16, row: u16) {
+    // When collapsed messages popup is open, use popup geometry
+    if state.show_collapsed_messages {
+        handle_popup_drag(state, col, row);
+        return;
+    }
+
     // Use the accurate message_area_height from the last render
     let message_area_height = state.message_area_height as usize;
 
@@ -136,9 +179,35 @@ pub fn handle_drag(state: &mut AppState, col: u16, row: u16) {
     state.selection.end_col = Some(rel_col);
 }
 
+/// Handle drag within the collapsed messages fullscreen popup
+fn handle_popup_drag(state: &mut AppState, col: u16, row: u16) {
+    if !state.selection.active {
+        return;
+    }
+
+    let popup_height = state.collapsed_popup_area_height as usize;
+
+    // Clamp row to popup content area
+    let row_in_popup = (row as usize).saturating_sub(state.collapsed_popup_area_y as usize);
+    let clamped_row = row_in_popup.min(popup_height.saturating_sub(1));
+
+    // Convert screen row to absolute line index using popup's own scroll
+    let absolute_line = state.collapsed_messages_scroll + clamped_row;
+    let rel_col = popup_content_col(state, col);
+
+    state.selection.end_line = Some(absolute_line);
+    state.selection.end_col = Some(rel_col);
+}
+
 /// Handle mouse drag end - extracts text, copies to clipboard, shows toast
 /// Also detects clicks on user messages to show action popup
 pub fn handle_drag_end(state: &mut AppState, col: u16, row: u16) {
+    // When collapsed messages popup is open, use popup-specific logic
+    if state.show_collapsed_messages {
+        handle_popup_drag_end(state, col, row);
+        return;
+    }
+
     // Check if we're ending an input area selection
     if state.text_area.selection.is_active() {
         if let Some(selected_text) = state.text_area.end_selection()
@@ -221,6 +290,54 @@ pub fn handle_drag_end(state: &mut AppState, col: u16, row: u16) {
     }
 }
 
+/// Handle drag end within the collapsed messages fullscreen popup
+fn handle_popup_drag_end(state: &mut AppState, col: u16, row: u16) {
+    if !state.selection.active {
+        return;
+    }
+
+    // Update final position using popup geometry
+    handle_popup_drag(state, col, row);
+
+    // Check if this was just a click (no actual drag)
+    let is_just_click = match (
+        &state.selection.start_line,
+        &state.selection.end_line,
+        &state.selection.start_col,
+        &state.selection.end_col,
+    ) {
+        (Some(sl), Some(el), Some(sc), Some(ec)) => *sl == *el && *sc == *ec,
+        _ => true,
+    };
+
+    if is_just_click {
+        // In the popup, a click just clears selection (no message action popup)
+        state.selection = SelectionState::default();
+        return;
+    }
+
+    // Extract selected text from the collapsed message lines cache
+    let selected_text = extract_selected_text_from_collapsed(state);
+
+    // Clear selection
+    state.selection = SelectionState::default();
+
+    if selected_text.is_empty() {
+        return;
+    }
+
+    // Copy to clipboard
+    match copy_to_clipboard(&selected_text) {
+        Ok(()) => {
+            state.toast = Some(Toast::success("Copied!"));
+        }
+        Err(e) => {
+            log::warn!("Failed to copy to clipboard: {}", e);
+            state.toast = Some(Toast::error("Copy failed"));
+        }
+    }
+}
+
 /// Handle scroll during active selection - extends selection in scroll direction
 pub fn handle_scroll_during_selection(
     state: &mut AppState,
@@ -236,6 +353,20 @@ pub fn handle_scroll_during_selection(
         return;
     };
 
+    // Choose the correct cache depending on whether the collapsed popup is open
+    let cached_lines: Option<&Vec<ratatui::text::Line<'static>>> = if state.show_collapsed_messages
+    {
+        state
+            .collapsed_message_lines_cache
+            .as_ref()
+            .map(|(_, _, lines)| lines)
+    } else {
+        state
+            .assembled_lines_cache
+            .as_ref()
+            .map(|(_, lines, _)| lines)
+    };
+
     // Calculate new end line based on scroll direction
     let new_end_line = if direction < 0 {
         // Scrolling up - extend selection upward
@@ -243,10 +374,8 @@ pub fn handle_scroll_during_selection(
     } else {
         // Scrolling down - extend selection downward
         // Get total lines from cache to clamp
-        let max_line = state
-            .assembled_lines_cache
-            .as_ref()
-            .map(|(_, lines, _)| lines.len().saturating_sub(1))
+        let max_line = cached_lines
+            .map(|lines| lines.len().saturating_sub(1))
             .unwrap_or(end_line);
         (end_line + 1).min(max_line)
     };
@@ -255,10 +384,10 @@ pub fn handle_scroll_during_selection(
 
     // Update end column to end of line when extending via scroll
     // This gives a better selection experience
-    if let Some((_, cached_lines, _)) = &state.assembled_lines_cache
-        && new_end_line < cached_lines.len()
+    if let Some(lines) = cached_lines
+        && new_end_line < lines.len()
     {
-        let line_width: u16 = cached_lines[new_end_line]
+        let line_width: u16 = lines[new_end_line]
             .spans
             .iter()
             .map(|span| unicode_width::UnicodeWidthStr::width(span.content.as_ref()) as u16)

--- a/tui/src/services/text_selection.rs
+++ b/tui/src/services/text_selection.rs
@@ -113,15 +113,9 @@ fn extract_text_from_line(line: &Line, start_col: u16, end_col: u16) -> String {
     result
 }
 
-/// Extract selected text from the assembled lines cache
-pub fn extract_selected_text(state: &AppState) -> String {
-    let Some((start_line, start_col, end_line, end_col)) = state.selection.normalized_bounds()
-    else {
-        return String::new();
-    };
-
-    // Get cached lines
-    let Some((_, cached_lines, _)) = &state.assembled_lines_cache else {
+/// Extract selected text from a slice of cached lines using the current selection bounds
+fn extract_selected_text_from_lines(selection: &SelectionState, cached_lines: &[Line]) -> String {
+    let Some((start_line, start_col, end_line, end_col)) = selection.normalized_bounds() else {
         return String::new();
     };
 
@@ -145,6 +139,13 @@ pub fn extract_selected_text(state: &AppState) -> String {
 
         let line_text = extract_text_from_line(line, col_start, col_end);
 
+        // Skip SPACING_MARKER lines (internal rendering markers that should be treated as empty)
+        let line_text = if line_text.trim() == "SPACING_MARKER" {
+            String::new()
+        } else {
+            line_text
+        };
+
         if !line_text.is_empty() {
             if !result.is_empty() {
                 result.push('\n');
@@ -163,6 +164,24 @@ pub fn extract_selected_text(state: &AppState) -> String {
         .map(|l| l.trim())
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+/// Extract selected text from the assembled lines cache (main message area)
+pub fn extract_selected_text(state: &AppState) -> String {
+    let Some((_, cached_lines, _)) = &state.assembled_lines_cache else {
+        return String::new();
+    };
+
+    extract_selected_text_from_lines(&state.selection, cached_lines)
+}
+
+/// Extract selected text from the collapsed message lines cache (fullscreen popup)
+pub fn extract_selected_text_from_collapsed(state: &AppState) -> String {
+    let Some((_, _, cached_lines)) = &state.collapsed_message_lines_cache else {
+        return String::new();
+    };
+
+    extract_selected_text_from_lines(&state.selection, cached_lines)
 }
 
 /// Calculate display width of a line

--- a/tui/src/view.rs
+++ b/tui/src/view.rs
@@ -584,6 +584,11 @@ fn render_collapsed_messages_content(f: &mut Frame, state: &mut AppState, area: 
     let width = area.width as usize;
     let height = area.height as usize;
 
+    // Store popup content area geometry for text selection coordinate mapping
+    state.collapsed_popup_area_y = area.y;
+    state.collapsed_popup_area_x = area.x;
+    state.collapsed_popup_area_height = area.height;
+
     // Messages are already owned, no need to clone
     let all_lines: Vec<Line> = get_wrapped_collapsed_message_lines_cached(state, width);
 
@@ -619,6 +624,11 @@ fn render_collapsed_messages_content(f: &mut Frame, state: &mut AppState, area: 
         state.collapsed_messages_scroll
     };
 
+    // Write the clamped scroll back to state so that event handlers (text selection,
+    // click detection) use the same scroll value that was used for rendering.
+    // This mirrors the pattern in render_messages() for state.scroll.
+    state.collapsed_messages_scroll = scroll;
+
     // Create visible lines
     let mut visible_lines = Vec::new();
     for i in 0..height {
@@ -629,6 +639,17 @@ fn render_collapsed_messages_content(f: &mut Frame, state: &mut AppState, area: 
             visible_lines.push(Line::from(""));
         }
     }
+
+    // Apply selection highlighting if active (same as render_messages)
+    let visible_lines = if state.selection.active {
+        crate::services::text_selection::apply_selection_highlight(
+            visible_lines,
+            &state.selection,
+            scroll,
+        )
+    } else {
+        visible_lines
+    };
 
     // NOTE: Don't use Paragraph::wrap() - lines are already pre-wrapped
     let message_widget = Paragraph::new(visible_lines);


### PR DESCRIPTION
Add mouse drag text selection support to the fullscreen collapsed messages popup (Ctrl+T). Previously, mouse events fell through to the main message area handlers, producing incorrect selection coordinates and extracting text from the wrong cache.

- Add popup content area geometry fields to AppState for coordinate mapping
- Add popup-aware branches to all selection handlers (drag start/drag/end/scroll)
- Use collapsed_message_lines_cache for text extraction in popup mode
- Apply selection highlighting during popup rendering
- Write back clamped scroll to state for consistent event handling
- Clear selection state when toggling/closing the popup
- Filter SPACING_MARKER lines during text extraction