### PR TITLE
fix: slash command filtering broken in external terminals

### DIFF
--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -457,7 +457,7 @@ impl AppState {
             show_helper_dropdown: false,
             helper_selected: 0,
             helper_scroll: 0,
-            filtered_helpers: helpers,
+            filtered_helpers: Vec::new(),
             filtered_files: Vec::new(),
             show_shortcuts: false,
             is_dialog_open: false,
@@ -861,7 +861,7 @@ impl AppState {
         });
     }
 
-    // --- NEW: Poll file_search results and update state ---
+    // --- Poll file_search results and update state (for @ file completion only) ---
     pub fn poll_file_search_results(&mut self) {
         if let Some(rx) = &mut self.file_search_rx {
             while let Ok(result) = rx.try_recv() {
@@ -878,22 +878,30 @@ impl AppState {
                     None
                 };
 
-                // Update filtered_helpers from async worker
-                self.filtered_helpers = result.filtered_helpers;
+                // NOTE: Slash command filtering (filtered_helpers) is now done synchronously
+                // in handle_input_changed / handle_input_backspace to avoid race conditions
+                // that caused buggy behavior in external terminals (iTerm2, Warp, etc.).
+                // The async worker still computes filtered_helpers but we ignore it here.
 
-                // Reset selection index if it's out of bounds
-                if !self.filtered_helpers.is_empty()
-                    && self.helper_selected >= self.filtered_helpers.len()
+                // Show dropdown for @ file triggers (slash command dropdown is managed synchronously)
+                let has_at_trigger =
+                    find_at_trigger(&result.input, result.cursor_position).is_some();
+                if has_at_trigger && !self.waiting_for_shell_input {
+                    self.show_helper_dropdown = true;
+                }
+                // If we have file results, reset selection if out of bounds
+                if !self.filtered_files.is_empty()
+                    && self.helper_selected >= self.filtered_files.len()
                 {
                     self.helper_selected = 0;
                 }
 
-                // Show dropdown if input is exactly '/' or if filtered_helpers is not empty and input starts with '/'
-                let has_at_trigger =
-                    find_at_trigger(&result.input, result.cursor_position).is_some();
-                self.show_helper_dropdown = (input_text.trim().starts_with('/'))
-                    || (!self.filtered_helpers.is_empty() && input_text.starts_with('/'))
-                    || (has_at_trigger && !self.waiting_for_shell_input);
+                // Don't overwrite show_helper_dropdown for slash commands —
+                // that state is already set synchronously by the input handlers.
+                // Only hide if input is completely empty (safety net).
+                if input_text.is_empty() {
+                    self.show_helper_dropdown = false;
+                }
             }
         }
     }

--- a/tui/src/services/handlers/input.rs
+++ b/tui/src/services/handlers/input.rs
@@ -277,8 +277,11 @@ pub fn handle_input_changed(state: &mut AppState, c: char, input_tx: &Sender<Inp
         }
         state.show_helper_dropdown = true;
         state.helper_scroll = 0;
+        // Synchronously filter slash commands — no async race condition
+        filter_helpers_sync(state);
     }
 
+    // Send input to async file_search worker for @ file completion only
     if let Some(tx) = &state.file_search_tx {
         let _ = tx.try_send((state.input().to_string(), state.cursor_position()));
     }
@@ -327,6 +330,8 @@ pub fn handle_input_backspace(state: &mut AppState) {
         }
         state.show_helper_dropdown = true;
         state.helper_scroll = 0;
+        // Synchronously filter slash commands — no async race condition
+        filter_helpers_sync(state);
     }
 
     // Hide dropdown if input is empty
@@ -468,12 +473,14 @@ fn handle_input_submitted(
         state.show_helper_dropdown = false;
     }
 
-    // Check if input starts with a known command that takes arguments
-    // This runs regardless of show_helper_dropdown state to handle cases like:
-    // - User types "/editor path/to/file" manually
-    // - User selects a file via @ dropdown, resulting in "/editor filename"
+    // Defense-in-depth: if the input starts with '/' try to match it as a slash command,
+    // even if the dropdown wasn't showing (e.g. text was pasted, or dropdown state got out
+    // of sync). This prevents slash commands from being sent as user messages.
     {
         let input = state.input().to_string();
+        let input_trimmed = input.trim();
+
+        // First check commands that take arguments
         let command_with_args: Option<&str> = if input.starts_with("/editor ") {
             Some("/editor")
         } else if input.starts_with("/toggle_auto_approve ") {
@@ -492,6 +499,27 @@ fn handle_input_submitted(
                 push_error_message(state, &e, None);
             }
             return;
+        }
+
+        // Then check if input exactly matches a known slash command (no args)
+        if input_trimmed.starts_with('/') {
+            let matched_command = state
+                .helpers
+                .iter()
+                .find(|h| h.command == input_trimmed)
+                .map(|h| h.command);
+
+            if let Some(command_id) = matched_command {
+                let ctx = CommandContext {
+                    state,
+                    input_tx,
+                    output_tx,
+                };
+                if let Err(e) = execute_command(command_id, ctx) {
+                    push_error_message(state, &e, None);
+                }
+                return;
+            }
         }
     }
 
@@ -851,6 +879,23 @@ pub fn handle_paste(state: &mut AppState, pasted: String) -> bool {
         state.text_area.insert_str(&redacted_pasted);
     }
 
+    // After paste, update slash command filtering synchronously so dropdown reflects
+    // pasted content (e.g. pasting "/model" should show the dropdown immediately)
+    if state.input().starts_with('/') {
+        if state.file_search.is_active() {
+            state.file_search.reset();
+        }
+        state.show_helper_dropdown = true;
+        state.helper_scroll = 0;
+        filter_helpers_sync(state);
+    } else {
+        // Input doesn't start with '/' (or is empty) — dismiss slash command dropdown
+        state.show_helper_dropdown = false;
+        state.filtered_helpers.clear();
+        state.helper_selected = 0;
+        state.helper_scroll = 0;
+    }
+
     true
 }
 
@@ -999,12 +1044,29 @@ fn attach_image(state: &mut AppState, path: PathBuf, width: u32, height: u32, fo
 pub fn handle_input_delete(state: &mut AppState) {
     state.text_area.set_text("");
     state.show_helper_dropdown = false;
+    state.filtered_helpers.clear();
+    state.helper_selected = 0;
+    state.helper_scroll = 0;
 }
 
 /// Handle input delete word
 pub fn handle_input_delete_word(state: &mut AppState) {
     state.text_area.delete_backward_word();
-    state.show_helper_dropdown = false;
+    // Re-evaluate slash command state after word deletion
+    if state.input().starts_with('/') {
+        state.show_helper_dropdown = true;
+        state.helper_scroll = 0;
+        filter_helpers_sync(state);
+    } else {
+        state.show_helper_dropdown = false;
+        state.filtered_helpers.clear();
+        state.helper_selected = 0;
+        state.helper_scroll = 0;
+    }
+    // Send to async file search worker so @ file completion also updates
+    if let Some(tx) = &state.file_search_tx {
+        let _ = tx.try_send((state.input().to_string(), state.cursor_position()));
+    }
 }
 
 /// Handle cursor move to start of line
@@ -1402,4 +1464,27 @@ fn convert_path_to_placeholder(
     }
 
     true
+}
+
+/// Synchronously filter slash commands based on current input.
+/// This is intentionally synchronous (not async) because the helpers list is small (~15 items)
+/// and substring matching is instantaneous. Running this synchronously eliminates the race
+/// condition where the async worker returns stale filtered results, which caused the dropdown
+/// to show unfiltered commands in external terminals (iTerm2, Warp, etc.).
+fn filter_helpers_sync(state: &mut AppState) {
+    let input = state.input().to_string();
+    if input.starts_with('/') && input.len() > 1 {
+        let query = input[1..].to_lowercase();
+        state.filtered_helpers = state
+            .helpers
+            .iter()
+            .filter(|h| h.command.to_lowercase().contains(&query))
+            .cloned()
+            .collect();
+    } else {
+        // Input is just "/" — show all commands
+        state.filtered_helpers = state.helpers.clone();
+    }
+    // Always reset selection when filter changes to avoid pointing at wrong command
+    state.helper_selected = 0;
 }

--- a/tui/src/services/handlers/navigation.rs
+++ b/tui/src/services/handlers/navigation.rs
@@ -11,13 +11,9 @@ use crate::services::message::{
 
 /// Updates helper dropdown scroll position to keep selected item visible
 fn update_helper_dropdown_scroll(state: &mut AppState) {
-    let commands_to_show = if state.input() == "/" {
-        &state.helpers
-    } else {
-        &state.filtered_helpers
-    };
-
-    let total_commands = commands_to_show.len();
+    // filtered_helpers is maintained synchronously and already contains all
+    // commands when input is just "/", so no special-case needed
+    let total_commands = state.filtered_helpers.len();
     if total_commands == 0 {
         return;
     }
@@ -94,16 +90,11 @@ pub fn handle_dropdown_down(state: &mut AppState) {
                 state.helper_selected += 1;
             }
         } else {
-            // Regular helper mode
-            let commands_to_show = if state.input() == "/" {
-                &state.helpers
-            } else {
-                &state.filtered_helpers
-            };
-
-            if !commands_to_show.is_empty()
+            // Regular helper mode — filtered_helpers is maintained synchronously
+            // and already contains all commands when input is just "/"
+            if !state.filtered_helpers.is_empty()
                 && state.input().starts_with('/')
-                && state.helper_selected + 1 < commands_to_show.len()
+                && state.helper_selected + 1 < state.filtered_helpers.len()
             {
                 state.helper_selected += 1;
                 update_helper_dropdown_scroll(state);

--- a/tui/src/services/helper_dropdown.rs
+++ b/tui/src/services/helper_dropdown.rs
@@ -9,14 +9,12 @@ use ratatui::{
 
 pub fn render_helper_dropdown(f: &mut Frame, state: &AppState, dropdown_area: Rect) {
     let input = state.input().trim();
-    let show = input == "/" || (input.starts_with('/') && !state.filtered_helpers.is_empty());
+    let show = input.starts_with('/') && !state.filtered_helpers.is_empty();
     if state.show_helper_dropdown && show {
-        // Get the commands to show
-        let commands_to_show = if state.input() == "/" {
-            &state.helpers
-        } else {
-            &state.filtered_helpers
-        };
+        // filtered_helpers is maintained synchronously by filter_helpers_sync():
+        // - When input is just "/", it contains all commands
+        // - When input is "/foo", it contains only matching commands
+        let commands_to_show = &state.filtered_helpers;
 
         if commands_to_show.is_empty() {
             return;


### PR DESCRIPTION
## Summary

- **Fixes slash command dropdown not filtering** in external terminals (iTerm2, Warp, macOS Terminal) — commands showed unfiltered or the dropdown didn't appear at all
- **Fixes `/model`, `/help`, etc. being sent as plain user messages** instead of executing the command

## Root Cause

Slash command filtering (`filtered_helpers`) was done asynchronously via the `file_search_worker` tokio task. This created a race condition:

1. User types a character → `show_helper_dropdown = true` set **synchronously**
2. `filtered_helpers` updated **asynchronously** when the worker responds
3. `poll_file_search_results()` overwrites both `filtered_helpers` and `show_helper_dropdown` based on potentially **stale** async results

In VSCode's integrated terminal the timing was favorable so the race rarely manifested. In external terminals (iTerm2, Warp) the different event processing timing made it consistently visible.

Additionally, `filtered_helpers` was initialized to **all commands** at startup (`app.rs:460`), so before the first async result arrived, stale data was displayed.

## Changes

### Core fix: synchronous slash command filtering
- Added `filter_helpers_sync()` in `input.rs` — filters the ~15 slash commands instantly via substring match (no need for async)
- Called from `handle_input_changed()`, `handle_input_backspace()`, `handle_paste()`, and `handle_input_delete_word()`
- `poll_file_search_results()` no longer overwrites `filtered_helpers` or `show_helper_dropdown` for slash commands — it now only manages `@` file search results

### Defense-in-depth: prevent /commands sent as messages
- On submit, if input exactly matches a known slash command (e.g. `/model`), execute it even if the dropdown wasn't showing — prevents slash commands from ever being sent as user messages

### Consistency fixes
- Initialize `filtered_helpers` to `Vec::new()` instead of all helpers
- Fix `trim()` inconsistency between `helper_dropdown.rs` and `app.rs`
- Remove `state.input() == "/"` special-case in `helper_dropdown.rs` and `navigation.rs` — `filter_helpers_sync()` already populates all commands when input is just `/`
- `handle_input_delete()` and `handle_input_delete_word()` now properly maintain dropdown state

## Files Changed

| File | What |
|------|------|
| `tui/src/services/handlers/input.rs` | `filter_helpers_sync()`, sync filtering in all input handlers, submit fallback |
| `tui/src/app.rs` | Empty init for `filtered_helpers`, `poll_file_search_results()` scoped to `@` only |
| `tui/src/services/helper_dropdown.rs` | `trim()` fix, removed `input == "/"` special-case |
| `tui/src/services/handlers/navigation.rs` | Removed `input == "/"` special-case in scroll/down handlers |