### PR TITLE
docs(slack): reference app manifest in system prompt, CLI help, and init flow

### DIFF
--- a/cli/src/commands/autopilot.rs
+++ b/cli/src/commands/autopilot.rs
@@ -223,7 +223,7 @@ pub enum AutopilotChannelCommands {
 
     /// Add a channel
     #[command(
-        after_long_help = "HOW TO GET TOKENS:\n\n  Slack (requires both --bot-token and --app-token):\n    1. Create app at https://api.slack.com/apps\n    2. Enable Socket Mode → generate app-level token (xapp-...) with connections:write scope\n    3. OAuth & Permissions → add Bot Token Scopes:\n       app_mentions:read, channels:history, channels:read, chat:write,\n       groups:history, groups:read, im:history, im:read,\n       mpim:history, mpim:read, reactions:read, reactions:write\n    4. Event Subscriptions → subscribe to bot events:\n       message.channels, message.groups, message.im, app_mention\n    5. Install to Workspace → copy Bot User OAuth Token (xoxb-...)\n\n  Telegram:\n    1. Message @BotFather on Telegram\n    2. Send /newbot → choose name and username (must end in 'bot')\n    3. Copy the bot token (format: 123456789:ABCdef...)\n\n  Discord:\n    1. Create app at https://discord.com/developers/applications\n    2. Bot tab → copy the bot token\n    3. OAuth2 → enable bot scope and required permissions\n\n  Optional default notification target:\n    --target sets [notifications].channel/chat_id for watch alerts\n    Example: --target \"#engineering\" (Slack)\n"
+        after_long_help = "HOW TO GET TOKENS:\n\n  Slack (requires both --bot-token and --app-token):\n\n    RECOMMENDED: Use the app manifest for quick setup:\n    1. Go to https://api.slack.com/apps → Create New App → From an app manifest\n    2. Paste the manifest from: https://github.com/stakpak/agent/blob/main/libs/gateway/src/channels/slack-manifest.yaml\n    3. Basic Information → App-Level Tokens → generate token with connections:write scope (xapp-...)\n    4. Install to Workspace → copy Bot User OAuth Token (xoxb-...)\n\n    Manual setup (if you already have an app):\n    1. Create app at https://api.slack.com/apps\n    2. Enable Socket Mode → generate app-level token (xapp-...) with connections:write scope\n    3. OAuth & Permissions → add Bot Token Scopes:\n       app_mentions:read, channels:history, channels:read, chat:write,\n       groups:history, groups:read, im:history, im:read,\n       mpim:history, mpim:read, reactions:read, reactions:write\n    4. Event Subscriptions → subscribe to bot events:\n       message.channels, message.groups, message.im, app_mention\n    5. Interactivity & Shortcuts → enable\n    6. Install to Workspace → copy Bot User OAuth Token (xoxb-...)\n\n  Telegram:\n    1. Message @BotFather on Telegram\n    2. Send /newbot → choose name and username (must end in 'bot')\n    3. Copy the bot token (format: 123456789:ABCdef...)\n\n  Discord:\n    1. Create app at https://discord.com/developers/applications\n    2. Bot tab → copy the bot token\n    3. OAuth2 → enable bot scope and required permissions\n\n  Optional default notification target:\n    --target sets [notifications].channel/chat_id for watch alerts\n    Example: --target \"#engineering\" (Slack)\n"
     )]
     Add {
         /// Channel type (slack, telegram, discord)
@@ -747,6 +747,11 @@ async fn start_autopilot(config: &mut AppConfig, options: StartOptions) -> Resul
             println!();
             println!("Channels let autopilot talk to you on Slack, Telegram, or Discord.");
             println!("You can add them now or later with: stakpak autopilot channel add");
+            println!();
+            println!("  Slack quick setup: use the app manifest at");
+            println!(
+                "  https://github.com/stakpak/agent/blob/main/libs/gateway/src/channels/slack-manifest.yaml"
+            );
             println!();
         }
     }

--- a/cli/src/prompts/system_prompt.v1.md
+++ b/cli/src/prompts/system_prompt.v1.md
@@ -461,6 +461,67 @@ stakpak autopilot channel add telegram --token $TELEGRAM_BOT_TOKEN
 stakpak autopilot channel add discord --token $DISCORD_BOT_TOKEN
 ```
 
+### Slack App Setup (recommended: use manifest)
+When helping users set up a Slack channel, **always recommend the manifest-based approach** — it's faster and less error-prone than manual scope/event configuration.
+
+**Steps to guide users through:**
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) → **Create New App** → **From an app manifest**
+2. Select the target workspace
+3. Paste the following Slack App Manifest YAML:
+
+```yaml
+display_information:
+  name: Stakpak
+  description: AI agent for infrastructure operations
+  background_color: "#1a1a2e"
+
+features:
+  bot_user:
+    display_name: Stakpak
+    always_online: true
+  app_home:
+    home_tab_enabled: false
+    messages_tab_enabled: true
+    messages_tab_read_only_enabled: false
+
+oauth_config:
+  scopes:
+    bot:
+      - chat:write
+      - reactions:read
+      - reactions:write
+      - channels:read
+      - groups:read
+      - im:read
+      - mpim:read
+      - channels:history
+      - groups:history
+      - im:history
+      - mpim:history
+      - app_mentions:read
+
+settings:
+  event_subscriptions:
+    bot_events:
+      - message.channels
+      - message.groups
+      - message.im
+      - app_mention
+  interactivity:
+    is_enabled: true
+  org_deploy_enabled: false
+  socket_mode_enabled: true
+  token_rotation_enabled: false
+```
+
+4. Review and create the app
+5. **Basic Information** → **App-Level Tokens** → generate a token with `connections:write` scope → this is the `xapp-*` token
+6. **Install to Workspace** → copy the **Bot User OAuth Token** (`xoxb-*`)
+7. Run: `stakpak autopilot channel add slack --bot-token "$SLACK_BOT_TOKEN" --app-token "$SLACK_APP_TOKEN"`
+8. Verify: `stakpak autopilot channel test`
+
+**If the user already has a Slack app** and just needs to fix permissions, direct them to add the missing scopes under OAuth & Permissions and re-install the app.
+
 **IMPORTANT:** Always use `stakpak up` to start and install the system service. Do NOT manually create systemd unit files or launchd plist files.
 
 **Production trust model:** When setting up autopilot on production servers, recommend starting with **read-only IAM permissions** (e.g., `ReadOnlyAccess`, `ViewOnlyAccess`, or equivalent). This lets the user build confidence in autopilot's behavior before granting write access. Escalate permissions only after the user explicitly requests mutating actions (e.g., auto-remediation, scaling).


### PR DESCRIPTION
## Description

Reference the Slack app manifest YAML across all user-facing surfaces so users get the fastest path to a working Slack channel setup.

## Related Issues

Improves Slack onboarding UX — no existing issue.

## Changes Made

- **System prompt** (`system_prompt.v1.md`): Added a "Slack App Setup (recommended: use manifest)" section with the full `slack-manifest.yaml` embedded inline and an 8-step walkthrough. The agent will now always recommend the manifest-based approach over manual scope/event configuration.
- **CLI help** (`autopilot.rs`): Updated `channel add --help` to show a "RECOMMENDED" manifest-first path with a direct GitHub link, relabeling the existing manual steps as fallback. Also added the missing "Interactivity & Shortcuts → enable" step.
- **Init flow** (`autopilot.rs`): Added a manifest URL hint during interactive first-run setup (`stakpak up`) when no channel env vars are detected.

## Testing

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets` — zero warnings
- [x] `cargo check --bin stakpak` — compiles
- [ ] Tested on macOS

## Breaking Changes

None — documentation/prompt-only changes.