### PR TITLE
fix(acp): allow sovereign/local provider inference without Stakpak API key

### DIFF
--- a/cli/src/commands/acp/server.rs
+++ b/cli/src/commands/acp/server.rs
@@ -1564,9 +1564,14 @@ impl acp::Agent for StakpakAcpAgent {
             *caps = args.client_capabilities.clone();
         }
 
-        // If no API key, provide an auth method for browser-based authentication
+        // Only advertise Stakpak auth if the user has no credentials at all
+        // (no Stakpak API key AND no local provider keys configured)
         // This implements ACP Agent Auth - the agent handles the OAuth-like flow internally
-        let auth_methods = if self.config.read().await.api_key.is_none() {
+        let config_guard = self.config.read().await;
+        let has_any_credentials = config_guard.api_key.is_some()
+            || !config_guard.get_llm_provider_config().providers.is_empty();
+        drop(config_guard);
+        let auth_methods = if !has_any_credentials {
             vec![acp::AuthMethod::new(
                 acp::AuthMethodId::new("stakpak"),
                 "Login to Stakpak",
@@ -1693,7 +1698,7 @@ impl acp::Agent for StakpakAcpAgent {
     ) -> Result<acp::NewSessionResponse, acp::Error> {
         log::info!("Received new session request {args:?}");
 
-        // Check if we have a valid API key
+        // Check if we have valid credentials: either a Stakpak API key OR local provider keys
         // In-memory config is now always up-to-date since authenticate() updates it directly
         let config = self.config.read().await;
         let has_api_key = config.api_key.is_some() || std::env::var("STAKPAK_API_KEY").is_ok() || {
@@ -1710,12 +1715,13 @@ impl acp::Agent for StakpakAcpAgent {
                 Err(_) => false,
             }
         };
+        let has_provider_keys = !config.get_llm_provider_config().providers.is_empty();
         drop(config);
 
-        if !has_api_key {
-            log::error!("API key is missing - authentication required");
+        if !has_api_key && !has_provider_keys {
+            log::error!("No credentials configured - authentication required");
             return Err(acp::Error::auth_required().data(
-                "Authentication required. Use the 'stakpak' auth method to authenticate via browser.".to_string()
+                "Authentication required. Configure a provider with `stakpak auth login` or use the 'stakpak' auth method to authenticate via browser.".to_string()
             ));
         }
 


### PR DESCRIPTION
## Summary

Fixes #659 — ACP mode was unusable for sovereign/local inference because `new_session()` unconditionally required a Stakpak API key, even when the user had valid local provider credentials configured.

## Root Cause

The ACP `new_session()` handler in `cli/src/commands/acp/server.rs` had a hard gate that **only** checked for a Stakpak API key (`config.api_key`). Users who set up sovereign inference via `stakpak auth login --provider anthropic --api-key $KEY` store their credentials in `config.providers["anthropic"].auth`, not in `config.api_key`. This meant the check always failed for local provider setups, returning:

```
Authentication required. Use the 'stakpak' auth method to authenticate via browser.
```

This was inconsistent with the regular agent mode (`main.rs:314-316`), which correctly accepts **either** a Stakpak API key **or** local provider keys.

## Changes

**`cli/src/commands/acp/server.rs`** — two targeted fixes:

1. **`new_session()`**: Added a `has_provider_keys` check alongside the existing `has_api_key` check. Session creation now succeeds if the user has **either** a Stakpak API key **or** configured local provider keys — matching agent mode behavior.

2. **`initialize()`**: The Stakpak browser auth method was advertised whenever `config.api_key.is_none()`, which is always true for sovereign setups. Now it only advertises auth when the user has **no credentials at all**, avoiding confusion for users who already have valid local provider keys.

## What's Not Affected

- **Remote users** (Stakpak API key): `has_api_key` is `true` → same path as before
- **Unauthenticated users**: Both checks are `false` → still get `auth_required`
- **Browser auth flow**: The `authenticate()` method is completely untouched
- **Session storage**: `AgentClient::new()` already correctly uses `LocalStorage` (SQLite) when no Stakpak key is present — this was working but unreachable due to the gate
- **All 330 binary tests pass**, clippy and fmt are clean