### PR TITLE
fix: skip terminal theme detection in async mode

### DIFF
--- a/cli/src/commands/agent/run/mode_async.rs
+++ b/cli/src/commands/agent/run/mode_async.rs
@@ -596,7 +596,6 @@ pub async fn run_async(ctx: AppConfig, config: RunAsyncConfig) -> Result<AsyncOu
                     .iter()
                     .map(|tc| tc.function.name.as_str())
                     .collect();
-
                 if auto_approve_config.any_requires_approval(&tool_names) {
                     // PAUSE: tools require approval
                     let pending: Vec<PendingToolCall> =

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -297,10 +297,15 @@ async fn main() {
             if matches!(cli.command, None | Some(Commands::Init)) {
                 // Initialize theme detection early, before any color code runs (e.g. onboarding).
                 // This ensures --theme flag takes effect for CLI colors too.
-                let theme_override = match cli.theme.to_lowercase().as_str() {
-                    "light" => Some(stakpak_shared::terminal_theme::Theme::Light),
-                    "dark" => Some(stakpak_shared::terminal_theme::Theme::Dark),
-                    _ => None,
+                // In async mode, skip terminal detection (no TTY) — default to Dark.
+                let theme_override = if cli.r#async || cli.print {
+                    Some(stakpak_shared::terminal_theme::Theme::Dark)
+                } else {
+                    match cli.theme.to_lowercase().as_str() {
+                        "light" => Some(stakpak_shared::terminal_theme::Theme::Light),
+                        "dark" => Some(stakpak_shared::terminal_theme::Theme::Dark),
+                        _ => None,
+                    }
                 };
                 stakpak_shared::terminal_theme::init_theme(theme_override);
 


### PR DESCRIPTION
## Problem

Non-sandboxed async subagents hang indefinitely at startup, preventing pause-on-approval from working. Subagents appear perpetually "Running" instead of pausing when they hit mutating tool calls.

## Root Cause

`terminal_light::luma()` is called during `init_theme()` at startup. The library:

1. Acquires `io::stdout().lock()` (process-wide mutex)
2. Writes an OSC escape sequence to stdout
3. Opens `/dev/tty` and calls `select()` waiting for the terminal's response

When the subagent inherits the parent agent's TTY (but the parent TUI is actively reading terminal input), the OSC response never arrives. The `select()` call blocks indefinitely, holding the stdout lock, which deadlocks the process before it ever reaches the agent loop.

The existing 100ms timeout wrapper (`mpsc::recv_timeout`) cannot recover because the blocked thread holds `io::stdout().lock()`, preventing subsequent stdout operations from completing.

## Fix

Skip terminal theme detection in async (`-a`) and print (`--print`) modes by forcing `Theme::Dark`. These are headless modes that don't need terminal color detection.

## Testing

Before fix: subagent hangs at `init_theme()`, never reaches agent loop
After fix:
- ✅ Subagent starts successfully
- ✅ Pauses correctly on mutating tool calls (verified with `view_web_page`)
- ✅ Resume with `--approve` works end-to-end
- ✅ Interactive mode unaffected (theme detection still runs)