### PR TITLE
fix: prevent duplicate text when sending markdown tables to Slack

### DIFF
--- a/libs/gateway/src/channels/slack.rs
+++ b/libs/gateway/src/channels/slack.rs
@@ -685,10 +685,21 @@ impl Channel for SlackChannel {
                 } else {
                     Some(msg.blocks)
                 };
+                // When blocks is None, Slack renders the `text` field as the
+                // visible message body instead of using it only for
+                // notifications. If the message carries attachments (e.g. a
+                // table) but no top-level blocks, send an empty `text` so the
+                // attachment content isn't duplicated as raw plaintext above
+                // the rendered table.
+                let text = if blocks.is_none() && msg.attachments.is_some() {
+                    String::new()
+                } else {
+                    msg.fallback_text
+                };
                 let ts = self
                     .post_message(
                         &channel,
-                        &msg.fallback_text,
+                        &text,
                         blocks,
                         msg.attachments,
                         thread_ts.as_deref(),

--- a/libs/gateway/src/slack_blocks.rs
+++ b/libs/gateway/src/slack_blocks.rs
@@ -909,15 +909,39 @@ fn fallback_chunk(fallback: &str, _offset: usize, _block_count: usize) -> String
 // ---------------------------------------------------------------------------
 
 /// Generate plain text from markdown by stripping all formatting.
+///
+/// Table content is omitted from the fallback because Slack renders tables
+/// via attachments. Including the raw cell text would produce an unreadable
+/// wall of concatenated values (e.g. "IDNameAge1Alice30") in notifications.
+/// A short "[table]" placeholder is emitted instead.
 fn generate_fallback_text(text: &str) -> String {
     let options = Options::ENABLE_TABLES | Options::ENABLE_STRIKETHROUGH;
     let parser = Parser::new_ext(text, options);
 
     let mut output = String::new();
     let mut last_was_block = false;
+    let mut in_table = false;
 
     for event in parser {
         match event {
+            // Skip all content inside tables — they are rendered as
+            // attachments and the raw cell text is unreadable when
+            // concatenated.
+            Event::Start(Tag::Table(_)) => {
+                in_table = true;
+                if !output.is_empty() && !last_was_block {
+                    output.push('\n');
+                }
+                output.push_str("[table]\n");
+                last_was_block = true;
+            }
+            Event::End(TagEnd::Table) => {
+                in_table = false;
+            }
+            _ if in_table => {
+                // Ignore all events inside a table.
+            }
+
             Event::Text(content) => {
                 output.push_str(content.as_ref());
                 last_was_block = false;
@@ -1461,6 +1485,38 @@ mod tests {
         assert!(fallback.contains("code"));
         assert!(!fallback.contains("**"));
         assert!(!fallback.contains("`"));
+    }
+
+    #[test]
+    fn fallback_omits_table_content() {
+        let md = "Here is a table:\n\n| Name | Age |\n|------|-----|\n| Alice | 30 |\n| Bob   | 25 |\n\nDone.";
+        let fallback = generate_fallback_text(md);
+        // Table cell content should NOT appear in the fallback.
+        assert!(
+            !fallback.contains("Alice"),
+            "table cell text should be omitted"
+        );
+        assert!(
+            !fallback.contains("Bob"),
+            "table cell text should be omitted"
+        );
+        assert!(
+            !fallback.contains("NameAge"),
+            "concatenated header text should be omitted"
+        );
+        // Non-table content should still be present.
+        assert!(fallback.contains("Here is a table:"));
+        assert!(fallback.contains("Done."));
+        // A placeholder should indicate a table was present.
+        assert!(fallback.contains("[table]"));
+    }
+
+    #[test]
+    fn fallback_table_only_message() {
+        let md = "| X | Y |\n|---|---|\n| 1 | 2 |";
+        let fallback = generate_fallback_text(md);
+        assert!(!fallback.contains('1'), "table cell text should be omitted");
+        assert!(fallback.contains("[table]"));
     }
 
     // ---- 10. Edge Cases ----


### PR DESCRIPTION
## Problem

When sending a markdown table via the Slack autopilot channel, the table data was rendered **twice**: once as raw concatenated text (unformatted) and again as a properly formatted table attachment.

![Screenshot showing the bug — raw text dump above the formatted table](https://github.com/stakpak/agent/assets/screenshot-placeholder)

## Root Cause

Two issues working together:

### 1. `text` field rendered as visible body (primary)
**`libs/gateway/src/channels/slack.rs`** — `send_with_receipt()`

When a message has a table but no other content, `blocks` is empty → set to `None`. Per [Slack docs](https://docs.slack.dev/reference/methods/chat.postMessage/):

> *"If you're using blocks, [text] is used as a fallback string to display in notifications. If you aren't, this is the main body text of the message."*

So the full fallback text was rendered as visible content above the table attachment.

### 2. Fallback text includes garbled table data (secondary)
**`libs/gateway/src/slack_blocks.rs`** — `generate_fallback_text()`

The fallback generator didn't track table context, so all `Event::Text` events from table cells were concatenated without separators, producing unreadable output like `IDNameAge1Alice30` in notifications.

## Fix

1. **`send_with_receipt()`**: When `blocks` is `None` and `attachments` is `Some` (table-only messages), send an empty `text` field so Slack doesn't render the fallback as visible content.

2. **`generate_fallback_text()`**: Track `in_table` state and skip all events inside tables, emitting a `[table]` placeholder instead.

## Testing

- 2 new tests: `fallback_omits_table_content` and `fallback_table_only_message`
- All 143 gateway tests pass
- Zero clippy warnings