### PR TITLE
fix(watch): inject runtime gateway auth token into scheduler config

### DIFF
--- a/cli/src/commands/watch/commands/run.rs
+++ b/cli/src/commands/watch/commands/run.rs
@@ -47,8 +47,13 @@ pub async fn run_scheduler(server: AgentServerConnection) -> Result<(), String> 
     print_banner();
 
     // Load and validate configuration
-    let config =
+    let mut config =
         ScheduleConfig::load_default().map_err(|e| format!("Failed to load config: {}", e))?;
+
+    // Inject the runtime-generated gateway token so the scheduler can
+    // authenticate against the co-hosted gateway API (/v1/gateway/send).
+    // The token is ephemeral (generated each `stakpak up`) and never persisted.
+    config.apply_runtime_gateway_credentials(&server.url, &server.token);
 
     info!(
         schedules = config.schedules.len(),
@@ -286,6 +291,7 @@ pub async fn run_scheduler(server: AgentServerConnection) -> Result<(), String> 
                             &config_clone2,
                             &snapshot_clone2,
                             &config_path_clone,
+                            &server_clone2,
                         )
                         .await;
                         if success {
@@ -315,6 +321,7 @@ pub async fn run_scheduler(server: AgentServerConnection) -> Result<(), String> 
                         &config_clone2,
                         &snapshot_clone2,
                         &config_path_clone,
+                        &server_clone2,
                     )
                     .await;
                 }
@@ -411,8 +418,9 @@ async fn trigger_config_reload(
     config: &Arc<RwLock<Arc<ScheduleConfig>>>,
     snapshot: &Arc<Mutex<ScheduleSnapshot>>,
     config_path: &Path,
+    server: &AgentServerConnection,
 ) -> bool {
-    trigger_config_reload_with_loader(scheduler, config, snapshot, || {
+    trigger_config_reload_with_loader(scheduler, config, snapshot, server, || {
         ScheduleConfig::load(config_path)
     })
     .await
@@ -422,18 +430,23 @@ async fn trigger_config_reload_with_loader<F>(
     scheduler: &Arc<Mutex<Scheduler>>,
     config: &Arc<RwLock<Arc<ScheduleConfig>>>,
     snapshot: &Arc<Mutex<ScheduleSnapshot>>,
+    server: &AgentServerConnection,
     load_config: F,
 ) -> bool
 where
     F: Fn() -> Result<ScheduleConfig, crate::commands::watch::config::ConfigError>,
 {
-    let new_config = match load_config() {
+    let mut new_config = match load_config() {
         Ok(config) => config,
         Err(error) => {
             warn!(error = %error, "Config reload failed (keeping current schedules)");
             return false;
         }
     };
+
+    // Re-apply runtime gateway credentials — disk values are never authoritative
+    // for the ephemeral token generated at `stakpak up` time.
+    new_config.apply_runtime_gateway_credentials(&server.url, &server.token);
 
     let current_db_path = {
         let config_guard = config.read().await;
@@ -1491,15 +1504,25 @@ mod tests {
     use crate::commands::watch::db::{RELOAD_SENTINEL, SchedulerState};
     use crate::commands::watch::reconciler::{RegisteredSchedule, ScheduleSnapshot};
     use crate::commands::watch::{
-        CheckResult, InteractionMode, Schedule, ScheduleConfig, ScheduleDb, Scheduler,
+        AgentServerConnection, CheckResult, InteractionMode, Schedule, ScheduleConfig, ScheduleDb,
+        Scheduler,
     };
     use chrono::{Duration, Utc};
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
     use std::time::Duration as StdDuration;
     use tempfile::tempdir;
     use tokio::sync::{Mutex as AsyncMutex, RwLock, mpsc};
+
+    fn dummy_server() -> AgentServerConnection {
+        AgentServerConnection {
+            url: "http://127.0.0.1:4096".to_string(),
+            token: "test-token".to_string(),
+            model: None,
+            default_allowed_tools: HashSet::new(),
+        }
+    }
 
     fn escape_toml_string(value: &Path) -> String {
         value.to_string_lossy().replace('\\', "\\\\")
@@ -1625,14 +1648,20 @@ mod tests {
         );
 
         let loader_path = config_path.clone();
-        trigger_config_reload_with_loader(&scheduler, &config_state, &snapshot, move || {
-            ScheduleConfig::load(&loader_path)
-        })
+        let server = dummy_server();
+        trigger_config_reload_with_loader(
+            &scheduler,
+            &config_state,
+            &snapshot,
+            &server,
+            move || ScheduleConfig::load(&loader_path),
+        )
         .await;
 
         let snapshot_guard = snapshot.lock().await;
         assert_eq!(snapshot_guard.registered.len(), 2);
         assert!(snapshot_guard.registered.contains_key("alpha"));
+
         assert!(snapshot_guard.registered.contains_key("beta"));
         drop(snapshot_guard);
 
@@ -1662,11 +1691,15 @@ mod tests {
         let mut changed_config = config.clone();
         changed_config.watch.db_path = changed_db_path.to_string_lossy().to_string();
 
-        let success =
-            trigger_config_reload_with_loader(&scheduler, &config_state, &snapshot, move || {
-                Ok(changed_config.clone())
-            })
-            .await;
+        let server = dummy_server();
+        let success = trigger_config_reload_with_loader(
+            &scheduler,
+            &config_state,
+            &snapshot,
+            &server,
+            move || Ok(changed_config.clone()),
+        )
+        .await;
         assert!(!success, "db_path change should be rejected");
 
         let snapshot_guard = snapshot.lock().await;
@@ -1700,13 +1733,19 @@ mod tests {
         let config = ScheduleConfig::load(&config_path).expect("failed to load initial config");
         let (scheduler, snapshot, config_state, _event_rx) = build_runtime_state(&config).await;
 
-        let success =
-            trigger_config_reload_with_loader(&scheduler, &config_state, &snapshot, || {
+        let server = dummy_server();
+        let success = trigger_config_reload_with_loader(
+            &scheduler,
+            &config_state,
+            &snapshot,
+            &server,
+            || {
                 Err(crate::commands::watch::config::ConfigError::ReadError(
                     std::io::Error::new(std::io::ErrorKind::NotFound, "simulated read failure"),
                 ))
-            })
-            .await;
+            },
+        )
+        .await;
         assert!(!success, "parse failure should return false");
 
         // State unchanged.
@@ -1743,11 +1782,15 @@ mod tests {
         write_autopilot_config(&config_path, &db_path, &[("alpha", "*/10 * * * *", true)]);
 
         let loader_path = config_path.clone();
-        let success =
-            trigger_config_reload_with_loader(&scheduler, &config_state, &snapshot, move || {
-                ScheduleConfig::load(&loader_path)
-            })
-            .await;
+        let server = dummy_server();
+        let success = trigger_config_reload_with_loader(
+            &scheduler,
+            &config_state,
+            &snapshot,
+            &server,
+            move || ScheduleConfig::load(&loader_path),
+        )
+        .await;
         assert!(success);
 
         let snapshot_guard = snapshot.lock().await;
@@ -1796,11 +1839,15 @@ mod tests {
         );
 
         let loader_path = config_path.clone();
-        let success =
-            trigger_config_reload_with_loader(&scheduler, &config_state, &snapshot, move || {
-                ScheduleConfig::load(&loader_path)
-            })
-            .await;
+        let server = dummy_server();
+        let success = trigger_config_reload_with_loader(
+            &scheduler,
+            &config_state,
+            &snapshot,
+            &server,
+            move || ScheduleConfig::load(&loader_path),
+        )
+        .await;
         assert!(success);
 
         let snapshot_guard = snapshot.lock().await;
@@ -1848,9 +1895,14 @@ mod tests {
             ],
         );
         let loader_path = config_path.clone();
-        trigger_config_reload_with_loader(&scheduler, &config_state, &snapshot, move || {
-            ScheduleConfig::load(&loader_path)
-        })
+        let server = dummy_server();
+        trigger_config_reload_with_loader(
+            &scheduler,
+            &config_state,
+            &snapshot,
+            &server,
+            move || ScheduleConfig::load(&loader_path),
+        )
         .await;
 
         let snapshot_guard = snapshot.lock().await;
@@ -1867,11 +1919,14 @@ mod tests {
             ],
         );
         let loader_path2 = config_path.clone();
-        let success =
-            trigger_config_reload_with_loader(&scheduler, &config_state, &snapshot, move || {
-                ScheduleConfig::load(&loader_path2)
-            })
-            .await;
+        let success = trigger_config_reload_with_loader(
+            &scheduler,
+            &config_state,
+            &snapshot,
+            &server,
+            move || ScheduleConfig::load(&loader_path2),
+        )
+        .await;
         assert!(success);
 
         let snapshot_guard = snapshot.lock().await;
@@ -1973,5 +2028,399 @@ mod tests {
         let max_age = interactive_run_max_age(&config, "missing");
 
         assert!(max_age.num_hours() >= 24);
+    }
+
+    // ========================================================================
+    // Gateway credential injection integration tests
+    // ========================================================================
+
+    /// Write a config with a [notifications] section. The gateway_token field
+    /// is intentionally omitted (or stale) to simulate what's on disk.
+    fn write_autopilot_config_with_notifications(
+        path: &Path,
+        db_path: &Path,
+        schedules: &[(&str, &str, bool)],
+        gateway_url: &str,
+        gateway_token: Option<&str>,
+    ) {
+        let log_dir = db_path.parent().unwrap_or(Path::new(".")).join("logs");
+
+        let mut content = String::new();
+        content.push_str("[watch]\n");
+        content.push_str(&format!("db_path = \"{}\"\n", escape_toml_string(db_path)));
+        content.push_str(&format!(
+            "log_dir = \"{}\"\n\n",
+            escape_toml_string(&log_dir)
+        ));
+
+        content.push_str("[notifications]\n");
+        content.push_str(&format!("gateway_url = \"{}\"\n", gateway_url));
+        if let Some(token) = gateway_token {
+            content.push_str(&format!("gateway_token = \"{}\"\n", token));
+        }
+        content.push_str("channel = \"slack\"\n");
+        content.push_str("chat_id = \"#ops\"\n\n");
+
+        for (name, cron, enabled) in schedules {
+            content.push_str("[[schedules]]\n");
+            content.push_str(&format!("name = \"{}\"\n", name));
+            content.push_str(&format!("cron = \"{}\"\n", cron));
+            content.push_str("prompt = \"test prompt\"\n");
+            content.push_str(&format!("enabled = {}\n\n", enabled));
+        }
+
+        std::fs::write(path, content).expect("failed to write autopilot config");
+    }
+
+    #[tokio::test]
+    async fn test_config_reload_preserves_runtime_gateway_token() {
+        // Simulates: disk config has no gateway_token, runtime injects one,
+        // then a hot-reload from disk should re-inject the runtime token.
+        let temp = tempdir().expect("failed to create temp directory");
+        let config_path = temp.path().join("autopilot.toml");
+        let db_path = temp.path().join("autopilot.db");
+
+        write_autopilot_config_with_notifications(
+            &config_path,
+            &db_path,
+            &[("alpha", "*/10 * * * *", true)],
+            "http://127.0.0.1:4096",
+            None, // no token on disk — the real-world default
+        );
+
+        let config = ScheduleConfig::load(&config_path).expect("failed to load initial config");
+        let (scheduler, snapshot, config_state, _event_rx) = build_runtime_state(&config).await;
+
+        let server = AgentServerConnection {
+            url: "http://127.0.0.1:4096".to_string(),
+            token: "ephemeral-runtime-token-42".to_string(),
+            model: None,
+            default_allowed_tools: HashSet::new(),
+        };
+
+        // Reload from disk (simulates mtime change trigger).
+        let loader_path = config_path.clone();
+        let success = trigger_config_reload_with_loader(
+            &scheduler,
+            &config_state,
+            &snapshot,
+            &server,
+            move || ScheduleConfig::load(&loader_path),
+        )
+        .await;
+        assert!(success, "reload should succeed");
+
+        // Verify the in-memory config has the runtime token injected.
+        let config_guard = config_state.read().await;
+        let notifications = config_guard
+            .notifications
+            .as_ref()
+            .expect("notifications should exist after reload");
+        assert_eq!(
+            notifications.gateway_token.as_deref(),
+            Some("ephemeral-runtime-token-42"),
+            "runtime gateway token must survive config reload from disk"
+        );
+        assert_eq!(
+            notifications.gateway_url, "http://127.0.0.1:4096",
+            "gateway URL should be preserved"
+        );
+        drop(config_guard);
+
+        let mut scheduler_guard = scheduler.lock().await;
+        scheduler_guard
+            .shutdown()
+            .await
+            .expect("failed to shutdown scheduler");
+    }
+
+    #[tokio::test]
+    async fn test_config_reload_overwrites_stale_disk_token() {
+        // Simulates: someone manually wrote a gateway_token into the TOML
+        // (perhaps from a previous run). The reload must replace it with the
+        // current runtime token.
+        let temp = tempdir().expect("failed to create temp directory");
+        let config_path = temp.path().join("autopilot.toml");
+        let db_path = temp.path().join("autopilot.db");
+
+        write_autopilot_config_with_notifications(
+            &config_path,
+            &db_path,
+            &[("alpha", "*/10 * * * *", true)],
+            "http://127.0.0.1:4096",
+            Some("stale-token-from-yesterday"), // stale on disk
+        );
+
+        let config = ScheduleConfig::load(&config_path).expect("failed to load initial config");
+        let (scheduler, snapshot, config_state, _event_rx) = build_runtime_state(&config).await;
+
+        let server = AgentServerConnection {
+            url: "http://127.0.0.1:4096".to_string(),
+            token: "todays-fresh-token".to_string(),
+            model: None,
+            default_allowed_tools: HashSet::new(),
+        };
+
+        let loader_path = config_path.clone();
+        let success = trigger_config_reload_with_loader(
+            &scheduler,
+            &config_state,
+            &snapshot,
+            &server,
+            move || ScheduleConfig::load(&loader_path),
+        )
+        .await;
+        assert!(success);
+
+        let config_guard = config_state.read().await;
+        let notifications = config_guard
+            .notifications
+            .as_ref()
+            .expect("notifications should exist");
+        assert_eq!(
+            notifications.gateway_token.as_deref(),
+            Some("todays-fresh-token"),
+            "stale disk token must be replaced by runtime token after reload"
+        );
+        drop(config_guard);
+
+        let mut scheduler_guard = scheduler.lock().await;
+        scheduler_guard
+            .shutdown()
+            .await
+            .expect("failed to shutdown scheduler");
+    }
+
+    #[tokio::test]
+    async fn test_config_reload_preserves_custom_external_gateway_url() {
+        // Users may point notifications at an external gateway (not loopback).
+        // The reload must preserve their custom URL, only injecting the token.
+        let temp = tempdir().expect("failed to create temp directory");
+        let config_path = temp.path().join("autopilot.toml");
+        let db_path = temp.path().join("autopilot.db");
+
+        write_autopilot_config_with_notifications(
+            &config_path,
+            &db_path,
+            &[("alpha", "*/10 * * * *", true)],
+            "https://gateway.prod.example.com",
+            None,
+        );
+
+        let config = ScheduleConfig::load(&config_path).expect("failed to load initial config");
+        let (scheduler, snapshot, config_state, _event_rx) = build_runtime_state(&config).await;
+
+        let server = AgentServerConnection {
+            url: "http://127.0.0.1:4096".to_string(),
+            token: "runtime-token".to_string(),
+            model: None,
+            default_allowed_tools: HashSet::new(),
+        };
+
+        let loader_path = config_path.clone();
+        let success = trigger_config_reload_with_loader(
+            &scheduler,
+            &config_state,
+            &snapshot,
+            &server,
+            move || ScheduleConfig::load(&loader_path),
+        )
+        .await;
+        assert!(success);
+
+        let config_guard = config_state.read().await;
+        let notifications = config_guard
+            .notifications
+            .as_ref()
+            .expect("notifications should exist");
+        assert_eq!(
+            notifications.gateway_url, "https://gateway.prod.example.com",
+            "custom external gateway URL must not be overwritten by loopback URL"
+        );
+        assert_eq!(
+            notifications.gateway_token.as_deref(),
+            Some("runtime-token"),
+        );
+        drop(config_guard);
+
+        let mut scheduler_guard = scheduler.lock().await;
+        scheduler_guard
+            .shutdown()
+            .await
+            .expect("failed to shutdown scheduler");
+    }
+
+    #[tokio::test]
+    async fn test_config_reload_without_notifications_section_is_safe() {
+        // Config has no [notifications] at all. Reload should not fabricate one.
+        let temp = tempdir().expect("failed to create temp directory");
+        let config_path = temp.path().join("autopilot.toml");
+        let db_path = temp.path().join("autopilot.db");
+
+        write_autopilot_config(&config_path, &db_path, &[("alpha", "*/10 * * * *", true)]);
+
+        let config = ScheduleConfig::load(&config_path).expect("failed to load initial config");
+        let (scheduler, snapshot, config_state, _event_rx) = build_runtime_state(&config).await;
+
+        let server = AgentServerConnection {
+            url: "http://127.0.0.1:4096".to_string(),
+            token: "runtime-token".to_string(),
+            model: None,
+            default_allowed_tools: HashSet::new(),
+        };
+
+        let loader_path = config_path.clone();
+        let success = trigger_config_reload_with_loader(
+            &scheduler,
+            &config_state,
+            &snapshot,
+            &server,
+            move || ScheduleConfig::load(&loader_path),
+        )
+        .await;
+        assert!(success);
+
+        let config_guard = config_state.read().await;
+        assert!(
+            config_guard.notifications.is_none(),
+            "should not create a notifications section when none exists on disk"
+        );
+        drop(config_guard);
+
+        let mut scheduler_guard = scheduler.lock().await;
+        scheduler_guard
+            .shutdown()
+            .await
+            .expect("failed to shutdown scheduler");
+    }
+
+    #[tokio::test]
+    async fn test_consecutive_reloads_always_carry_runtime_token() {
+        // Simulates multiple hot-reloads in succession (schedule edits).
+        // Each reload reads disk (no token) but the runtime token must persist.
+        let temp = tempdir().expect("failed to create temp directory");
+        let config_path = temp.path().join("autopilot.toml");
+        let db_path = temp.path().join("autopilot.db");
+
+        write_autopilot_config_with_notifications(
+            &config_path,
+            &db_path,
+            &[("alpha", "*/10 * * * *", true)],
+            "http://127.0.0.1:4096",
+            None,
+        );
+
+        let config = ScheduleConfig::load(&config_path).expect("failed to load initial config");
+        let (scheduler, snapshot, config_state, _event_rx) = build_runtime_state(&config).await;
+
+        let server = AgentServerConnection {
+            url: "http://127.0.0.1:4096".to_string(),
+            token: "stable-runtime-token".to_string(),
+            model: None,
+            default_allowed_tools: HashSet::new(),
+        };
+
+        // Reload #1: add a schedule
+        write_autopilot_config_with_notifications(
+            &config_path,
+            &db_path,
+            &[
+                ("alpha", "*/10 * * * *", true),
+                ("beta", "*/5 * * * *", true),
+            ],
+            "http://127.0.0.1:4096",
+            None, // disk still has no token
+        );
+
+        let loader_path1 = config_path.clone();
+        trigger_config_reload_with_loader(
+            &scheduler,
+            &config_state,
+            &snapshot,
+            &server,
+            move || ScheduleConfig::load(&loader_path1),
+        )
+        .await;
+
+        {
+            let guard = config_state.read().await;
+            let n = guard
+                .notifications
+                .as_ref()
+                .expect("notifications should exist");
+            assert_eq!(n.gateway_token.as_deref(), Some("stable-runtime-token"));
+            assert_eq!(guard.schedules.len(), 2);
+        }
+
+        // Reload #2: remove a schedule
+        write_autopilot_config_with_notifications(
+            &config_path,
+            &db_path,
+            &[("alpha", "*/10 * * * *", true)],
+            "http://127.0.0.1:4096",
+            None, // still no token
+        );
+
+        let loader_path2 = config_path.clone();
+        trigger_config_reload_with_loader(
+            &scheduler,
+            &config_state,
+            &snapshot,
+            &server,
+            move || ScheduleConfig::load(&loader_path2),
+        )
+        .await;
+
+        {
+            let guard = config_state.read().await;
+            let n = guard
+                .notifications
+                .as_ref()
+                .expect("notifications should exist");
+            assert_eq!(
+                n.gateway_token.as_deref(),
+                Some("stable-runtime-token"),
+                "runtime token must survive consecutive reloads from disk"
+            );
+            assert_eq!(guard.schedules.len(), 1);
+        }
+
+        // Reload #3: someone writes a different token to disk (should be overridden)
+        write_autopilot_config_with_notifications(
+            &config_path,
+            &db_path,
+            &[("alpha", "*/10 * * * *", true)],
+            "http://127.0.0.1:4096",
+            Some("someone-wrote-a-token-to-disk"),
+        );
+
+        let loader_path3 = config_path.clone();
+        trigger_config_reload_with_loader(
+            &scheduler,
+            &config_state,
+            &snapshot,
+            &server,
+            move || ScheduleConfig::load(&loader_path3),
+        )
+        .await;
+
+        {
+            let guard = config_state.read().await;
+            let n = guard
+                .notifications
+                .as_ref()
+                .expect("notifications should exist");
+            assert_eq!(
+                n.gateway_token.as_deref(),
+                Some("stable-runtime-token"),
+                "disk token must always be overridden by runtime token"
+            );
+        }
+
+        let mut scheduler_guard = scheduler.lock().await;
+        scheduler_guard
+            .shutdown()
+            .await
+            .expect("failed to shutdown scheduler");
     }
 }

--- a/cli/src/commands/watch/config.rs
+++ b/cli/src/commands/watch/config.rs
@@ -518,6 +518,32 @@ impl ScheduleConfig {
         expand_tilde(&self.watch.log_dir)
     }
 
+    /// Inject runtime-generated gateway credentials into the notification config.
+    ///
+    /// The gateway auth token is generated fresh each `stakpak up` and never
+    /// persisted to disk.  Without this patch the scheduler would read a stale
+    /// (or absent) `gateway_token` from `autopilot.toml` and get 401s on every
+    /// `POST /v1/gateway/send` call.
+    ///
+    /// This must be called after every config load (initial *and* hot-reload)
+    /// so that the in-memory config always carries the current runtime token.
+    pub fn apply_runtime_gateway_credentials(&mut self, url: &str, token: &str) {
+        if let Some(ref mut notifications) = self.notifications {
+            // Always override the token — disk value is never authoritative.
+            // Trim to avoid storing whitespace-only tokens that would cause
+            // auth failures downstream (symmetric with the URL path below).
+            let trimmed = token.trim();
+            if !trimmed.is_empty() {
+                notifications.gateway_token = Some(trimmed.to_string());
+            }
+            // Fill the URL only when missing/empty; the user may have set a
+            // custom external gateway URL that should be preserved.
+            if notifications.gateway_url.trim().is_empty() {
+                notifications.gateway_url = url.to_string();
+            }
+        }
+    }
+
     /// True when notifications are configured to local loopback gateway URL.
     pub fn notifications_points_to_local_loopback(&self) -> bool {
         let Some(notifications) = &self.notifications else {
@@ -1002,5 +1028,234 @@ interaction = "silent"
 
         let config = ScheduleConfig::parse(config_str).expect("config should parse");
         assert_eq!(config.schedules[0].interaction, InteractionMode::Silent);
+    }
+
+    // ========================================================================
+    // apply_runtime_gateway_credentials tests
+    // ========================================================================
+
+    fn config_with_notifications(gateway_url: &str, gateway_token: Option<&str>) -> ScheduleConfig {
+        let config_str = format!(
+            r##"
+[notifications]
+gateway_url = "{gateway_url}"
+channel = "slack"
+chat_id = "#ops"
+
+[[schedules]]
+name = "test"
+cron = "0 * * * *"
+prompt = "test"
+"##,
+        );
+        let mut config = ScheduleConfig::parse(&config_str).expect("config should parse");
+        if let Some(ref mut n) = config.notifications {
+            n.gateway_token = gateway_token.map(String::from);
+        }
+        config
+    }
+
+    fn config_without_notifications() -> ScheduleConfig {
+        let config_str = r##"
+[[schedules]]
+name = "test"
+cron = "0 * * * *"
+prompt = "test"
+"##;
+        ScheduleConfig::parse(config_str).expect("config should parse")
+    }
+
+    #[test]
+    fn test_apply_credentials_injects_token_when_missing() {
+        let mut config = config_with_notifications("http://127.0.0.1:4096", None);
+        assert!(
+            config
+                .notifications
+                .as_ref()
+                .expect("notifications should exist")
+                .gateway_token
+                .is_none()
+        );
+
+        config
+            .apply_runtime_gateway_credentials("http://127.0.0.1:4096", "runtime-secret-token-abc");
+
+        let notifications = config.notifications.expect("notifications should exist");
+        assert_eq!(
+            notifications.gateway_token.as_deref(),
+            Some("runtime-secret-token-abc"),
+            "runtime token should be injected"
+        );
+    }
+
+    #[test]
+    fn test_apply_credentials_overwrites_stale_disk_token() {
+        let mut config = config_with_notifications(
+            "http://127.0.0.1:4096",
+            Some("stale-token-from-previous-run"),
+        );
+
+        config.apply_runtime_gateway_credentials("http://127.0.0.1:4096", "fresh-runtime-token");
+
+        let notifications = config.notifications.expect("notifications should exist");
+        assert_eq!(
+            notifications.gateway_token.as_deref(),
+            Some("fresh-runtime-token"),
+            "stale disk token should be overwritten by runtime token"
+        );
+    }
+
+    #[test]
+    fn test_apply_credentials_preserves_custom_gateway_url() {
+        let custom_url = "https://gateway.example.com";
+        let mut config = config_with_notifications(custom_url, None);
+
+        config.apply_runtime_gateway_credentials("http://127.0.0.1:4096", "runtime-token");
+
+        let notifications = config.notifications.expect("notifications should exist");
+        assert_eq!(
+            notifications.gateway_url, custom_url,
+            "user-configured external gateway URL should not be overwritten"
+        );
+        assert_eq!(
+            notifications.gateway_token.as_deref(),
+            Some("runtime-token"),
+        );
+    }
+
+    #[test]
+    fn test_apply_credentials_fills_empty_gateway_url() {
+        let mut config = config_with_notifications("", None);
+
+        config.apply_runtime_gateway_credentials("http://127.0.0.1:5555", "runtime-token");
+
+        let notifications = config.notifications.expect("notifications should exist");
+        assert_eq!(
+            notifications.gateway_url, "http://127.0.0.1:5555",
+            "empty gateway_url should be filled from runtime"
+        );
+    }
+
+    #[test]
+    fn test_apply_credentials_fills_whitespace_only_gateway_url() {
+        let config_str = r##"
+[notifications]
+gateway_url = "   "
+channel = "slack"
+chat_id = "#ops"
+
+[[schedules]]
+name = "test"
+cron = "0 * * * *"
+prompt = "test"
+"##;
+        let mut config = ScheduleConfig::parse(config_str).expect("config should parse");
+
+        config.apply_runtime_gateway_credentials("http://127.0.0.1:4096", "runtime-token");
+
+        let notifications = config.notifications.expect("notifications should exist");
+        assert_eq!(
+            notifications.gateway_url, "http://127.0.0.1:4096",
+            "whitespace-only gateway_url should be replaced"
+        );
+    }
+
+    #[test]
+    fn test_apply_credentials_noop_without_notifications_section() {
+        let mut config = config_without_notifications();
+        assert!(config.notifications.is_none());
+
+        // Should not panic or create a notifications section.
+        config.apply_runtime_gateway_credentials("http://127.0.0.1:4096", "runtime-token");
+
+        assert!(
+            config.notifications.is_none(),
+            "should not fabricate a notifications section"
+        );
+    }
+
+    #[test]
+    fn test_apply_credentials_skips_empty_runtime_token() {
+        let mut config = config_with_notifications("http://127.0.0.1:4096", Some("existing-token"));
+
+        config.apply_runtime_gateway_credentials("http://127.0.0.1:4096", "");
+
+        let notifications = config.notifications.expect("notifications should exist");
+        assert_eq!(
+            notifications.gateway_token.as_deref(),
+            Some("existing-token"),
+            "empty runtime token should not overwrite an existing token"
+        );
+    }
+
+    #[test]
+    fn test_apply_credentials_skips_whitespace_only_runtime_token() {
+        let mut config = config_with_notifications("http://127.0.0.1:4096", Some("existing-token"));
+
+        config.apply_runtime_gateway_credentials("http://127.0.0.1:4096", "   ");
+
+        let notifications = config.notifications.expect("notifications should exist");
+        assert_eq!(
+            notifications.gateway_token.as_deref(),
+            Some("existing-token"),
+            "whitespace-only runtime token should not overwrite an existing token"
+        );
+    }
+
+    #[test]
+    fn test_apply_credentials_trims_runtime_token() {
+        let mut config = config_with_notifications("http://127.0.0.1:4096", None);
+
+        config.apply_runtime_gateway_credentials("http://127.0.0.1:4096", "  runtime-token  ");
+
+        let notifications = config.notifications.expect("notifications should exist");
+        assert_eq!(
+            notifications.gateway_token.as_deref(),
+            Some("runtime-token"),
+            "stored token should be trimmed"
+        );
+    }
+
+    #[test]
+    fn test_apply_credentials_skips_empty_runtime_token_when_disk_token_absent() {
+        let mut config = config_with_notifications("http://127.0.0.1:4096", None);
+
+        config.apply_runtime_gateway_credentials("http://127.0.0.1:4096", "");
+
+        let notifications = config.notifications.expect("notifications should exist");
+        assert!(
+            notifications.gateway_token.is_none(),
+            "empty runtime token should not inject a Some(\"\")"
+        );
+    }
+
+    #[test]
+    fn test_apply_credentials_idempotent() {
+        let mut config = config_with_notifications("http://127.0.0.1:4096", None);
+
+        config.apply_runtime_gateway_credentials("http://127.0.0.1:4096", "runtime-token");
+        config.apply_runtime_gateway_credentials("http://127.0.0.1:4096", "runtime-token");
+
+        let notifications = config.notifications.expect("notifications should exist");
+        assert_eq!(
+            notifications.gateway_token.as_deref(),
+            Some("runtime-token"),
+        );
+        assert_eq!(notifications.gateway_url, "http://127.0.0.1:4096",);
+    }
+
+    #[test]
+    fn test_apply_credentials_preserves_notification_fields() {
+        let mut config = config_with_notifications("http://127.0.0.1:4096", None);
+
+        config.apply_runtime_gateway_credentials("http://127.0.0.1:4096", "runtime-token");
+
+        let notifications = config.notifications.expect("notifications should exist");
+        assert_eq!(notifications.channel.as_deref(), Some("slack"));
+        assert_eq!(notifications.chat_id.as_deref(), Some("#ops"));
+        assert!(
+            notifications.notify_on.is_none(),
+            "unrelated fields should not be mutated"
+        );
     }
 }


### PR DESCRIPTION
## Description

The scheduler's notification and interactive-session calls to the gateway API (`POST /v1/gateway/send`, `GET /v1/gateway/sessions/{id}`) were failing with **401 Unauthorized** because the gateway auth token is generated fresh each `stakpak up` but the scheduler reads `NotificationConfig.gateway_token` from `autopilot.toml` on disk — where the token is never persisted.

Inbound DMs still worked because they go through the in-process `Dispatcher` → `StakpakClient` path (initialized with the runtime token), bypassing the HTTP auth boundary entirely.

## Root Cause

```
start_autopilot()
├── generated_token = generate_password(64)
├── → server AuthConfig::token(generated_token)         ✅ server knows token
├── → GatewayCliFlags { token: generated_token }        ✅ gateway knows token
├── → AgentServerConnection { token: generated_token }  ✅ scheduler→server works
│
├── → ScheduleConfig::load_default()                    ❌ reads disk, no runtime token
│     └── notifications.gateway_token = None            ❌ scheduler→gateway 401
```

## Changes Made

- **`cli/src/commands/watch/config.rs`**: Add `ScheduleConfig::apply_runtime_gateway_credentials(url, token)` — patches the in-memory notification config with the ephemeral runtime token. Trims whitespace-only tokens, preserves user-configured external gateway URLs, no-ops when `[notifications]` is absent.
- **`cli/src/commands/watch/commands/run.rs`**: Call the patch after initial config load AND after every hot-reload (`trigger_config_reload_with_loader`). Thread `&AgentServerConnection` through reload functions so the runtime token is always available.

## Testing

- [x] All existing tests pass (50 total)
- [x] 12 new unit tests for `apply_runtime_gateway_credentials` edge cases
- [x] 5 new integration tests verifying token survives reloads:
  - Token injected when missing on disk
  - Stale disk token overwritten by runtime token
  - Custom external gateway URL preserved
  - No `[notifications]` section → no crash
  - 3 consecutive reloads (add/remove/stale write) all carry correct token
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --bin stakpak` zero warnings
- [x] `cargo check --workspace` clean

## Breaking Changes

None. `trigger_config_reload_with_loader` gains a new `&AgentServerConnection` parameter but it is `pub(super)` — no external callers.