### PR TITLE
fix(secrets): add standalone Telegram bot token detection rule

### DIFF
--- a/libs/shared/src/secrets/additional_rules.toml
+++ b/libs/shared/src/secrets/additional_rules.toml
@@ -43,6 +43,17 @@ entropy = 0.5
 keywords = ["://", "@"]
 
 [[rules]]
+id = "telegram-bot-token-standalone"
+description = "Detected a Telegram Bot API Token by its distinctive format (bot_id:secret), even without surrounding context keywords."
+# Telegram bot tokens follow a strict format: 5-16 digit bot ID, colon, then
+# exactly 35 chars starting with 'A' (base64url alphabet: [A-Za-z0-9_-]).
+# The original gitleaks rule requires contextual keywords like "telegram" and
+# an assignment operator, so it misses bare tokens pasted or typed directly.
+# We use \b on the left and a terminator on the right to avoid partial matches.
+regex = '''\b([0-9]{5,16}:A[A-Za-z0-9_\-]{34})\b'''
+keywords = []
+
+[[rules]]
 id = "huawei-access-key-id"
 description = "Detected a Huawei Cloud Access Key ID (AK), which could allow unauthorized access to Huawei Cloud services."
 regex = '''\b[A-Z0-9]{20}\b'''

--- a/libs/shared/src/secrets/gitleaks.rs
+++ b/libs/shared/src/secrets/gitleaks.rs
@@ -687,6 +687,53 @@ mod tests {
     }
 
     #[test]
+    fn test_telegram_bot_token_standalone_detection() {
+        // Bare token with no surrounding context — the original gitleaks rule
+        // requires "telegr" + assignment operator, so it misses this.
+        let bare_token = "8797664862:AAFXV3ySwPk-k7mq-2MPLOwKAQ2QKv791v4";
+        let secrets = detect_secrets(bare_token, None, false);
+        let tg = secrets
+            .iter()
+            .find(|s| s.rule_id == "telegram-bot-token-standalone");
+        assert!(
+            tg.is_some(),
+            "Should detect bare Telegram bot token without context. Detected: {:?}",
+            secrets
+        );
+        assert_eq!(tg.unwrap().value, bare_token);
+
+        // Token inside a sentence (still no "telegram" keyword)
+        let in_sentence = "Use 8797664862:AAFXV3ySwPk-k7mq-2MPLOwKAQ2QKv791v4 as the bot cred";
+        let secrets2 = detect_secrets(in_sentence, None, false);
+        assert!(
+            secrets2
+                .iter()
+                .any(|s| s.rule_id == "telegram-bot-token-standalone"),
+            "Should detect Telegram bot token embedded in text"
+        );
+
+        // Should NOT match a short numeric prefix (< 5 digits)
+        let too_short = "1234:AAFXV3ySwPk-k7mq-2MPLOwKAQ2QKv791v4";
+        let secrets3 = detect_secrets(too_short, None, false);
+        assert!(
+            !secrets3
+                .iter()
+                .any(|s| s.rule_id == "telegram-bot-token-standalone"),
+            "Should not match token with fewer than 5 digit bot ID"
+        );
+
+        // Should NOT match when the secret part doesn't start with A
+        let bad_prefix = "8797664862:BAFXV3ySwPk-k7mq-2MPLOwKAQ2QKv791v4";
+        let secrets4 = detect_secrets(bad_prefix, None, false);
+        assert!(
+            !secrets4
+                .iter()
+                .any(|s| s.rule_id == "telegram-bot-token-standalone"),
+            "Should not match token whose secret doesn't start with A"
+        );
+    }
+
+    #[test]
     fn test_privacy_mode_aws_account_id() {
         let test_input = "AWS_ACCOUNT_ID=987654321098";
 

--- a/libs/shared/src/secrets/mod.rs
+++ b/libs/shared/src/secrets/mod.rs
@@ -1514,6 +1514,54 @@ mod tests {
     }
 
     #[test]
+    fn test_telegram_bot_token_redaction_bare() {
+        // Bare Telegram bot token without any surrounding context — this was
+        // previously missed because the gitleaks rule requires "telegr" + assignment.
+        let token = "8797664862:AAFXV3ySwPk-k7mq-2MPLOwKAQ2QKv791v4";
+        let result = redact_secrets(token, None, &HashMap::new(), false);
+
+        assert!(
+            !result.redaction_map.is_empty(),
+            "Should redact bare Telegram bot token. Got: {}",
+            result.redacted_string
+        );
+        assert!(
+            !result.redacted_string.contains(token),
+            "Token should be replaced with redaction placeholder"
+        );
+        assert!(
+            result
+                .redacted_string
+                .contains("[REDACTED_SECRET:telegram-bot-token-standalone:"),
+            "Should use telegram-bot-token-standalone rule. Got: {}",
+            result.redacted_string
+        );
+
+        // Verify round-trip restoration
+        let restored = restore_secrets(&result.redacted_string, &result.redaction_map);
+        assert_eq!(restored, token);
+    }
+
+    #[test]
+    fn test_telegram_bot_token_redaction_in_context() {
+        // Token embedded in a config-style line with "telegram" keyword — should
+        // be caught by either the standalone rule or the original gitleaks rule.
+        let input = "TELEGRAM_BOT_TOKEN=8797664862:AAFXV3ySwPk-k7mq-2MPLOwKAQ2QKv791v4";
+        let result = redact_secrets(input, None, &HashMap::new(), false);
+
+        assert!(
+            !result.redaction_map.is_empty(),
+            "Should redact Telegram bot token in config context"
+        );
+        assert!(
+            !result
+                .redacted_string
+                .contains("8797664862:AAFXV3ySwPk-k7mq-2MPLOwKAQ2QKv791v4"),
+            "Token should be replaced with redaction placeholder"
+        );
+    }
+
+    #[test]
     fn test_huawei_cloud_credentials_detection() {
         // Test Huawei Cloud credentials in CSV format
         // Using obviously fake test values (TESTHUAWEI prefix) to avoid GitHub push protection


### PR DESCRIPTION
## Summary

Fixes secret redaction for Telegram bot tokens (e.g. `8797664862:AAF...v4`) that are pasted or typed without surrounding config-style context.

## Problem

The existing `telegram-bot-api-token` rule from gitleaks requires:
1. A contextual keyword like `telegr` before the token
2. An assignment operator (`=`, `:`, `=>`, etc.) between the keyword and the value

This means bare tokens are **not redacted** when:
- Pasted directly into the input or ask_user custom input
- Typed character-by-character without surrounding context like `TELEGRAM_TOKEN=...`
- Embedded in free-form text without the word "telegram"

The `generic-api-key` rule also cannot help because the `:` separator in Telegram tokens is not matched by `\w` in its capture group, so it splits at the colon.

### Why "sometimes works"

The gitleaks rule keywords include generic terms like `bot`, `token`, `key`. When any of those appear elsewhere in the input, the keyword pre-filter passes, but the regex itself still demands `(?:telegr)` in the prefix — so it only fires when the user writes something like `telegram_token = <value>`.

## Solution

Added a new `telegram-bot-token-standalone` rule in `additional_rules.toml` that matches Telegram bot tokens purely by their distinctive format:

```toml
regex = '''\b([0-9]{5,16}:A[A-Za-z0-9_\-]{34})\b'''
keywords = []
```

- **Format-based detection**: Matches the well-defined Telegram token structure (5-16 digit bot ID + `:` + `A` + 34 base64url chars) without requiring any surrounding context
- **`keywords = []`**: Disables the keyword pre-filter so the rule runs against all input — acceptable because the regex is highly specific to Telegram's token format
- **Coexists with the original rule**: The gitleaks `telegram-bot-api-token` rule is preserved for config-style detection; overlapping matches are deduplicated by the existing logic in `redact_secrets()`

## Test plan

Added 5 test cases across 3 tests:

| Test | Validates |
|------|-----------|
| `test_telegram_bot_token_standalone_detection` | Bare token detection, in-sentence detection, rejects short bot IDs (<5 digits), rejects non-`A` prefix |
| `test_telegram_bot_token_redaction_bare` | Full redaction pipeline + round-trip restoration |
| `test_telegram_bot_token_redaction_in_context` | Token with `TELEGRAM_BOT_TOKEN=` prefix still detected |

```
cargo test -p stakpak-shared --lib -- telegram
# 3 passed, 0 failed
cargo test -p stakpak-shared --lib -- secrets::
# 54 passed, 0 failed (all existing tests unaffected)
```

## Files changed

| File | Change |
|------|--------|
| `libs/shared/src/secrets/additional_rules.toml` | New `telegram-bot-token-standalone` rule |
| `libs/shared/src/secrets/gitleaks.rs` | Test for `detect_secrets()` layer |
| `libs/shared/src/secrets/mod.rs` | Tests for full `redact_secrets()` pipeline |