### PR TITLE
fix(test): correct validate_profile_reference test broken by overrides merge

### DIFF
--- a/cli/src/commands/autopilot.rs
+++ b/cli/src/commands/autopilot.rs
@@ -4276,8 +4276,12 @@ api_key = "monitoring-key"
 
     #[test]
     fn validate_profile_reference_surfaces_config_load_errors() {
-        let missing_path = temp_file_path("autopilot-validate-profile-missing-config");
-        let app_config = test_app_config(&missing_path);
+        // Write invalid TOML so load_config_file returns a parse error
+        // (a missing file returns Ok(default_config) with a "default" profile).
+        let bad_path = temp_file_path("autopilot-validate-profile-bad-config");
+        std::fs::write(&bad_path, "{{{{invalid toml!!!!").expect("write bad config");
+
+        let app_config = test_app_config(&bad_path);
         let result = validate_profile_reference("default", &app_config);
 
         assert!(result.is_err());
@@ -4286,6 +4290,8 @@ api_key = "monitoring-key"
                 .expect_err("expected config load error")
                 .contains("Failed to load config.toml")
         );
+
+        let _ = std::fs::remove_file(bad_path);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes the `validate_profile_reference_surfaces_config_load_errors` test that was failing after the per-request run overrides PRs (#616, #632, #638) were merged.

## Related Issues

Introduced by PR #632 (`feat/per-request-run-overrides-impl`).

## Changes Made

- The test previously pointed at a **non-existent** config file path and expected `validate_profile_reference("default", ...)` to return an error.
- However, `AppConfig::load_config_file()` returns `Ok(ConfigFile::with_default_profile())` on `NotFound`, which includes a `"default"` profile — so validation always succeeded.
- **Fix:** Write invalid TOML to the temp path so `load_config_file` hits a parse error, which is the actual code path this test should exercise.
- Added cleanup of the temp file after the test.

## Testing

- [x] All tests pass locally (`cargo test --workspace` — 1,674 tests, 0 failures)
- [x] No clippy warnings (`cargo clippy --all-targets`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Tested on macOS

## Breaking Changes

None