### PR TITLE
fix: improve channel tool execution and schedule trigger formatting

### DIFF
--- a/cli/src/commands/watch/commands/run.rs
+++ b/cli/src/commands/watch/commands/run.rs
@@ -266,9 +266,14 @@ pub async fn run_scheduler(server: AgentServerConnection) -> Result<(), String> 
                             tokio::spawn(async move {
                                 info!(schedule = %schedule.name, "Manual schedule fired");
                                 print_event("fire", &schedule.name, "Manual schedule fired");
-                                if let Err(e) =
-                                    handle_schedule_event(&db, config.as_ref(), &schedule, &server)
-                                        .await
+                                if let Err(e) = handle_schedule_event(
+                                    &db,
+                                    config.as_ref(),
+                                    &schedule,
+                                    &server,
+                                    true,
+                                )
+                                .await
                                 {
                                     error!(
                                         schedule = %schedule.name,
@@ -369,7 +374,7 @@ pub async fn run_scheduler(server: AgentServerConnection) -> Result<(), String> 
                         };
                         let server = Arc::clone(&server);
                         tokio::spawn(async move {
-                            if let Err(e) = handle_schedule_event(&db, config.as_ref(), &event.schedule, &server).await {
+                            if let Err(e) = handle_schedule_event(&db, config.as_ref(), &event.schedule, &server, false).await {
                                 error!(schedule = %event.schedule.name, error = %e, "Failed to handle schedule event");
                             }
                         });
@@ -547,6 +552,7 @@ async fn handle_schedule_event(
     config: &ScheduleConfig,
     schedule: &crate::commands::watch::Schedule,
     server: &AgentServerConnection,
+    manual: bool,
 ) -> Result<(), String> {
     // Singleton guard: skip if this schedule already has a running run
     match db.has_running_run(&schedule.name).await {
@@ -685,7 +691,14 @@ async fn handle_schedule_event(
     let caller_context = build_schedule_caller_context(schedule, check_result.as_ref());
 
     if schedule.interaction == InteractionMode::Interactive {
-        match try_start_interactive_session(config, schedule, check_result.as_ref(), &prompt).await
+        match try_start_interactive_session(
+            config,
+            schedule,
+            check_result.as_ref(),
+            &prompt,
+            manual,
+        )
+        .await
         {
             Ok(Some(session_id)) => {
                 db.update_run_interactive_started(run_id, &session_id, INTERACTIVE_DELEGATED_NOTE)
@@ -867,6 +880,7 @@ async fn try_start_interactive_session(
     schedule: &crate::commands::watch::Schedule,
     check_result: Option<&crate::commands::watch::CheckResult>,
     prompt: &str,
+    manual: bool,
 ) -> Result<Option<String>, String> {
     let Some(notifications) = &config.notifications else {
         return Ok(None);
@@ -878,10 +892,11 @@ async fn try_start_interactive_session(
 
     let caller_context = build_interactive_caller_context(schedule, check_result);
     let check_output = normalized_check_output(check_result);
+    let trigger_text = format_trigger_text(&schedule.name, check_result, manual);
     let payload = serde_json::json!({
         "channel": delivery.channel,
         "target": build_gateway_target(&delivery),
-        "text": format!("⚙️ [{}] Schedule fired", schedule.name),
+        "text": trigger_text,
         "context": {
             "schedule": schedule.name,
             "check_output": check_output,
@@ -899,6 +914,28 @@ async fn try_start_interactive_session(
     match post_gateway_send(notifications, &payload).await {
         Ok(response) => Ok(response.session_id),
         Err(error) => Err(error),
+    }
+}
+
+fn format_trigger_text(
+    schedule_name: &str,
+    check_result: Option<&crate::commands::watch::CheckResult>,
+    manual: bool,
+) -> String {
+    if manual {
+        return format!("👤 Schedule **{schedule_name}** manual trigger");
+    }
+
+    match check_result {
+        Some(result) => {
+            let exit_code = result.exit_code.unwrap_or(-1);
+            if result.passed() {
+                format!("⏩ Schedule **{schedule_name}** check passed (exit {exit_code})")
+            } else {
+                format!("⚠️ Schedule **{schedule_name}** check failed (exit {exit_code})")
+            }
+        }
+        None => format!("🕐 Schedule **{schedule_name}** triggered"),
     }
 }
 

--- a/libs/gateway/src/dispatcher.rs
+++ b/libs/gateway/src/dispatcher.rs
@@ -1308,14 +1308,8 @@ async fn consume_run_events(
                                     }
                                 }
                                 ApprovalMode::AllowAll | ApprovalMode::DenyAll => {
-                                    let tool_names = proposed
-                                        .tool_calls
-                                        .iter()
-                                        .map(|tool_call| tool_call.name.as_str())
-                                        .collect::<Vec<_>>()
-                                        .join(", ");
-                                    if !tool_names.is_empty() {
-                                        let text = format!("🔧 Running: {tool_names}");
+                                    if !proposed.tool_calls.is_empty() {
+                                        let text = render_running_tools_summary(&proposed.tool_calls);
                                         deliver_channel_text(&run_context.channels, &run_context.delivery, text).await;
                                     }
 
@@ -1620,7 +1614,7 @@ fn render_approval_prompt(tool_calls: &[ProposedToolCall], auto_count: usize) ->
     for (index, tool_call) in tool_calls.iter().enumerate() {
         let name = strip_mcp_prefix(&tool_call.name);
         let preview = render_tool_preview(name, &tool_call.arguments);
-        text.push_str(&format!("{}. `{}`\n{}\n", index + 1, name, preview));
+        text.push_str(&format!("**{} · {}**\n{}\n\n", index + 1, name, preview));
 
         if text.len() > MAX_APPROVAL_PROMPT_CHARS {
             let remaining = tool_calls.len() - index - 1;
@@ -1632,7 +1626,31 @@ fn render_approval_prompt(tool_calls: &[ProposedToolCall], auto_count: usize) ->
     }
 
     if auto_count > 0 {
-        text.push_str(&format!("\nℹ️ {auto_count} tool(s) auto-approved\n"));
+        text.push_str(&format!("ℹ️ {auto_count} tool(s) auto-approved\n"));
+    }
+
+    text
+}
+
+fn render_running_tools_summary(tool_calls: &[ProposedToolCall]) -> String {
+    let mut text = if tool_calls.len() == 1 {
+        "🔧 Running tool\n\n".to_string()
+    } else {
+        format!("🔧 Running {} tools\n\n", tool_calls.len())
+    };
+
+    for (index, tool_call) in tool_calls.iter().enumerate() {
+        let name = strip_mcp_prefix(&tool_call.name);
+        let preview = render_tool_preview(name, &tool_call.arguments);
+        text.push_str(&format!("**{} · {}**\n{}\n\n", index + 1, name, preview));
+
+        if text.len() > MAX_APPROVAL_PROMPT_CHARS {
+            let remaining = tool_calls.len() - index - 1;
+            if remaining > 0 {
+                text.push_str(&format!("_…and {remaining} more tool(s)_\n"));
+            }
+            break;
+        }
     }
 
     text
@@ -1761,9 +1779,12 @@ fn render_subagent_preview(args: &serde_json::Map<String, serde_json::Value>) ->
     let mut out = String::new();
 
     if sandbox {
-        out.push_str(&format!("*{}* (🛡 sandboxed)\n", truncate(description, 80)));
+        out.push_str(&format!(
+            "**{}** (🛡 sandboxed)\n",
+            truncate(description, 80)
+        ));
     } else {
-        out.push_str(&format!("*{}*\n", truncate(description, 80)));
+        out.push_str(&format!("**{}**\n", truncate(description, 80)));
     }
 
     if let Some(tool_list) = tools {
@@ -2643,7 +2664,7 @@ mod tests {
                 "enable_sandbox": true
             }),
         );
-        assert!(preview.starts_with("*Enumerate S3 buckets* (🛡 sandboxed)\n"));
+        assert!(preview.starts_with("**Enumerate S3 buckets** (🛡 sandboxed)\n"));
         assert!(preview.contains("tools: `view`, `run_command`, `search_docs`"));
         assert!(
             preview.contains(
@@ -2680,7 +2701,7 @@ mod tests {
             }),
         );
         assert!(!preview.contains("sandboxed"));
-        assert!(preview.starts_with("*Check logs*\n"));
+        assert!(preview.starts_with("**Check logs**\n"));
         assert!(preview.contains("tools: `view`"));
     }
 
@@ -2820,13 +2841,59 @@ mod tests {
 
         let prompt = render_approval_prompt(&tool_calls, 1);
         assert!(prompt.contains("2 tools need approval"));
-        assert!(prompt.contains("1. `run_command`"));
+        assert!(prompt.contains("**1 · run_command**"));
         assert!(prompt.contains("```\nkubectl get pods -n staging\n```"));
-        assert!(prompt.contains("2. `str_replace`"));
+        assert!(prompt.contains("**2 · str_replace**"));
         assert!(prompt.contains("`deploy.yaml`"));
         assert!(prompt.contains("- replicas: 1"));
         assert!(prompt.contains("+ replicas: 3"));
         assert!(prompt.contains("1 tool(s) auto-approved"));
+    }
+
+    #[test]
+    fn render_running_tools_summary_strips_prefixes_and_shows_previews() {
+        let tool_calls = vec![
+            ProposedToolCall {
+                id: "tc1".to_string(),
+                name: "stakpak__run_command".to_string(),
+                arguments: serde_json::json!({"command": "kubectl get pods"}),
+                metadata: None,
+            },
+            ProposedToolCall {
+                id: "tc2".to_string(),
+                name: "mcp__server__view".to_string(),
+                arguments: serde_json::json!({"path": "/etc/config.yaml"}),
+                metadata: None,
+            },
+        ];
+
+        let summary = render_running_tools_summary(&tool_calls);
+        assert!(summary.contains("Running 2 tools"));
+        // Tool names should be stripped and numbered
+        assert!(summary.contains("**1 · run_command**"));
+        assert!(summary.contains("**2 · view**"));
+        // Should NOT contain raw prefixed names
+        assert!(!summary.contains("stakpak__"));
+        assert!(!summary.contains("mcp__"));
+        // Should include tool previews
+        assert!(summary.contains("kubectl get pods"));
+        assert!(summary.contains("/etc/config.yaml"));
+    }
+
+    #[test]
+    fn render_running_tools_summary_single_tool() {
+        let tool_calls = vec![ProposedToolCall {
+            id: "tc1".to_string(),
+            name: "stakpak__create".to_string(),
+            arguments: serde_json::json!({"path": "/tmp/test.txt", "file_text": "hello"}),
+            metadata: None,
+        }];
+
+        let summary = render_running_tools_summary(&tool_calls);
+        assert!(summary.contains("Running tool"));
+        assert!(!summary.contains("Running 1 tools"));
+        assert!(summary.contains("**1 · create**"));
+        assert!(summary.contains("/tmp/test.txt"));
     }
 
     #[test]


### PR DESCRIPTION
## Changes

### Tool execution messages (dispatcher.rs)
- **Strip MCP/namespace prefixes** from tool names (`stakpak__run_command` → `run_command`)
- **Show tool argument previews** (commands, file paths, diffs) in auto-approve mode — previously only showed raw tool names
- **Numbered bold labels** (`**1 · run_command**`) for visual separation between tool calls — fixes Slack resetting numbered list counters when code blocks appear between items
- New `render_running_tools_summary()` function matching the approval prompt style

### Schedule trigger messages (run.rs)
- Replace generic `⚙️ [name] Schedule fired` with contextual formats:
  - `🕐 Schedule **name** triggered` — cron, no check script
  - `⚠️ Schedule **name** check failed (exit 1)` — check script failed
  - `⏩ Schedule **name** check passed (exit 0)` — check script passed
  - `👤 Schedule **name** manual trigger` — manually triggered
- Thread `manual` flag through `handle_schedule_event` → `try_start_interactive_session`

### Markdown consistency
- Use standard markdown `**bold**` instead of Slack mrkdwn `*bold*` — the slack_blocks layer handles conversion

### Tests
- Added tests for `render_running_tools_summary` (multi-tool and single-tool)
- Updated existing tests for new formatting