### PR TITLE
feat(config): update default model to claude-opus-4-6

### DIFF
--- a/cli/src/config/app.rs
+++ b/cli/src/config/app.rs
@@ -878,7 +878,7 @@ impl AppConfig {
         // Priority: cli_override > model > default
         let model_str = cli_override
             .or(self.model.as_deref())
-            .unwrap_or("claude-opus-4-5");
+            .unwrap_or("claude-opus-4-6");
 
         // Extract explicit provider prefix if present (e.g., "amazon-bedrock/claude-sonnet-4-5")
         let explicit_provider = model_str.find('/').map(|idx| &model_str[..idx]);

--- a/cli/src/onboarding/config_templates.rs
+++ b/cli/src/onboarding/config_templates.rs
@@ -58,7 +58,7 @@ use crate::config::ProviderType;
 use stakpak_shared::models::llm::ProviderConfig;
 
 /// Default model for all new profiles
-pub const DEFAULT_MODEL: &str = "claude-opus-4-5";
+pub const DEFAULT_MODEL: &str = "claude-opus-4-6";
 
 /// Generate OpenAI profile configuration (credentials stored separately in config.toml auth field)
 pub fn generate_openai_profile() -> ProfileConfig {


### PR DESCRIPTION
## Description
Update the default LLM model from `claude-opus-4-5` to `claude-opus-4-6`.

## Changes Made
- Update fallback model in `AppConfig::resolve_model()` (`cli/src/config/app.rs`)
- Update `DEFAULT_MODEL` constant in `cli/src/onboarding/config_templates.rs`

## Testing
- [x] All tests pass locally
- [x] No clippy warnings
- [x] Code is formatted

## Breaking Changes
None — existing users with an explicit model in their profile are unaffected. Only the default for new profiles / unset configs changes.