### PR TITLE
fix: prevent popups from consuming backend streaming events

### DIFF
--- a/tui/src/services/handlers/message.rs
+++ b/tui/src/services/handlers/message.rs
@@ -5,7 +5,7 @@
 use crate::app::AppState;
 use crate::services::helper_block::push_usage_message;
 use crate::services::message::{
-    invalidate_message_cache, invalidate_message_lines_cache, Message, MessageContent,
+    Message, MessageContent, invalidate_message_cache, invalidate_message_lines_cache,
 };
 use stakpak_shared::models::llm::LLMTokenUsage;
 use tokio::sync::mpsc::Sender;

--- a/tui/src/services/handlers/misc.rs
+++ b/tui/src/services/handlers/misc.rs
@@ -5,14 +5,14 @@
 use crate::app::{AppState, InputEvent};
 use crate::services::bash_block::render_bash_block_rejected;
 use crate::services::board_tasks::{
-    extract_board_agent_id_from_messages, fetch_tasks_as_todo_items, FetchTasksResult,
+    FetchTasksResult, extract_board_agent_id_from_messages, fetch_tasks_as_todo_items,
 };
 use crate::services::commands::list_auto_approved_tools;
 use crate::services::detect_term::ThemeColors;
 use crate::services::file_search::{handle_file_selection, handle_tab_trigger};
 use crate::services::helper_block::{handle_errors, push_error_message, push_styled_message};
-use crate::services::message::get_wrapped_collapsed_message_lines_cached;
 use crate::services::message::Message;
+use crate::services::message::get_wrapped_collapsed_message_lines_cached;
 use ratatui::layout::Size;
 use stakai::Model;
 use uuid::Uuid;
@@ -279,7 +279,7 @@ pub fn handle_set_sessions(state: &mut AppState, sessions: Vec<crate::app::Sessi
 
     state.sessions = sessions;
     state.session_selected = 0; // Reset selection to first item
-                                // Open unified popup at Sessions tab instead of separate sessions dialog
+    // Open unified popup at Sessions tab instead of separate sessions dialog
     state.show_shortcuts_popup = true;
     state.shortcuts_popup_mode = crate::app::ShortcutsPopupMode::Sessions;
 }


### PR DESCRIPTION
## Summary

- Fix TUI getting permanently stuck on "Stakpaking..." loading state when a popup (model switcher, file changes, plan review, etc.) is open while the LLM is streaming a response
- Backend events (streaming content, loading state, tool results) now bypass all popup interceptors instead of being silently consumed by their `_ => { return; }` catch-all branches

## Problem

Every popup interceptor in the TUI `update()` function has a catch-all match arm that consumes unhandled events:

```rust
if state.show_model_switcher {
    match event {
        InputEvent::HandleEsc => { /* close popup */ }
        InputEvent::Up => { /* navigate */ }
        // ...
        _ => { return; }  // <-- silently drops ALL other events
    }
}
```

When a user opens any popup (e.g. `/model`) while the LLM is streaming, `StreamAssistantMessage` and `EndLoadingOperation` events are consumed by the catch-all. The response is lost and the loading indicator never clears.

## Fix

Added `InputEvent::is_backend_event()` that identifies events originating from the backend (stream processing, CLI) that must always reach their handlers. All 6 popup interceptors now check `!skip_popup_interception` before consuming events:

```rust
let skip_popup_interception = event.is_backend_event();

if state.show_model_switcher && !skip_popup_interception {
    // ... popup keyboard handling, catch-all only affects UI events
}
```

**Affected popups:** message action, existing plan modal, plan review, file changes, ask user, model switcher.

## Testing

- All 234 TUI tests pass
- All 12 stream processing tests pass
- Manually verified: opening `/model` during streaming no longer blocks the response
