### PR TITLE
Fix/ask user experience

### DIFF
--- a/tui/src/services/bash_block.rs
+++ b/tui/src/services/bash_block.rs
@@ -2446,8 +2446,7 @@ pub fn render_ask_user_block(
 
         for q in questions {
             let review_label_width = max_content_width.saturating_sub(2);
-            let wrapped_review_label =
-                wrap_text_by_word(&q.label, review_label_width.max(1));
+            let wrapped_review_label = wrap_text_by_word(&q.label, review_label_width.max(1));
             for review_line in &wrapped_review_label {
                 let line_width = calculate_display_width(review_line);
                 let line_padding = max_content_width.saturating_sub(line_width);
@@ -2661,10 +2660,8 @@ pub fn render_ask_user_block(
             // and align with the text start (after bracket + space).
             let bracket_display_width = calculate_display_width(&bracket);
             let label_indent_width = bracket_display_width + 1; // "[›] " prefix
-            let label_available_width =
-                max_content_width.saturating_sub(label_indent_width);
-            let wrapped_label =
-                wrap_text_by_word(&opt.label, label_available_width.max(1));
+            let label_available_width = max_content_width.saturating_sub(label_indent_width);
+            let wrapped_label = wrap_text_by_word(&opt.label, label_available_width.max(1));
 
             for (li, label_line) in wrapped_label.iter().enumerate() {
                 if li == 0 {
@@ -2684,8 +2681,7 @@ pub fn render_ask_user_block(
                     let indent = " ".repeat(label_indent_width);
                     let line_text = format!("{}{}", indent, label_line);
                     let line_width = calculate_display_width(&line_text);
-                    let line_padding =
-                        max_content_width.saturating_sub(line_width);
+                    let line_padding = max_content_width.saturating_sub(line_width);
                     formatted_lines.push(Line::from(vec![
                         Span::styled("│", Style::default().fg(border_color)),
                         Span::from(" "),
@@ -2705,16 +2701,12 @@ pub fn render_ask_user_block(
                 };
                 // Align description with label text start
                 let desc_indent = " ".repeat(label_indent_width);
-                let desc_available_width =
-                    max_content_width.saturating_sub(label_indent_width);
-                let wrapped_desc =
-                    wrap_text_by_word(desc, desc_available_width.max(1));
+                let desc_available_width = max_content_width.saturating_sub(label_indent_width);
+                let wrapped_desc = wrap_text_by_word(desc, desc_available_width.max(1));
                 for desc_line in &wrapped_desc {
-                    let desc_text =
-                        format!("{}{}", desc_indent, desc_line);
+                    let desc_text = format!("{}{}", desc_indent, desc_line);
                     let desc_width = calculate_display_width(&desc_text);
-                    let desc_padding =
-                        max_content_width.saturating_sub(desc_width);
+                    let desc_padding = max_content_width.saturating_sub(desc_width);
                     formatted_lines.push(Line::from(vec![
                         Span::styled("│", Style::default().fg(border_color)),
                         Span::from(" "),
@@ -2779,8 +2771,7 @@ pub fn render_ask_user_block(
                     let bracket_display_width = calculate_display_width(&bracket);
                     let prefix_width = bracket_display_width + 1; // bracket + space
                     // Reserve 1 char for cursor on last line
-                    let available_text_width =
-                        max_content_width.saturating_sub(prefix_width + 1);
+                    let available_text_width = max_content_width.saturating_sub(prefix_width + 1);
                     let wrapped_input =
                         wrap_text_by_word(custom_input, available_text_width.max(1));
                     let total_lines = wrapped_input.len();
@@ -2791,11 +2782,9 @@ pub fn render_ask_user_block(
 
                         if is_first {
                             let cursor_part = if is_last { "│" } else { "" };
-                            let text =
-                                format!("{} {}{}", bracket, input_line, cursor_part);
+                            let text = format!("{} {}{}", bracket, input_line, cursor_part);
                             let text_width = calculate_display_width(&text);
-                            let text_padding =
-                                max_content_width.saturating_sub(text_width);
+                            let text_padding = max_content_width.saturating_sub(text_width);
                             let mut spans = vec![
                                 Span::styled("│", Style::default().fg(border_color)),
                                 Span::from(" "),
@@ -2815,18 +2804,15 @@ pub fn render_ask_user_block(
                                 ));
                             }
                             spans.push(Span::from(" ".repeat(text_padding)));
-                            spans
-                                .push(Span::styled(" │", Style::default().fg(border_color)));
+                            spans.push(Span::styled(" │", Style::default().fg(border_color)));
                             formatted_lines.push(Line::from(spans));
                         } else {
                             // Continuation lines: indent to align with text above
                             let indent = " ".repeat(prefix_width);
                             let cursor_part = if is_last { "│" } else { "" };
-                            let text =
-                                format!("{}{}{}", indent, input_line, cursor_part);
+                            let text = format!("{}{}{}", indent, input_line, cursor_part);
                             let text_width = calculate_display_width(&text);
-                            let text_padding =
-                                max_content_width.saturating_sub(text_width);
+                            let text_padding = max_content_width.saturating_sub(text_width);
                             let mut spans = vec![
                                 Span::styled("│", Style::default().fg(border_color)),
                                 Span::from(" "),
@@ -2845,8 +2831,7 @@ pub fn render_ask_user_block(
                                 ));
                             }
                             spans.push(Span::from(" ".repeat(text_padding)));
-                            spans
-                                .push(Span::styled(" │", Style::default().fg(border_color)));
+                            spans.push(Span::styled(" │", Style::default().fg(border_color)));
                             formatted_lines.push(Line::from(spans));
                         }
                     }
@@ -2855,10 +2840,8 @@ pub fn render_ask_user_block(
                 // Wrap long answered custom text to fit within the bordered block.
                 let bracket_display_width = calculate_display_width(&bracket);
                 let prefix_width = bracket_display_width + 1;
-                let available_text_width =
-                    max_content_width.saturating_sub(prefix_width);
-                let wrapped_answer =
-                    wrap_text_by_word(&answer.answer, available_text_width.max(1));
+                let available_text_width = max_content_width.saturating_sub(prefix_width);
+                let wrapped_answer = wrap_text_by_word(&answer.answer, available_text_width.max(1));
 
                 for (line_idx, answer_line) in wrapped_answer.iter().enumerate() {
                     let is_first = line_idx == 0;
@@ -2866,8 +2849,7 @@ pub fn render_ask_user_block(
                     if is_first {
                         let text = format!("{} {}", bracket, answer_line);
                         let text_width = calculate_display_width(&text);
-                        let text_padding =
-                            max_content_width.saturating_sub(text_width);
+                        let text_padding = max_content_width.saturating_sub(text_width);
                         formatted_lines.push(Line::from(vec![
                             Span::styled("│", Style::default().fg(border_color)),
                             Span::from(" "),
@@ -2884,8 +2866,7 @@ pub fn render_ask_user_block(
                         let indent = " ".repeat(prefix_width);
                         let text = format!("{}{}", indent, answer_line);
                         let text_width = calculate_display_width(&text);
-                        let text_padding =
-                            max_content_width.saturating_sub(text_width);
+                        let text_padding = max_content_width.saturating_sub(text_width);
                         formatted_lines.push(Line::from(vec![
                             Span::styled("│", Style::default().fg(border_color)),
                             Span::from(" "),

--- a/tui/src/services/handlers/ask_user.rs
+++ b/tui/src/services/handlers/ask_user.rs
@@ -118,7 +118,14 @@ fn refresh_ask_user_block(state: &mut AppState) {
                 break;
             }
         }
-        crate::services::message::invalidate_message_lines_cache(state);
+        // Force-invalidate all caches unconditionally. The normal invalidate_message_lines_cache
+        // skips invalidation when stay_at_bottom=false && is_streaming=true (to prevent
+        // jitter during streaming). But ask_user refreshes are user-driven interactions
+        // that must always be reflected visually.
+        state.assembled_lines_cache = None;
+        state.visible_lines_cache = None;
+        state.message_lines_cache = None;
+        state.collapsed_message_lines_cache = None;
     }
 }
 

--- a/tui/src/services/handlers/mod.rs
+++ b/tui/src/services/handlers/mod.rs
@@ -407,7 +407,8 @@ pub fn update(
 
     // Intercept keys for Ask User inline block
     // Always active while visible — no focus mode.
-    // ↑/↓ navigate options; at boundary they fall through to scroll.
+    // ↑/↓ always navigate options (clamped at boundaries, never scroll).
+    // Mouse wheel (ScrollUp/ScrollDown) scrolls the viewport.
     // ←/→ switch question tabs (except in custom input).
     // Enter selects/toggles. Esc cancels.
     if state.show_ask_user_popup {
@@ -426,20 +427,16 @@ pub fn update(
         let is_custom = ask_user::is_custom_input_selected(state);
 
         match event {
-            // --- Option navigation: ↑/↓ with scroll-on-boundary ---
-            // Only navigate options when at the bottom of chat (block is in view).
-            // If the user has scrolled up, arrows always scroll.
+            // --- Option navigation: ↑/↓ always navigate options ---
+            // Arrows are captured unconditionally while the popup is active.
+            // Mouse wheel (ScrollUp/ScrollDown) still scrolls the viewport.
             InputEvent::Up | InputEvent::AskUserPrevOption => {
-                if state.stay_at_bottom && ask_user::handle_ask_user_prev_option(state) {
-                    return; // Moved — consume the event
-                }
-                // At top boundary or scrolled up — fall through to scroll
+                ask_user::handle_ask_user_prev_option(state);
+                return; // Always consume — clamps at top boundary
             }
             InputEvent::Down | InputEvent::AskUserNextOption => {
-                if state.stay_at_bottom && ask_user::handle_ask_user_next_option(state) {
-                    return; // Moved — consume the event
-                }
-                // At bottom boundary or scrolled up — fall through to scroll
+                ask_user::handle_ask_user_next_option(state);
+                return; // Always consume — clamps at bottom boundary
             }
 
             // --- Question tab navigation: ←/→ (always work, no scroll conflict) ---
@@ -519,7 +516,7 @@ pub fn update(
                 return;
             }
 
-            // --- Scroll events always pass through ---
+            // --- Scroll events always pass through (mouse wheel scrolls viewport) ---
             InputEvent::ScrollUp
             | InputEvent::ScrollDown
             | InputEvent::PageUp
@@ -1857,7 +1854,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ask_user_boundary_scroll_passthrough() {
+    async fn ask_user_arrows_always_navigate_options() {
         use stakpak_shared::models::integrations::openai::{AskUserOption, AskUserQuestion};
 
         let mut state = build_state();
@@ -1896,7 +1893,7 @@ mod tests {
         };
         ask_user::handle_show_ask_user_popup(&mut state, tool_call, questions);
 
-        // stay_at_bottom defaults to true — arrows navigate options
+        // stay_at_bottom defaults to true
         assert!(state.stay_at_bottom);
 
         // Down navigates from option 0 → 1
@@ -1916,7 +1913,7 @@ mod tests {
             "Down should navigate to option 1"
         );
 
-        // Down at bottom boundary — falls through to scroll, may unset stay_at_bottom
+        // Down at bottom boundary — clamped, does NOT fall through to scroll
         update(
             &mut state,
             InputEvent::Down,
@@ -1930,12 +1927,13 @@ mod tests {
         );
         assert_eq!(
             state.ask_user_selected_option, 1,
-            "Down at bottom should not change option"
+            "Down at bottom should clamp at last option"
         );
-
-        // After boundary scroll, stay_at_bottom may be false.
-        // Scroll back to bottom so arrows navigate again.
-        state.stay_at_bottom = true;
+        // stay_at_bottom is unchanged — arrows no longer affect scroll state
+        assert!(
+            state.stay_at_bottom,
+            "Down at boundary should NOT affect stay_at_bottom"
+        );
 
         // Up navigates from option 1 → 0
         update(
@@ -1954,7 +1952,7 @@ mod tests {
             "Up should navigate to option 0"
         );
 
-        // Up at top boundary — falls through to scroll (sets stay_at_bottom = false)
+        // Up at top boundary — clamped, does NOT fall through to scroll
         update(
             &mut state,
             InputEvent::Up,
@@ -1968,14 +1966,15 @@ mod tests {
         );
         assert_eq!(
             state.ask_user_selected_option, 0,
-            "Up at top should not change option"
+            "Up at top should clamp at first option"
         );
         assert!(
-            !state.stay_at_bottom,
-            "Scrolling up should unset stay_at_bottom"
+            state.stay_at_bottom,
+            "Up at boundary should NOT affect stay_at_bottom"
         );
 
-        // Now arrows pass through to scroll (don't navigate options)
+        // Even when stay_at_bottom is false, arrows still navigate options
+        state.stay_at_bottom = false;
         update(
             &mut state,
             InputEvent::Down,
@@ -1988,8 +1987,8 @@ mod tests {
             Size::new(80, 24),
         );
         assert_eq!(
-            state.ask_user_selected_option, 0,
-            "Down while scrolled up should scroll, not navigate"
+            state.ask_user_selected_option, 1,
+            "Down should navigate even when scrolled up"
         );
     }
 }


### PR DESCRIPTION
## Fix AskUser popup keyboard navigation broken on first tool call

### Problem

When the AskUser popup had many choices exceeding terminal height, keyboard navigation (arrow keys, left/right for tabs) appeared completely broken on the **first** tool call. However, the same popup worked perfectly on `/resume`. Two separate issues were at play:

1. **Arrow keys fell through to scroll at boundaries**: When pressing Up at the first option or Down at the last option, the event fell through to the viewport scroll handler, which set `stay_at_bottom = false`. Once that happened, all subsequent arrow key presses became scroll events instead of option navigation — the user had to scroll all the way back to regain control.

2. **Render cache not invalidated during streaming**: `invalidate_message_lines_cache()` has a guard that skips invalidation when `stay_at_bottom=false && is_streaming=true` (to prevent jitter during streaming). On first tool call, `is_streaming` is still `true` when the popup appears. If the user scrolled up with mouse wheel (`stay_at_bottom=false`), all subsequent `refresh_ask_user_block()` calls silently failed to invalidate the cache — the state changed but the stale cached render was displayed. On `/resume`, `is_streaming` is `false`, so the guard never triggers and everything works.

### Fix

**`tui/src/services/handlers/mod.rs`** — Arrow keys unconditionally captured:
- Up/Down always navigate options while the popup is active (clamped at boundaries, never fall through to scroll)
- Left/Right always switch question tabs
- Mouse wheel (`ScrollUp`/`ScrollDown`) still scrolls the viewport freely
- Removed the `stay_at_bottom` guard that previously gated option navigation

**`tui/src/services/handlers/ask_user.rs`** — Force cache invalidation:
- `refresh_ask_user_block()` now directly clears all 4 render caches (`assembled_lines_cache`, `visible_lines_cache`, `message_lines_cache`, `collapsed_message_lines_cache`) instead of calling `invalidate_message_lines_cache()`
- This bypasses the streaming jitter guard, ensuring user-driven interactions always reflect visually

### Changed files

| File | Change |
|------|--------|
| `tui/src/services/handlers/mod.rs` | Arrow keys always captured by ask_user block; removed `stay_at_bottom` guard and scroll fall-through at boundaries |
| `tui/src/services/handlers/ask_user.rs` | Force-invalidate all render caches in `refresh_ask_user_block()` |
| `tui/src/services/bash_block.rs` | Formatting cleanup (no logic changes) |

### Testing

- Updated `ask_user_boundary_scroll_passthrough` test → renamed to `ask_user_arrows_always_navigate_options` with assertions verifying arrows navigate regardless of `stay_at_bottom` state and don't affect scroll position
- All 24 existing ask_user tests pass
- Manually verified on both first tool call and `/resume`
