### PR TITLE
fix: support paste in ask_user custom input and improve display on resume

### DIFF
--- a/tui/src/services/handlers/ask_user.rs
+++ b/tui/src/services/handlers/ask_user.rs
@@ -351,6 +351,23 @@ pub fn handle_ask_user_confirm_question(state: &mut AppState, output_tx: &Sender
     handle_ask_user_next_tab(state);
 }
 
+/// Handle pasted text for custom answer (bulk insert, single refresh)
+pub fn handle_ask_user_custom_input_paste(state: &mut AppState, text: &str) {
+    if !state.show_ask_user_popup {
+        return;
+    }
+
+    if state.ask_user_current_tab >= state.ask_user_questions.len() {
+        return;
+    }
+
+    let current_q = &state.ask_user_questions[state.ask_user_current_tab];
+    if current_q.allow_custom && state.ask_user_selected_option == current_q.options.len() {
+        state.ask_user_custom_input.push_str(text);
+        refresh_ask_user_block(state);
+    }
+}
+
 /// Handle character input for custom answer
 pub fn handle_ask_user_custom_input_changed(state: &mut AppState, c: char) {
     if !state.show_ask_user_popup {

--- a/tui/src/services/handlers/mod.rs
+++ b/tui/src/services/handlers/mod.rs
@@ -507,6 +507,15 @@ pub fn update(
                 return;
             }
 
+            // --- Paste: insert into custom input if selected ---
+            InputEvent::HandlePaste(text) => {
+                if is_custom {
+                    ask_user::handle_ask_user_custom_input_paste(state, &text);
+                }
+                // Always consume paste when popup is open (don't paste into chat)
+                return;
+            }
+
             // --- Scroll events always pass through ---
             InputEvent::ScrollUp
             | InputEvent::ScrollDown

--- a/tui/src/services/message.rs
+++ b/tui/src/services/message.rs
@@ -2453,6 +2453,12 @@ pub fn extract_truncated_command_arguments(tool_call: &ToolCall, sign: Option<St
 }
 
 pub fn extract_full_command_arguments(tool_call: &ToolCall) -> String {
+    let tool_name = strip_tool_name(&tool_call.function.name);
+
+    if tool_name == "ask_user" {
+        return "Ask user questions...".to_string();
+    }
+
     // First try to parse as valid JSON
     if let Ok(v) = serde_json::from_str::<Value>(&tool_call.function.arguments) {
         return format_json_value(&v);


### PR DESCRIPTION
## Summary

- **Paste support in ask_user custom input**: `HandlePaste` events were silently consumed by the catch-all arm when the ask_user popup was open, making it impossible to paste text into the "Type your own answer" field. Now paste is routed to a new bulk insert handler that appends the full string and refreshes once.
- **Fix `[object, object, object]` display on session resume**: When a pending `ask_user` tool call was shown in a pending border block (e.g. on session resume), `extract_full_command_arguments` would format the nested question objects via `format_simple_value`, which renders JSON objects as the literal string `"object"`. Now short-circuits to display `"Ask user questions..."` instead.

## Changes

| File | What |
|------|------|
| `tui/src/services/handlers/mod.rs` | Intercept `HandlePaste` in ask_user popup, route to custom input when selected |
| `tui/src/services/handlers/ask_user.rs` | Add `handle_ask_user_custom_input_paste()` for bulk string insert with single UI refresh |
| `tui/src/services/message.rs` | Early return `"Ask user questions..."` for `ask_user` in `extract_full_command_arguments()` |