### PR TITLE
fix: improve tool approval rendering for Slack/Discord

### DIFF
--- a/libs/gateway/src/dispatcher.rs
+++ b/libs/gateway/src/dispatcher.rs
@@ -1770,7 +1770,7 @@ fn render_subagent_preview(args: &serde_json::Map<String, serde_json::Value>) ->
         let names: Vec<&str> = tool_list
             .iter()
             .filter_map(|v| v.as_str())
-            .map(|name| strip_mcp_prefix(name))
+            .map(strip_mcp_prefix)
             .collect();
         if !names.is_empty() {
             out.push_str(&format!("tools: `{}`\n", names.join("`, `")));
@@ -2645,7 +2645,11 @@ mod tests {
         );
         assert!(preview.starts_with("*Enumerate S3 buckets* (🛡 sandboxed)\n"));
         assert!(preview.contains("tools: `view`, `run_command`, `search_docs`"));
-        assert!(preview.contains("```\nList all S3 buckets in the account.\nInclude regions and sizes.\n```"));
+        assert!(
+            preview.contains(
+                "```\nList all S3 buckets in the account.\nInclude regions and sizes.\n```"
+            )
+        );
         // tools line appears before the code block
         let tools_pos = preview.find("tools:").expect("tools line");
         let code_pos = preview.find("```").expect("code block");


### PR DESCRIPTION
## Problem

Tool calls with complex multi-param arguments (especially `dynamic_subagent_task`) render poorly in Slack autopilot approval prompts. They fall through to the generic fallback which dumps a raw `key=\`value\`` — ugly and unhelpful.

**Before:**
```
1. `dynamic_subagent_task`
context=`- User is on macOS (machine: 42.local), shell: zsh
- AWS credentials are stored in ~/.aws/ (both co...`
```

**After:**
```
1. `dynamic_subagent_task`
*Enumerate S3 buckets* (🛡 sandboxed)
tools: `view`, `run_command`, `search_docs`
\`\`\`
List all S3 buckets in the account.
Include regions and sizes.
\`\`\`
```

## Changes

**`libs/gateway/src/dispatcher.rs`**

### Dedicated renderers added

| Tool | What it shows |
|------|---------------|
| `dynamic_subagent_task` | Description with sandbox badge, tool list, instructions in code block |
| `search_docs` | Keywords as comma-separated inline code (array + string formats) |
| `ask_user` | Numbered question labels with overflow |

### Improved generic fallback

For multi-param unknown tools, builds a compact `·`-separated summary instead of dumping one raw value:
- Short strings: `key=\`value\``
- Long strings (>60 chars): `key: truncated…`
- Arrays: `key: [N items]`
- Booleans/numbers: `key=value`
- Objects: `key: {N keys}`
- Caps at 4 params with `…+N more`

Single-param tools still use the original key=value fallback.

### Tests

13 new tests added covering all new renderers + generic fallback improvements. All existing tests pass unchanged.