### PR TITLE
fix: use read_timeout instead of total timeout for HTTP client

### DIFF
--- a/libs/ai/src/providers/tls.rs
+++ b/libs/ai/src/providers/tls.rs
@@ -24,7 +24,13 @@ pub fn create_platform_tls_client() -> Result<Client> {
 
     Client::builder()
         .use_preconfigured_tls(tls_config)
-        .timeout(std::time::Duration::from_secs(300))
+        // Use read_timeout instead of timeout: read_timeout only fires when no
+        // data arrives for the given duration (idle timeout), while timeout caps
+        // the *entire* request lifecycle. SSE streams can legitimately run for
+        // many minutes during long tool calls, so a total timeout causes
+        // spurious "Transport error: TimedOut" failures.
+        .read_timeout(std::time::Duration::from_secs(300))
+        .connect_timeout(std::time::Duration::from_secs(30))
         .build()
         .map_err(|e| Error::provider_error(format!("Failed to create TLS HTTP client: {}", e)))
 }


### PR DESCRIPTION
Replace .timeout(300s) with .read_timeout(300s) + .connect_timeout(30s) in create_platform_tls_client(). The total timeout was killing SSE streams that run longer than 5 minutes during long tool calls, causing 'Transport error: TimedOut' failures. read_timeout only fires when no data arrives for the given duration (idle detection), which is the correct behavior for streaming connections.