### PR TITLE
feat(auth): add OpenAI Codex OAuth support

### DIFF
--- a/cli/src/commands/auth/login.rs
+++ b/cli/src/commands/auth/login.rs
@@ -244,7 +244,7 @@ async fn handle_oauth_login(
         .oauth_config(method_id)
         .ok_or("OAuth not supported for this method")?;
 
-    let mut flow = OAuthFlow::new(oauth_config);
+    let mut flow = OAuthFlow::new(oauth_config.clone());
     let auth_url = flow.generate_auth_url();
 
     println!();
@@ -255,31 +255,56 @@ async fn handle_oauth_login(
     println!("\x1b]8;;{}\x1b\\{}\x1b]8;;\x1b\\", auth_url, auth_url);
     println!();
 
-    // Try to open browser
-    let _ = open::that(&auth_url);
+    let callback = if should_wait_for_local_oauth_callback(&oauth_config.redirect_url) {
+        println!(
+            "Waiting for OAuth callback on {}...",
+            oauth_config.redirect_url
+        );
 
-    // Prompt for authorization code
-    print!("Paste the authorization code: ");
-    io::stdout().flush().map_err(|e| e.to_string())?;
+        let callback_listener =
+            bind_local_oauth_callback_listener(oauth_config.redirect_url.clone()).await?;
 
-    let mut code = String::new();
-    io::stdin()
-        .read_line(&mut code)
-        .map_err(|e| format!("Failed to read input: {}", e))?;
-    let code = code.trim();
+        // Try to open browser after the listener is ready.
+        let _ = open::that(&auth_url);
 
-    if code.is_empty() {
-        println!("Cancelled.");
-        return Ok(());
-    }
+        OAuthCallback::FromRedirect(
+            callback_listener
+                .wait(std::time::Duration::from_secs(300))
+                .await?,
+        )
+    } else {
+        // Try to open browser
+        let _ = open::that(&auth_url);
+
+        // Prompt for authorization code
+        print!("Paste the authorization code: ");
+        io::stdout().flush().map_err(|e| e.to_string())?;
+
+        let mut code = String::new();
+        io::stdin()
+            .read_line(&mut code)
+            .map_err(|e| format!("Failed to read input: {}", e))?;
+        let code = code.trim().to_string();
+
+        if code.is_empty() {
+            println!("Cancelled.");
+            return Ok(());
+        }
+
+        OAuthCallback::Manual(code)
+    };
 
     println!();
     println!("Exchanging code for tokens...");
 
-    let tokens = flow
-        .exchange_code(code)
-        .await
-        .map_err(|e| format!("Token exchange failed: {}", e))?;
+    let tokens = match callback {
+        OAuthCallback::Manual(code) => flow.exchange_code(&code).await,
+        OAuthCallback::FromRedirect(callback) => {
+            flow.exchange_code_with_state(&callback.code, &callback.state)
+                .await
+        }
+    }
+    .map_err(|e| format!("Token exchange failed: {}", e))?;
 
     let auth = provider
         .post_authorize(method_id, &tokens)
@@ -287,6 +312,172 @@ async fn handle_oauth_login(
         .map_err(|e| format!("Post-authorization failed: {}", e))?;
 
     save_auth_to_config(config_dir, provider, profile, auth)
+}
+
+fn should_wait_for_local_oauth_callback(redirect_url: &str) -> bool {
+    let Ok(url) = reqwest::Url::parse(redirect_url) else {
+        return false;
+    };
+
+    matches!(url.host_str(), Some("localhost") | Some("127.0.0.1"))
+}
+
+enum OAuthCallback {
+    Manual(String),
+    FromRedirect(LocalOAuthCallback),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LocalOAuthCallback {
+    code: String,
+    state: String,
+}
+
+struct LocalOAuthCallbackListener {
+    callback_rx: tokio::sync::oneshot::Receiver<Result<LocalOAuthCallback, String>>,
+    server_task: tokio::task::JoinHandle<()>,
+}
+
+impl LocalOAuthCallbackListener {
+    async fn wait(
+        self,
+        timeout_duration: std::time::Duration,
+    ) -> Result<LocalOAuthCallback, String> {
+        let code = match tokio::time::timeout(timeout_duration, self.callback_rx).await {
+            Ok(result) => result.map_err(|_| {
+                "OAuth callback listener closed before receiving a response".to_string()
+            })?,
+            Err(_) => Err(format!(
+                "OAuth callback timed out after {} seconds",
+                timeout_duration.as_secs()
+            )),
+        };
+
+        self.server_task.abort();
+        let _ = self.server_task.await;
+
+        code
+    }
+}
+
+async fn bind_local_oauth_callback_listener(
+    redirect_url: String,
+) -> Result<LocalOAuthCallbackListener, String> {
+    let parsed = reqwest::Url::parse(&redirect_url)
+        .map_err(|e| format!("Invalid OAuth redirect URL '{}': {}", redirect_url, e))?;
+    let host = parsed.host_str().unwrap_or("127.0.0.1");
+    let port = parsed
+        .port_or_known_default()
+        .ok_or_else(|| format!("OAuth redirect URL is missing a port: {}", redirect_url))?;
+    let bind_addr = format!("{}:{}", host, port);
+
+    let listener = tokio::net::TcpListener::bind(&bind_addr)
+        .await
+        .map_err(|e| {
+            format!(
+                "Failed to bind OAuth callback listener on {}: {}",
+                bind_addr, e
+            )
+        })?;
+
+    build_local_oauth_callback_listener(redirect_url, listener)
+}
+
+fn build_local_oauth_callback_listener(
+    redirect_url: String,
+    listener: tokio::net::TcpListener,
+) -> Result<LocalOAuthCallbackListener, String> {
+    let parsed = reqwest::Url::parse(&redirect_url)
+        .map_err(|e| format!("Invalid OAuth redirect URL '{}': {}", redirect_url, e))?;
+    let path = parsed.path().to_string();
+
+    let (code_tx, code_rx) = tokio::sync::oneshot::channel::<Result<LocalOAuthCallback, String>>();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+
+    let code_tx = std::sync::Arc::new(std::sync::Mutex::new(Some(code_tx)));
+    let shutdown_tx = std::sync::Arc::new(std::sync::Mutex::new(Some(shutdown_tx)));
+
+    let build_callback_route = || {
+        let code_tx = code_tx.clone();
+        let shutdown_tx = shutdown_tx.clone();
+        axum::routing::get(
+            move |axum::extract::Query(query): axum::extract::Query<
+                std::collections::HashMap<String, String>,
+            >| {
+                let code_tx = code_tx.clone();
+                let shutdown_tx = shutdown_tx.clone();
+                async move {
+                    let result = if let Some(error) = query.get("error") {
+                        Err(format!(
+                            "OAuth callback returned '{}'{}",
+                            error,
+                            query
+                                .get("error_description")
+                                .map(|description| format!(": {}", description))
+                                .unwrap_or_default()
+                        ))
+                    } else {
+                        match (query.get("code"), query.get("state")) {
+                            (Some(code), Some(state)) => Ok(LocalOAuthCallback {
+                                code: code.clone(),
+                                state: state.clone(),
+                            }),
+                            _ => Err("OAuth callback missing code or state".to_string()),
+                        }
+                    };
+
+                    if let Ok(mut sender) = code_tx.lock()
+                        && let Some(sender) = sender.take()
+                    {
+                        let _ = sender.send(result.clone());
+                    }
+
+                    if let Ok(mut sender) = shutdown_tx.lock()
+                        && let Some(sender) = sender.take()
+                    {
+                        let _ = sender.send(());
+                    }
+
+                    let (body, status) = match result {
+                        Ok(_) => (
+                            "Authentication complete. You can return to Stakpak.",
+                            axum::http::StatusCode::OK,
+                        ),
+                        Err(_) => (
+                            "Authentication failed. You can return to Stakpak for details.",
+                            axum::http::StatusCode::BAD_REQUEST,
+                        ),
+                    };
+
+                    (status, axum::response::Html(body.to_string()))
+                }
+            },
+        )
+    };
+
+    let mut app = axum::Router::new().route(&path, build_callback_route());
+    if path != "/" {
+        app = app.route("/", build_callback_route());
+    }
+    if path != "/callback" {
+        app = app.route("/callback", build_callback_route());
+    }
+
+    let server =
+        axum::serve(listener, app.into_make_service()).with_graceful_shutdown(async move {
+            let _ = shutdown_rx.await;
+        });
+
+    let server_task = tokio::spawn(async move {
+        if let Err(error) = server.await {
+            tracing::debug!("OAuth callback server exited: {}", error);
+        }
+    });
+
+    Ok(LocalOAuthCallbackListener {
+        callback_rx: code_rx,
+        server_task,
+    })
 }
 
 /// Persist a `ProviderAuth` into the config file for the given profile.
@@ -833,5 +1024,111 @@ mod tests {
         )
         .await;
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn should_wait_for_local_oauth_callback_detects_localhost_redirects() {
+        assert!(should_wait_for_local_oauth_callback(
+            "http://localhost:1455/callback"
+        ));
+        assert!(should_wait_for_local_oauth_callback(
+            "http://127.0.0.1:1455/callback"
+        ));
+        assert!(!should_wait_for_local_oauth_callback(
+            "https://console.anthropic.com/oauth/code/callback"
+        ));
+    }
+
+    fn reserve_local_callback_listener(
+        redirect_url: &str,
+    ) -> Result<(String, LocalOAuthCallbackListener), String> {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")
+            .map_err(|error| format!("bind temp listener: {error}"))?;
+        let port = listener
+            .local_addr()
+            .map_err(|error| format!("local addr: {error}"))?
+            .port();
+        listener
+            .set_nonblocking(true)
+            .map_err(|error| format!("set nonblocking: {error}"))?;
+        let listener = tokio::net::TcpListener::from_std(listener)
+            .map_err(|error| format!("tokio listener: {error}"))?;
+        let redirect_url = redirect_url.replace("{port}", &port.to_string());
+        let callback_listener =
+            build_local_oauth_callback_listener(redirect_url.clone(), listener)?;
+        Ok((redirect_url, callback_listener))
+    }
+
+    #[tokio::test]
+    async fn local_oauth_callback_listener_is_ready_before_request() {
+        let (redirect_url, callback_listener) =
+            reserve_local_callback_listener("http://127.0.0.1:{port}/callback")
+                .expect("reserve callback listener");
+        let callback_url = format!("{redirect_url}?code=test-code&state=test-state");
+
+        let response = reqwest::get(callback_url)
+            .await
+            .expect("send callback request");
+        assert!(response.status().is_success());
+
+        let callback = callback_listener
+            .wait(std::time::Duration::from_secs(1))
+            .await
+            .expect("oauth callback");
+        assert_eq!(callback.code, "test-code");
+        assert_eq!(callback.state, "test-state");
+    }
+
+    #[tokio::test]
+    async fn local_oauth_callback_listener_accepts_auth_callback_path() {
+        let (redirect_url, callback_listener) =
+            reserve_local_callback_listener("http://127.0.0.1:{port}/auth/callback")
+                .expect("reserve callback listener");
+        let callback_url = format!("{redirect_url}?code=test-code&state=test-state");
+
+        let response = reqwest::get(callback_url)
+            .await
+            .expect("send callback request");
+        assert!(response.status().is_success());
+
+        let callback = callback_listener
+            .wait(std::time::Duration::from_secs(1))
+            .await
+            .expect("oauth callback");
+        assert_eq!(callback.code, "test-code");
+        assert_eq!(callback.state, "test-state");
+    }
+
+    #[tokio::test]
+    async fn local_oauth_callback_listener_accepts_callback_path_when_redirect_uses_root() {
+        let (redirect_url, callback_listener) =
+            reserve_local_callback_listener("http://127.0.0.1:{port}")
+                .expect("reserve callback listener");
+        let callback_url = format!("{redirect_url}/callback?code=test-code&state=test-state");
+
+        let response = reqwest::get(callback_url)
+            .await
+            .expect("send callback request");
+        assert!(response.status().is_success());
+
+        let callback = callback_listener
+            .wait(std::time::Duration::from_secs(1))
+            .await
+            .expect("oauth callback");
+        assert_eq!(callback.code, "test-code");
+        assert_eq!(callback.state, "test-state");
+    }
+
+    #[tokio::test]
+    async fn local_oauth_callback_listener_times_out() {
+        let (_redirect_url, callback_listener) =
+            reserve_local_callback_listener("http://127.0.0.1:{port}/callback")
+                .expect("reserve callback listener");
+
+        let error = callback_listener
+            .wait(std::time::Duration::from_millis(10))
+            .await
+            .expect_err("listener should time out");
+        assert!(error.contains("timed out"));
     }
 }

--- a/cli/src/config/app.rs
+++ b/cli/src/config/app.rs
@@ -5,7 +5,6 @@ use stakpak_shared::auth_manager::AuthManager;
 use stakpak_shared::models::auth::ProviderAuth;
 use stakpak_shared::models::integrations::anthropic::AnthropicConfig;
 use stakpak_shared::models::integrations::gemini::GeminiConfig;
-use stakpak_shared::models::integrations::openai::OpenAIConfig;
 use stakpak_shared::models::llm::{LLMProviderConfig, ProviderConfig};
 use std::collections::HashMap;
 use std::fs::{create_dir_all, write};
@@ -217,6 +216,8 @@ impl AppConfig {
     ) -> Result<ConfigFile, ConfigError> {
         match std::fs::read_to_string(config_path.as_ref()) {
             Ok(content) => {
+                Self::validate_removed_openai_provider_fields(&content)?;
+
                 let config_file = toml::from_str::<ConfigFile>(&content).or_else(|e| {
                     println!("Failed to parse config file in new format: {}", e);
                     Self::migrate_old_config(config_path.as_ref(), &content)
@@ -231,6 +232,46 @@ impl AppConfig {
                 e
             ))),
         }
+    }
+
+    fn validate_removed_openai_provider_fields(content: &str) -> Result<(), ConfigError> {
+        let value = match content.parse::<toml::Value>() {
+            Ok(value) => value,
+            Err(_) => return Ok(()),
+        };
+
+        let Some(profiles) = value.get("profiles").and_then(toml::Value::as_table) else {
+            return Ok(());
+        };
+
+        for (profile_name, profile) in profiles {
+            if let Some(openai) = profile.get("openai").and_then(toml::Value::as_table) {
+                for removed_field in ["custom_headers", "use_responses_api"] {
+                    if openai.contains_key(removed_field) {
+                        return Err(ConfigError::Message(format!(
+                            "profiles.{profile_name}.openai.{removed_field} has been removed; update the OpenAI provider config"
+                        )));
+                    }
+                }
+            }
+
+            if let Some(openai) = profile
+                .get("providers")
+                .and_then(toml::Value::as_table)
+                .and_then(|providers| providers.get("openai"))
+                .and_then(toml::Value::as_table)
+            {
+                for removed_field in ["custom_headers", "use_responses_api"] {
+                    if openai.contains_key(removed_field) {
+                        return Err(ConfigError::Message(format!(
+                            "profiles.{profile_name}.providers.openai.{removed_field} has been removed; update the OpenAI provider config"
+                        )));
+                    }
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Migrate legacy provider configs (openai, anthropic, gemini)
@@ -446,9 +487,10 @@ impl AppConfig {
             .get(provider)
             .ok_or_else(|| format!("Unknown provider: {}", provider))?;
 
-        // Get OAuth config (use claude-max as default for Anthropic)
+        // Get OAuth config for the provider's default subscription flow.
         let method_id = match provider {
             "anthropic" => "claude-max",
+            "openai" => "chatgpt-plus-pro",
             _ => return Err(format!("OAuth refresh not implemented for {}", provider)),
         };
 
@@ -467,8 +509,16 @@ impl AppConfig {
 
         // Create new auth with updated tokens
         let new_expires = chrono::Utc::now().timestamp_millis() + (tokens.expires_in * 1000);
-        let new_auth =
-            ProviderAuth::oauth(&tokens.access_token, &tokens.refresh_token, new_expires);
+        let new_auth = if let Some(name) = auth.subscription_name() {
+            ProviderAuth::oauth_with_name(
+                &tokens.access_token,
+                &tokens.refresh_token,
+                new_expires,
+                name,
+            )
+        } else {
+            ProviderAuth::oauth(&tokens.access_token, &tokens.refresh_token, new_expires)
+        };
 
         // Save the updated tokens to config.toml
         if let Err(e) = self.save_provider_auth(provider, new_auth.clone()) {
@@ -584,67 +634,41 @@ impl AppConfig {
         None
     }
 
-    /// Get OpenAI config with resolved credentials.
-    pub fn get_openai_config_with_auth(&self) -> Option<OpenAIConfig> {
-        // First check providers HashMap
-        if let Some(ProviderConfig::OpenAI { api_endpoint, .. }) = self.providers.get("openai") {
-            if let Some(auth) = self.resolve_provider_auth("openai") {
-                let mut config = OpenAIConfig::from_provider_auth(&auth).unwrap_or(OpenAIConfig {
-                    api_key: None,
-                    api_endpoint: None,
-                });
-                config.api_endpoint = api_endpoint.clone();
-                return Some(config);
-            }
-            return None;
-        }
+    fn build_openai_provider_config_with_auth(&self, auth: ProviderAuth) -> ProviderConfig {
+        let api_endpoint = match self.providers.get("openai") {
+            Some(ProviderConfig::OpenAI { api_endpoint, .. }) => api_endpoint.clone(),
+            _ => None,
+        };
 
-        // Fall back to resolve_provider_auth only
-        self.resolve_provider_auth("openai")
-            .and_then(|auth| OpenAIConfig::from_provider_auth(&auth))
+        ProviderConfig::OpenAI {
+            api_key: None,
+            api_endpoint,
+            auth: Some(auth),
+        }
     }
 
-    /// Get OpenAI config with resolved credentials, refreshing OAuth tokens if needed.
-    pub async fn get_openai_config_with_auth_async(&self) -> Option<OpenAIConfig> {
-        // First check providers HashMap
-        if let Some(ProviderConfig::OpenAI { api_endpoint, .. }) = self.providers.get("openai") {
-            if let Some(auth) = self.resolve_provider_auth("openai") {
-                let auth = match self.refresh_provider_auth_if_needed("openai", &auth).await {
-                    Ok(refreshed_auth) => refreshed_auth,
-                    Err(e) => {
-                        eprintln!(
-                            "\x1b[33mWarning: Failed to refresh OpenAI token: {}\x1b[0m",
-                            e
-                        );
-                        auth
-                    }
-                };
-                let mut config = OpenAIConfig::from_provider_auth(&auth).unwrap_or(OpenAIConfig {
-                    api_key: None,
-                    api_endpoint: None,
-                });
-                config.api_endpoint = api_endpoint.clone();
-                return Some(config);
-            }
-            return None;
-        }
+    fn get_openai_provider_config_with_auth(&self) -> Option<ProviderConfig> {
+        self.resolve_provider_auth("openai")
+            .map(|auth| self.build_openai_provider_config_with_auth(auth))
+    }
 
-        // Fall back to resolve_provider_auth only (with refresh)
-        if let Some(auth) = self.resolve_provider_auth("openai") {
-            let auth = match self.refresh_provider_auth_if_needed("openai", &auth).await {
-                Ok(refreshed_auth) => refreshed_auth,
+    async fn get_openai_provider_config_with_auth_async(&self) -> Option<ProviderConfig> {
+        let auth = if let Some(auth) = self.resolve_provider_auth("openai") {
+            match self.refresh_provider_auth_if_needed("openai", &auth).await {
+                Ok(refreshed_auth) => Some(refreshed_auth),
                 Err(e) => {
                     eprintln!(
                         "\x1b[33mWarning: Failed to refresh OpenAI token: {}\x1b[0m",
                         e
                     );
-                    auth
+                    Some(auth)
                 }
-            };
-            return OpenAIConfig::from_provider_auth(&auth);
-        }
+            }
+        } else {
+            None
+        }?;
 
-        None
+        Some(self.build_openai_provider_config_with_auth(auth))
     }
 
     /// Get Gemini config with resolved credentials.
@@ -726,19 +750,12 @@ impl AppConfig {
     fn add_builtin_providers(
         &self,
         config: &mut LLMProviderConfig,
-        openai: Option<OpenAIConfig>,
+        openai: Option<ProviderConfig>,
         anthropic: Option<AnthropicConfig>,
         gemini: Option<GeminiConfig>,
     ) {
         if let Some(openai) = openai {
-            config.add_provider(
-                "openai",
-                ProviderConfig::OpenAI {
-                    api_key: openai.api_key,
-                    api_endpoint: openai.api_endpoint,
-                    auth: None, // Auth is already resolved into api_key
-                },
-            );
+            config.add_provider("openai", openai);
         }
         if let Some(anthropic) = anthropic {
             config.add_provider(
@@ -787,7 +804,7 @@ impl AppConfig {
         self.add_custom_providers(&mut config);
         self.add_builtin_providers(
             &mut config,
-            self.get_openai_config_with_auth(),
+            self.get_openai_provider_config_with_auth(),
             self.get_anthropic_config_with_auth(),
             self.get_gemini_config_with_auth(),
         );
@@ -802,7 +819,7 @@ impl AppConfig {
         self.add_custom_providers(&mut config);
         self.add_builtin_providers(
             &mut config,
-            self.get_openai_config_with_auth_async().await,
+            self.get_openai_provider_config_with_auth_async().await,
             self.get_anthropic_config_with_auth_async().await,
             self.get_gemini_config_with_auth_async().await,
         );

--- a/cli/src/config/mod.rs
+++ b/cli/src/config/mod.rs
@@ -11,6 +11,7 @@
 mod app;
 mod file;
 pub mod models_cache;
+pub(crate) mod openai_resolver;
 mod profile;
 pub(crate) mod profile_resolver;
 mod rulebook;

--- a/cli/src/config/openai_resolver.rs
+++ b/cli/src/config/openai_resolver.rs
@@ -1,0 +1,6 @@
+#[allow(unused_imports)]
+pub(crate) use stakpak_shared::models::openai_runtime::{
+    CodexBackendProfile, CompatibleBackendProfile, OfficialBackendProfile, OpenAIBackendProfile,
+    OpenAIBackendResolutionInput, OpenAIResolutionError, OpenAIResolvedAuth, OpenAIResolvedConfig,
+    resolve_openai_runtime,
+};

--- a/cli/src/config/tests.rs
+++ b/cli/src/config/tests.rs
@@ -877,6 +877,241 @@ api_key = "gemini-key"
     assert_eq!(gemini.api_key(), Some("gemini-key"));
 }
 
+#[test]
+fn openai_oauth_resolves_codex_backend_profile() {
+    use crate::config::openai_resolver::{OpenAIBackendProfile, OpenAIBackendResolutionInput};
+    use base64::Engine;
+
+    let dir = TempDir::new().expect("temp dir");
+    let config_path = dir.path().join("config.toml");
+
+    let payload = serde_json::json!({
+        "https://api.openai.com/auth": {
+            "chatgpt_account_id": "acct_test_789"
+        }
+    });
+    let encoded_payload =
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload.to_string().as_bytes());
+    let access_token = format!("header.{}.signature", encoded_payload);
+
+    let config_toml = format!(
+        r#"
+[settings]
+
+[profiles.default]
+provider = "local"
+
+[profiles.default.providers.openai]
+type = "openai"
+
+[profiles.default.providers.openai.auth]
+type = "oauth"
+access = "{access_token}"
+refresh = "refresh-token"
+expires = 1735600000000
+name = "ChatGPT Plus/Pro"
+"#
+    );
+
+    std::fs::write(&config_path, config_toml).expect("write config");
+    let app = AppConfig::load("default", Some(&config_path)).expect("load app config");
+    let input = OpenAIBackendResolutionInput::new(
+        app.providers.get("openai").cloned(),
+        app.resolve_provider_auth("openai"),
+    );
+    let openai = crate::config::openai_resolver::resolve_openai_runtime(input)
+        .expect("resolver success")
+        .expect("resolved openai config");
+
+    match openai.backend {
+        OpenAIBackendProfile::Codex(codex) => {
+            assert_eq!(
+                codex.base_url,
+                stakpak_shared::models::integrations::openai::OpenAIConfig::OPENAI_CODEX_BASE_URL
+            );
+            assert_eq!(codex.chatgpt_account_id, "acct_test_789");
+            assert_eq!(codex.originator, "stakpak");
+        }
+        _ => panic!("expected codex backend"),
+    }
+}
+
+#[test]
+fn openai_oauth_without_account_id_fails_runtime_resolution() {
+    use crate::config::openai_resolver::OpenAIBackendResolutionInput;
+    use base64::Engine;
+
+    let dir = TempDir::new().expect("temp dir");
+    let config_path = dir.path().join("config.toml");
+
+    let payload = serde_json::json!({
+        "https://api.openai.com/auth": {}
+    });
+    let encoded_payload =
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload.to_string().as_bytes());
+    let access_token = format!("header.{}.signature", encoded_payload);
+
+    let config_toml = format!(
+        r#"
+[settings]
+
+[profiles.default]
+provider = "local"
+
+[profiles.default.providers.openai]
+type = "openai"
+
+[profiles.default.providers.openai.auth]
+type = "oauth"
+access = "{access_token}"
+refresh = "refresh-token"
+expires = 1735600000000
+name = "ChatGPT Plus/Pro"
+"#
+    );
+
+    std::fs::write(&config_path, config_toml).expect("write config");
+    let app = AppConfig::load("default", Some(&config_path)).expect("load app config");
+    let input = OpenAIBackendResolutionInput::new(
+        app.providers.get("openai").cloned(),
+        app.resolve_provider_auth("openai"),
+    );
+
+    let result = crate::config::openai_resolver::resolve_openai_runtime(input);
+    assert!(result.is_err());
+}
+
+#[test]
+fn openai_oauth_resolves_codex_endpoint_headers_and_responses_mode() {
+    use base64::Engine;
+
+    let dir = TempDir::new().expect("temp dir");
+    let config_path = dir.path().join("config.toml");
+
+    let payload = serde_json::json!({
+        "https://api.openai.com/auth": {
+            "chatgpt_account_id": "acct_test_789"
+        }
+    });
+    let encoded_payload =
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload.to_string().as_bytes());
+    let access_token = format!("header.{}.signature", encoded_payload);
+
+    let config_toml = format!(
+        r#"
+[settings]
+
+[profiles.default]
+provider = "local"
+
+[profiles.default.providers.openai]
+type = "openai"
+
+[profiles.default.providers.openai.auth]
+type = "oauth"
+access = "{access_token}"
+refresh = "refresh-token"
+expires = 1735600000000
+name = "ChatGPT Plus/Pro"
+"#
+    );
+
+    std::fs::write(&config_path, config_toml).expect("write config");
+    let app = AppConfig::load("default", Some(&config_path)).expect("load app config");
+    let openai = crate::config::openai_resolver::resolve_openai_runtime(
+        crate::config::openai_resolver::OpenAIBackendResolutionInput::new(
+            app.providers.get("openai").cloned(),
+            app.resolve_provider_auth("openai"),
+        ),
+    )
+    .expect("resolver success")
+    .expect("resolved openai config");
+
+    match openai.backend {
+        crate::config::openai_resolver::OpenAIBackendProfile::Codex(codex) => {
+            assert_eq!(
+                codex.base_url,
+                stakpak_shared::models::integrations::openai::OpenAIConfig::OPENAI_CODEX_BASE_URL
+            );
+            assert_eq!(codex.chatgpt_account_id, "acct_test_789");
+            assert_eq!(codex.originator, "stakpak");
+        }
+        _ => panic!("expected codex backend"),
+    }
+
+    assert!(matches!(
+        openai.default_api_mode,
+        stakai::types::OpenAIApiConfig::Responses(_)
+    ));
+}
+
+#[test]
+fn openai_api_key_keeps_standard_routing() {
+    use crate::config::openai_resolver::{OpenAIBackendProfile, OpenAIResolvedAuth};
+
+    let dir = TempDir::new().expect("temp dir");
+    let config_path = dir.path().join("config.toml");
+    let config_toml = r#"
+[settings]
+
+[profiles.default]
+provider = "local"
+
+[profiles.default.providers.openai]
+type = "openai"
+api_key = "sk-openai-test"
+"#;
+
+    std::fs::write(&config_path, config_toml).expect("write config");
+    let app = AppConfig::load("default", Some(&config_path)).expect("load app config");
+    let openai = crate::config::openai_resolver::resolve_openai_runtime(
+        crate::config::openai_resolver::OpenAIBackendResolutionInput::new(
+            app.providers.get("openai").cloned(),
+            app.resolve_provider_auth("openai"),
+        ),
+    )
+    .expect("resolver success")
+    .expect("resolved openai config");
+
+    match openai.auth {
+        OpenAIResolvedAuth::ApiKey { key } => assert_eq!(key, "sk-openai-test"),
+        _ => panic!("expected api key auth"),
+    }
+
+    match openai.backend {
+        OpenAIBackendProfile::Official(profile) => {
+            assert_eq!(profile.base_url, "https://api.openai.com/v1")
+        }
+        _ => panic!("expected official backend"),
+    }
+}
+
+#[test]
+fn openai_removed_legacy_transport_fields_fail_to_load() {
+    let dir = TempDir::new().expect("temp dir");
+    let config_path = dir.path().join("config.toml");
+    let config_toml = r#"
+[settings]
+
+[profiles.default]
+provider = "local"
+
+[profiles.default.providers.openai]
+type = "openai"
+api_key = "sk-openai-test"
+use_responses_api = true
+
+[profiles.default.providers.openai.custom_headers]
+originator = "stakpak"
+"#;
+
+    std::fs::write(&config_path, config_toml).expect("write config");
+
+    let result = AppConfig::load("default", Some(&config_path));
+
+    assert!(result.is_err());
+}
+
 // =============================================================================
 // Legacy Provider Migration Tests
 // =============================================================================

--- a/libs/ai/src/providers/openai/convert.rs
+++ b/libs/ai/src/providers/openai/convert.rs
@@ -558,10 +558,16 @@ pub fn to_responses_request(req: &GenerateRequest, stream: bool) -> ResponsesReq
         req.options.top_p
     };
 
+    let store = match &req.provider_options {
+        Some(ProviderOptions::OpenAI(opts)) => opts.store,
+        _ => None,
+    };
+
     ResponsesRequest {
         model: req.model.id.clone(),
         input,
         instructions: None, // System message is in input array
+        store,
         max_output_tokens: req.options.max_tokens,
         temperature,
         top_p,
@@ -866,6 +872,21 @@ mod tests {
         let responses_req = to_responses_request(&req, false);
 
         assert_eq!(responses_req.service_tier, Some("flex".to_string()));
+    }
+
+    #[test]
+    fn test_to_responses_request_with_store_flag() {
+        let req = make_request(
+            "gpt-4o",
+            Some(ProviderOptions::OpenAI(OpenAIOptions {
+                api_config: Some(OpenAIApiConfig::Responses(ResponsesConfig::default())),
+                store: Some(true),
+                ..Default::default()
+            })),
+        );
+        let responses_req = to_responses_request(&req, false);
+
+        assert_eq!(responses_req.store, Some(true));
     }
 
     #[test]

--- a/libs/ai/src/providers/openai/mod.rs
+++ b/libs/ai/src/providers/openai/mod.rs
@@ -3,6 +3,7 @@
 pub mod convert;
 mod error;
 mod provider;
+pub mod runtime;
 pub mod stream;
 pub mod types;
 

--- a/libs/ai/src/providers/openai/provider.rs
+++ b/libs/ai/src/providers/openai/provider.rs
@@ -3,7 +3,10 @@
 use super::convert::{
     from_openai_response, from_responses_response, to_openai_request, to_responses_request,
 };
-use super::stream::{create_completions_stream, create_responses_stream};
+use super::runtime::{CodexBackendProfile, CompatibleBackendProfile, OfficialBackendProfile};
+use super::stream::{
+    create_completions_stream, create_responses_stream, create_responses_stream_from_response,
+};
 use super::types::{ChatCompletionResponse, OpenAIConfig, ResponsesResponse};
 use crate::error::{Error, Result};
 use crate::provider::Provider;
@@ -15,15 +18,322 @@ use crate::types::{
 use async_trait::async_trait;
 use reqwest::Client;
 use reqwest_eventsource::EventSource;
+use serde::Deserialize;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone)]
+struct CodexModelsCacheEntry {
+    models: Vec<Model>,
+    fetched_at: Instant,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexModelRecord {
+    id: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    reasoning: bool,
+    #[serde(default, alias = "context_window", alias = "context_length")]
+    context_window: Option<u64>,
+    #[serde(default, alias = "max_output_tokens", alias = "max_completion_tokens")]
+    max_output_tokens: Option<u64>,
+    #[serde(default)]
+    release_date: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum CodexModelsResponse {
+    Envelope { data: Vec<CodexModelRecord> },
+    Array(Vec<CodexModelRecord>),
+}
+
+impl CodexModelsResponse {
+    fn into_models(self) -> Vec<Model> {
+        let records = match self {
+            Self::Envelope { data } => data,
+            Self::Array(data) => data,
+        };
+
+        records
+            .into_iter()
+            .map(|record| {
+                let mut model = Model::new(
+                    record.id.clone(),
+                    record.name.unwrap_or_else(|| record.id.clone()),
+                    "openai",
+                    record.reasoning,
+                    None,
+                    crate::types::ModelLimit::new(
+                        record.context_window.unwrap_or(128_000),
+                        record.max_output_tokens.unwrap_or(8_192),
+                    ),
+                );
+                model.release_date = record.release_date;
+                model
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ApiMode {
+    Responses,
+    Completions,
+}
+
+fn apply_additional_headers(headers: &mut Headers, additional_headers: &Headers) {
+    headers.merge_with(additional_headers);
+}
+
+fn apply_codex_headers(
+    headers: &mut Headers,
+    profile: &CodexBackendProfile,
+    additional_headers: &Headers,
+) {
+    headers.merge_with(additional_headers);
+    headers.insert("originator", profile.originator.clone());
+    headers.insert("ChatGPT-Account-Id", profile.chatgpt_account_id.clone());
+}
+
+fn build_codex_responses_request(
+    request: &GenerateRequest,
+    stream: bool,
+) -> super::types::ResponsesRequest {
+    let mut responses_req = to_responses_request(request, stream);
+    let instructions = request
+        .messages
+        .iter()
+        .filter(|message| matches!(message.role, crate::types::Role::System))
+        .filter_map(|message| message.text())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    responses_req.instructions = Some(instructions);
+    responses_req.store = Some(false);
+    responses_req.max_output_tokens = None;
+    responses_req.input.retain(|item| {
+        !matches!(
+            item.get("role").and_then(|role| role.as_str()),
+            Some("system") | Some("developer")
+        )
+    });
+    responses_req
+}
+
+#[async_trait]
+trait OpenAIModelCatalog {
+    async fn list_models(
+        &self,
+        client: &Client,
+        headers: &Headers,
+        base_url: &str,
+    ) -> Result<Vec<Model>>;
+}
+
+#[derive(Debug, Default)]
+struct OfficialModelCatalog;
+
+#[async_trait]
+impl OpenAIModelCatalog for OfficialModelCatalog {
+    async fn list_models(
+        &self,
+        _client: &Client,
+        _headers: &Headers,
+        _base_url: &str,
+    ) -> Result<Vec<Model>> {
+        crate::registry::models_dev::load_models_for_provider("openai")
+    }
+}
+
+#[derive(Debug, Default)]
+struct CompatibleModelCatalog;
+
+#[async_trait]
+impl OpenAIModelCatalog for CompatibleModelCatalog {
+    async fn list_models(
+        &self,
+        _client: &Client,
+        _headers: &Headers,
+        _base_url: &str,
+    ) -> Result<Vec<Model>> {
+        crate::registry::models_dev::load_models_for_provider("openai")
+    }
+}
+
+#[derive(Debug, Default)]
+struct CodexModelCatalog {
+    cache: Mutex<Option<CodexModelsCacheEntry>>,
+}
+
+impl CodexModelCatalog {
+    const CACHE_TTL: Duration = Duration::from_secs(5 * 60);
+
+    fn cached_models(&self) -> Option<Vec<Model>> {
+        let Ok(cache) = self.cache.lock() else {
+            return None;
+        };
+        let entry = cache.as_ref()?;
+        if entry.fetched_at.elapsed() <= Self::CACHE_TTL {
+            return Some(entry.models.clone());
+        }
+        None
+    }
+
+    fn store_models(&self, models: &[Model]) {
+        if let Ok(mut cache) = self.cache.lock() {
+            *cache = Some(CodexModelsCacheEntry {
+                models: models.to_vec(),
+                fetched_at: Instant::now(),
+            });
+        }
+    }
+}
+
+#[async_trait]
+impl OpenAIModelCatalog for CodexModelCatalog {
+    async fn list_models(
+        &self,
+        client: &Client,
+        headers: &Headers,
+        base_url: &str,
+    ) -> Result<Vec<Model>> {
+        if let Some(models) = self.cached_models() {
+            return Ok(models);
+        }
+
+        let response = client
+            .get(format!("{base_url}/models"))
+            .headers(headers.to_reqwest_headers())
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            return Err(Error::provider_error(format!(
+                "OpenAI Codex models API error {}: {}",
+                status, error_text
+            )));
+        }
+
+        let response_body: CodexModelsResponse = response.json().await?;
+        let models = response_body.into_models();
+        self.store_models(&models);
+        Ok(models)
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+struct CodexStreamTransport;
+
+impl CodexStreamTransport {
+    fn build_headers(&self, mut headers: Headers, request: &GenerateRequest) -> Headers {
+        headers.insert("Accept", "text/event-stream");
+        headers.insert("OpenAI-Beta", "responses=experimental");
+
+        if let Some(ProviderOptions::OpenAI(options)) = request.provider_options.as_ref()
+            && let Some(OpenAIApiConfig::Responses(config)) = options.api_config.as_ref()
+            && let Some(session_id) = config.session_id.as_ref()
+        {
+            headers.insert("session_id", session_id.clone());
+        }
+
+        headers
+    }
+
+    async fn stream(
+        &self,
+        client: &Client,
+        base_url: &str,
+        headers: &Headers,
+        request: &super::types::ResponsesRequest,
+    ) -> Result<GenerateStream> {
+        let response = client
+            .post(format!("{base_url}/responses"))
+            .headers(headers.to_reqwest_headers())
+            .json(request)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            return Err(Error::provider_error(format!(
+                "OpenAI Responses API error {}: {}",
+                status, error_text
+            )));
+        }
+
+        create_responses_stream_from_response(response).await
+    }
+}
+
+#[derive(Debug)]
+struct OfficialBackend {
+    profile: OfficialBackendProfile,
+    additional_headers: Headers,
+    model_catalog: OfficialModelCatalog,
+}
+
+#[derive(Debug)]
+struct CompatibleBackend {
+    profile: CompatibleBackendProfile,
+    additional_headers: Headers,
+    model_catalog: CompatibleModelCatalog,
+}
+
+#[derive(Debug)]
+struct CodexBackend {
+    profile: CodexBackendProfile,
+    additional_headers: Headers,
+    stream_transport: CodexStreamTransport,
+    model_catalog: CodexModelCatalog,
+}
+
+#[derive(Debug)]
+enum OpenAIBackend {
+    Official(OfficialBackend),
+    Compatible(CompatibleBackend),
+    Codex(CodexBackend),
+}
+
+impl OpenAIBackend {
+    fn base_url(&self) -> &str {
+        match self {
+            Self::Official(backend) => &backend.profile.base_url,
+            Self::Compatible(backend) => &backend.profile.base_url,
+            Self::Codex(backend) => &backend.profile.base_url,
+        }
+    }
+
+    fn apply_headers(&self, headers: &mut Headers) {
+        match self {
+            Self::Official(backend) => {
+                apply_additional_headers(headers, &backend.additional_headers)
+            }
+            Self::Compatible(backend) => {
+                apply_additional_headers(headers, &backend.additional_headers)
+            }
+            Self::Codex(backend) => {
+                apply_codex_headers(headers, &backend.profile, &backend.additional_headers)
+            }
+        }
+    }
+}
 
 /// OpenAI provider
 pub struct OpenAIProvider {
     config: OpenAIConfig,
     client: Client,
+    backend: OpenAIBackend,
 }
 
 impl OpenAIProvider {
     const OFFICIAL_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
+    const CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
 
     /// Create a new OpenAI provider
     ///
@@ -35,22 +345,113 @@ impl OpenAIProvider {
             return Err(Error::MissingApiKey("openai".to_string()));
         }
 
-        // Normalize base_url: strip trailing slash to avoid double-slash in URL paths
         config.base_url = config.base_url.trim_end_matches('/').to_string();
-
+        let backend = Self::resolve_backend(&config)?;
         let client = create_platform_tls_client()?;
-        Ok(Self { config, client })
+        Ok(Self {
+            config,
+            client,
+            backend,
+        })
     }
 
-    fn should_use_responses_api(&self, request: &GenerateRequest) -> bool {
+    fn resolve_backend(config: &OpenAIConfig) -> Result<OpenAIBackend> {
+        let base_url = config.base_url.clone();
+        if base_url == Self::OFFICIAL_OPENAI_BASE_URL {
+            return Ok(OpenAIBackend::Official(OfficialBackend {
+                profile: OfficialBackendProfile { base_url },
+                additional_headers: config.custom_headers.clone(),
+                model_catalog: OfficialModelCatalog,
+            }));
+        }
+
+        if base_url == Self::CODEX_BASE_URL || base_url.ends_with("/backend-api/codex") {
+            let mut additional_headers = config.custom_headers.clone();
+            let chatgpt_account_id =
+                additional_headers
+                    .remove("ChatGPT-Account-Id")
+                    .ok_or_else(|| {
+                        Error::ConfigError(
+                            "Codex backend requires ChatGPT-Account-Id header during resolution"
+                                .to_string(),
+                        )
+                    })?;
+            let originator = additional_headers
+                .remove("originator")
+                .unwrap_or_else(|| "stakpak".to_string());
+
+            return Ok(OpenAIBackend::Codex(CodexBackend {
+                profile: CodexBackendProfile {
+                    base_url,
+                    originator,
+                    chatgpt_account_id,
+                },
+                additional_headers,
+                stream_transport: CodexStreamTransport,
+                model_catalog: CodexModelCatalog::default(),
+            }));
+        }
+
+        Ok(OpenAIBackend::Compatible(CompatibleBackend {
+            profile: CompatibleBackendProfile { base_url },
+            additional_headers: config.custom_headers.clone(),
+            model_catalog: CompatibleModelCatalog,
+        }))
+    }
+
+    fn requested_api_mode(request: &GenerateRequest) -> Option<ApiMode> {
         match request.provider_options.as_ref() {
             Some(ProviderOptions::OpenAI(opts)) => match &opts.api_config {
-                Some(OpenAIApiConfig::Responses(_)) => true,
-                Some(OpenAIApiConfig::Completions(_)) => false,
-                None => self.config.base_url == Self::OFFICIAL_OPENAI_BASE_URL,
+                Some(OpenAIApiConfig::Responses(_)) => Some(ApiMode::Responses),
+                Some(OpenAIApiConfig::Completions(_)) => Some(ApiMode::Completions),
+                None => None,
             },
-            Some(_) => false,
-            None => self.config.base_url == Self::OFFICIAL_OPENAI_BASE_URL,
+            _ => None,
+        }
+    }
+
+    fn effective_api_mode(&self, request: &GenerateRequest) -> ApiMode {
+        if let Some(mode) = Self::requested_api_mode(request) {
+            return match self.backend {
+                OpenAIBackend::Codex(_) => ApiMode::Responses,
+                _ => mode,
+            };
+        }
+
+        match &self.backend {
+            OpenAIBackend::Official(_) => ApiMode::Responses,
+            OpenAIBackend::Compatible(_) => self
+                .config
+                .default_openai_options
+                .as_ref()
+                .and_then(|options| options.api_config.as_ref())
+                .map(|api_config| match api_config {
+                    OpenAIApiConfig::Responses(_) => ApiMode::Responses,
+                    OpenAIApiConfig::Completions(_) => ApiMode::Completions,
+                })
+                .unwrap_or(ApiMode::Completions),
+            OpenAIBackend::Codex(_) => ApiMode::Responses,
+        }
+    }
+
+    fn build_responses_request(
+        &self,
+        request: &GenerateRequest,
+        stream: bool,
+    ) -> super::types::ResponsesRequest {
+        match &self.backend {
+            OpenAIBackend::Codex(_) => build_codex_responses_request(request, stream),
+            _ => to_responses_request(request, stream),
+        }
+    }
+
+    fn build_stream_headers(&self, request: &GenerateRequest) -> Headers {
+        let headers = self.build_headers(request.options.headers.as_ref());
+        match &self.backend {
+            OpenAIBackend::Codex(backend) => {
+                backend.stream_transport.build_headers(headers, request)
+            }
+            _ => headers,
         }
     }
 
@@ -76,6 +477,8 @@ impl Provider for OpenAIProvider {
             headers.insert("OpenAI-Organization", org);
         }
 
+        self.backend.apply_headers(&mut headers);
+
         if let Some(custom) = custom_headers {
             headers.merge_with(custom);
         }
@@ -86,9 +489,9 @@ impl Provider for OpenAIProvider {
     async fn generate(&self, request: GenerateRequest) -> Result<GenerateResponse> {
         let headers = self.build_headers(request.options.headers.as_ref());
 
-        if self.should_use_responses_api(&request) {
-            let url = format!("{}/responses", self.config.base_url);
-            let responses_req = to_responses_request(&request, false);
+        if matches!(self.effective_api_mode(&request), ApiMode::Responses) {
+            let url = format!("{}/responses", self.backend.base_url());
+            let responses_req = self.build_responses_request(&request, false);
 
             let response = self
                 .client
@@ -110,7 +513,7 @@ impl Provider for OpenAIProvider {
             let responses_resp: ResponsesResponse = response.json().await?;
             from_responses_response(responses_resp)
         } else {
-            let url = format!("{}/chat/completions", self.config.base_url);
+            let url = format!("{}/chat/completions", self.backend.base_url());
             let openai_req = to_openai_request(&request, false);
 
             let response = self
@@ -136,25 +539,45 @@ impl Provider for OpenAIProvider {
     }
 
     async fn stream(&self, request: GenerateRequest) -> Result<GenerateStream> {
-        let headers = self.build_headers(request.options.headers.as_ref());
-
-        if self.should_use_responses_api(&request) {
-            let url = format!("{}/responses", self.config.base_url);
-            let responses_req = to_responses_request(&request, true);
-
-            let req_builder = self
-                .client
-                .post(&url)
-                .headers(headers.to_reqwest_headers())
-                .json(&responses_req);
-
-            let event_source = EventSource::new(req_builder).map_err(|e| {
-                Error::stream_error(format!("Failed to create event source: {}", e))
-            })?;
-
-            create_responses_stream(event_source).await
+        let api_mode = self.effective_api_mode(&request);
+        let headers = if matches!(api_mode, ApiMode::Responses) {
+            self.build_stream_headers(&request)
         } else {
-            let url = format!("{}/chat/completions", self.config.base_url);
+            self.build_headers(request.options.headers.as_ref())
+        };
+
+        if matches!(api_mode, ApiMode::Responses) {
+            let url = format!("{}/responses", self.backend.base_url());
+            let responses_req = self.build_responses_request(&request, true);
+
+            match &self.backend {
+                OpenAIBackend::Codex(backend) => {
+                    backend
+                        .stream_transport
+                        .stream(
+                            &self.client,
+                            backend.profile.base_url.as_str(),
+                            &headers,
+                            &responses_req,
+                        )
+                        .await
+                }
+                _ => {
+                    let req_builder = self
+                        .client
+                        .post(&url)
+                        .headers(headers.to_reqwest_headers())
+                        .json(&responses_req);
+
+                    let event_source = EventSource::new(req_builder).map_err(|e| {
+                        Error::stream_error(format!("Failed to create event source: {}", e))
+                    })?;
+
+                    create_responses_stream(event_source).await
+                }
+            }
+        } else {
+            let url = format!("{}/chat/completions", self.backend.base_url());
             let openai_req = to_openai_request(&request, true);
 
             let req_builder = self
@@ -172,19 +595,41 @@ impl Provider for OpenAIProvider {
     }
 
     async fn list_models(&self) -> Result<Vec<Model>> {
-        // Load from models.dev cache
-        crate::registry::models_dev::load_models_for_provider("openai")
+        let headers = self.build_headers(None);
+        match &self.backend {
+            OpenAIBackend::Codex(backend) => match backend
+                .model_catalog
+                .list_models(&self.client, &headers, backend.profile.base_url.as_str())
+                .await
+            {
+                Ok(models) => Ok(models),
+                Err(_error) => crate::registry::models_dev::load_models_for_provider("openai"),
+            },
+            OpenAIBackend::Official(backend) => {
+                backend
+                    .model_catalog
+                    .list_models(&self.client, &headers, backend.profile.base_url.as_str())
+                    .await
+            }
+            OpenAIBackend::Compatible(backend) => {
+                backend
+                    .model_catalog
+                    .list_models(&self.client, &headers, backend.profile.base_url.as_str())
+                    .await
+            }
+        }
     }
 
     async fn get_model(&self, id: &str) -> Result<Option<Model>> {
-        let models = crate::registry::models_dev::load_models_for_provider("openai")?;
-        Ok(models.into_iter().find(|m| m.id == id))
+        let models = self.list_models().await?;
+        Ok(models.into_iter().find(|model| model.id == id))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::provider::Provider;
     use crate::types::{GenerateRequest, Message, OpenAIOptions, ProviderOptions, Role};
 
     fn make_request(provider_options: Option<ProviderOptions>) -> GenerateRequest {
@@ -200,7 +645,10 @@ mod tests {
     fn test_defaults_to_responses_for_official_openai_url() {
         let provider = OpenAIProvider::new(OpenAIConfig::new("test-key")).unwrap();
         let req = make_request(None);
-        assert!(provider.should_use_responses_api(&req));
+        assert!(matches!(
+            provider.effective_api_mode(&req),
+            ApiMode::Responses
+        ));
     }
 
     #[test]
@@ -210,14 +658,20 @@ mod tests {
         )
         .unwrap();
         let req = make_request(None);
-        assert!(!provider.should_use_responses_api(&req));
+        assert!(matches!(
+            provider.effective_api_mode(&req),
+            ApiMode::Completions
+        ));
     }
 
     #[test]
     fn test_explicit_completions_overrides_official_default() {
         let provider = OpenAIProvider::new(OpenAIConfig::new("test-key")).unwrap();
         let req = make_request(Some(ProviderOptions::OpenAI(OpenAIOptions::completions())));
-        assert!(!provider.should_use_responses_api(&req));
+        assert!(matches!(
+            provider.effective_api_mode(&req),
+            ApiMode::Completions
+        ));
     }
 
     #[test]
@@ -227,6 +681,200 @@ mod tests {
         )
         .unwrap();
         let req = make_request(Some(ProviderOptions::OpenAI(OpenAIOptions::responses())));
-        assert!(provider.should_use_responses_api(&req));
+        assert!(matches!(
+            provider.effective_api_mode(&req),
+            ApiMode::Responses
+        ));
+    }
+
+    #[test]
+    fn test_codex_config_defaults_to_responses_api() {
+        let provider = OpenAIProvider::new(
+            OpenAIConfig::new("test-key")
+                .with_base_url("https://chatgpt.com/backend-api/codex")
+                .with_custom_header("ChatGPT-Account-Id", "acct_test_123")
+                .with_default_openai_options(OpenAIOptions::responses()),
+        )
+        .unwrap();
+        let req = make_request(None);
+        assert!(matches!(
+            provider.effective_api_mode(&req),
+            ApiMode::Responses
+        ));
+    }
+
+    #[test]
+    fn test_codex_backend_requires_account_id_during_resolution() {
+        let result = OpenAIProvider::new(
+            OpenAIConfig::new("test-key")
+                .with_base_url("https://chatgpt.com/backend-api/codex")
+                .with_default_openai_options(OpenAIOptions::responses()),
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_build_headers_includes_config_custom_headers() {
+        let provider = OpenAIProvider::new(
+            OpenAIConfig::new("test-key")
+                .with_custom_header("originator", "stakpak")
+                .with_custom_header("ChatGPT-Account-Id", "acct_test_123"),
+        )
+        .unwrap();
+
+        let headers = provider.build_headers(None);
+
+        assert_eq!(headers.get("originator"), Some(&"stakpak".to_string()));
+        assert_eq!(
+            headers.get("ChatGPT-Account-Id"),
+            Some(&"acct_test_123".to_string())
+        );
+    }
+
+    #[test]
+    fn test_codex_responses_request_uses_instructions_field() {
+        let provider = OpenAIProvider::new(
+            OpenAIConfig::new("test-key")
+                .with_base_url("https://chatgpt.com/backend-api/codex")
+                .with_custom_header("ChatGPT-Account-Id", "acct_test_123")
+                .with_default_openai_options(OpenAIOptions::responses()),
+        )
+        .expect("provider");
+        let mut req = GenerateRequest::new(
+            Model::custom("codex-mini-latest", "openai"),
+            vec![
+                Message::new(Role::System, "You are a helpful assistant"),
+                Message::new(Role::User, "Hello"),
+            ],
+        );
+        req.provider_options = Some(ProviderOptions::OpenAI(OpenAIOptions::responses()));
+
+        let responses_req = provider.build_responses_request(&req, false);
+
+        assert_eq!(
+            responses_req.instructions,
+            Some("You are a helpful assistant".to_string())
+        );
+        assert_eq!(responses_req.store, Some(false));
+        assert!(responses_req.max_output_tokens.is_none());
+        assert_eq!(responses_req.input.len(), 1);
+        assert_eq!(responses_req.input[0]["role"], "user");
+    }
+
+    #[test]
+    fn test_codex_stream_headers_include_sse_beta_and_session_id() {
+        let provider = OpenAIProvider::new(
+            OpenAIConfig::new("test-key")
+                .with_base_url("https://chatgpt.com/backend-api/codex")
+                .with_custom_header("ChatGPT-Account-Id", "acct_test_123")
+                .with_default_openai_options(OpenAIOptions::responses()),
+        )
+        .expect("provider");
+        let mut req = GenerateRequest::new(
+            Model::custom("codex-mini-latest", "openai"),
+            vec![Message::new(Role::User, "Hello")],
+        );
+        req.provider_options = Some(ProviderOptions::OpenAI(OpenAIOptions {
+            api_config: Some(OpenAIApiConfig::Responses(crate::types::ResponsesConfig {
+                session_id: Some("session-123".to_string()),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }));
+
+        let headers = provider.build_stream_headers(&req);
+
+        assert_eq!(
+            headers.get("Accept"),
+            Some(&"text/event-stream".to_string())
+        );
+        assert_eq!(
+            headers.get("OpenAI-Beta"),
+            Some(&"responses=experimental".to_string())
+        );
+        assert_eq!(headers.get("session_id"), Some(&"session-123".to_string()));
+    }
+
+    #[test]
+    fn test_codex_responses_request_strips_max_output_tokens() {
+        let provider = OpenAIProvider::new(
+            OpenAIConfig::new("test-key")
+                .with_base_url("https://chatgpt.com/backend-api/codex")
+                .with_custom_header("ChatGPT-Account-Id", "acct_test_123")
+                .with_default_openai_options(OpenAIOptions::responses()),
+        )
+        .expect("provider");
+        let mut req = GenerateRequest::new(
+            Model::custom("codex-mini-latest", "openai"),
+            vec![
+                Message::new(Role::System, "You are a helpful assistant"),
+                Message::new(Role::User, "Hello"),
+            ],
+        );
+        req.options.max_tokens = Some(512);
+        req.provider_options = Some(ProviderOptions::OpenAI(OpenAIOptions::responses()));
+
+        let responses_req = provider.build_responses_request(&req, false);
+
+        assert!(responses_req.max_output_tokens.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_list_models_uses_codex_models_endpoint() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/backend-api/codex/models")
+            .match_header("authorization", "Bearer test-key")
+            .match_header("chatgpt-account-id", "acct_test_123")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":[{"id":"codex-mini-latest","name":"Codex Mini Latest","reasoning":true,"context_window":200000,"max_output_tokens":8192}]}"#,
+            )
+            .expect(1)
+            .create();
+
+        let provider = OpenAIProvider::new(
+            OpenAIConfig::new("test-key")
+                .with_base_url(format!("{}/backend-api/codex", server.url()))
+                .with_custom_header("ChatGPT-Account-Id", "acct_test_123"),
+        )
+        .expect("provider");
+
+        let models = provider.list_models().await.expect("codex models");
+
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "codex-mini-latest");
+        assert_eq!(models[0].name, "Codex Mini Latest");
+        assert!(models[0].reasoning);
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_list_models_caches_codex_models_for_ttl_window() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/backend-api/codex/models")
+            .match_header("authorization", "Bearer test-key")
+            .match_header("chatgpt-account-id", "acct_test_123")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data":[{"id":"codex-mini-latest","name":"Codex Mini Latest"}]}"#)
+            .expect(1)
+            .create();
+
+        let provider = OpenAIProvider::new(
+            OpenAIConfig::new("test-key")
+                .with_base_url(format!("{}/backend-api/codex", server.url()))
+                .with_custom_header("ChatGPT-Account-Id", "acct_test_123"),
+        )
+        .expect("provider");
+
+        let first = provider.list_models().await.expect("first model list");
+        let second = provider.list_models().await.expect("second model list");
+
+        assert_eq!(first, second);
+        mock.assert();
     }
 }

--- a/libs/ai/src/providers/openai/runtime.rs
+++ b/libs/ai/src/providers/openai/runtime.rs
@@ -1,0 +1,35 @@
+//! Shared OpenAI runtime profile types.
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OfficialBackendProfile {
+    pub base_url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompatibleBackendProfile {
+    pub base_url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodexBackendProfile {
+    pub base_url: String,
+    pub originator: String,
+    pub chatgpt_account_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OpenAIBackendProfile {
+    Official(OfficialBackendProfile),
+    Codex(CodexBackendProfile),
+    Compatible(CompatibleBackendProfile),
+}
+
+impl OpenAIBackendProfile {
+    pub fn base_url(&self) -> &str {
+        match self {
+            Self::Official(profile) => &profile.base_url,
+            Self::Codex(profile) => &profile.base_url,
+            Self::Compatible(profile) => &profile.base_url,
+        }
+    }
+}

--- a/libs/ai/src/providers/openai/stream.rs
+++ b/libs/ai/src/providers/openai/stream.rs
@@ -14,6 +14,11 @@ use futures::StreamExt;
 use reqwest_eventsource::{self, Event, EventSource};
 use std::error::Error as StdError;
 
+struct SseDispatchResult {
+    events: Vec<StreamEvent>,
+    done: bool,
+}
+
 /// Track state for each tool call during streaming
 #[derive(Debug, Clone)]
 struct ToolCallState {
@@ -353,6 +358,174 @@ pub async fn create_responses_stream(event_source: EventSource) -> Result<Genera
 }
 
 /// Parse a streaming event from Responses API
+fn dispatch_sse_event(
+    event_type: &mut String,
+    data_lines: &mut Vec<String>,
+    state: &mut ResponsesStreamState,
+    started: &mut bool,
+) -> Result<SseDispatchResult> {
+    if event_type.is_empty() && data_lines.is_empty() {
+        return Ok(SseDispatchResult {
+            events: Vec::new(),
+            done: false,
+        });
+    }
+
+    let current_event_type = std::mem::take(event_type);
+    let data = std::mem::take(data_lines).join("\n");
+    if data == "[DONE]" {
+        return Ok(SseDispatchResult {
+            events: Vec::new(),
+            done: true,
+        });
+    }
+
+    let normalized_event_type = if current_event_type.is_empty() {
+        "message"
+    } else {
+        current_event_type.as_str()
+    };
+
+    Ok(SseDispatchResult {
+        events: parse_responses_event(normalized_event_type, &data, state, started)?,
+        done: false,
+    })
+}
+
+fn parse_sse_line(
+    line: &str,
+    event_type: &mut String,
+    data_lines: &mut Vec<String>,
+    state: &mut ResponsesStreamState,
+    started: &mut bool,
+) -> Result<SseDispatchResult> {
+    if line.is_empty() {
+        return dispatch_sse_event(event_type, data_lines, state, started);
+    }
+
+    if line.starts_with(':') {
+        return Ok(SseDispatchResult {
+            events: Vec::new(),
+            done: false,
+        });
+    }
+
+    if let Some(value) = line.strip_prefix("event:") {
+        *event_type = value.trim_start().to_string();
+    } else if let Some(value) = line.strip_prefix("data:") {
+        data_lines.push(value.trim_start().to_string());
+    }
+
+    Ok(SseDispatchResult {
+        events: Vec::new(),
+        done: false,
+    })
+}
+
+pub async fn create_responses_stream_from_response(
+    response: reqwest::Response,
+) -> Result<GenerateStream> {
+    let stream = async_stream::stream! {
+        let mut byte_stream = response.bytes_stream();
+        let mut state = ResponsesStreamState::default();
+        let mut started = false;
+        let mut buffer = Vec::<u8>::new();
+        let mut event_type = String::new();
+        let mut data_lines = Vec::<String>::new();
+
+        while let Some(chunk) = byte_stream.next().await {
+            match chunk {
+                Ok(bytes) => {
+                    buffer.extend_from_slice(&bytes);
+
+                    while let Some(pos) = buffer.iter().position(|byte| *byte == b'\n') {
+                        let mut line_bytes: Vec<u8> = buffer.drain(..=pos).collect();
+                        if matches!(line_bytes.last(), Some(b'\n')) {
+                            let _ = line_bytes.pop();
+                        }
+                        if matches!(line_bytes.last(), Some(b'\r')) {
+                            let _ = line_bytes.pop();
+                        }
+
+                        let line = match String::from_utf8(line_bytes) {
+                            Ok(line) => line,
+                            Err(error) => {
+                                yield Err(Error::stream_error(format!(
+                                    "UTF-8 decode error in stream: {}",
+                                    error
+                                )));
+                                return;
+                            }
+                        };
+
+                        match parse_sse_line(&line, &mut event_type, &mut data_lines, &mut state, &mut started) {
+                            Ok(result) => {
+                                for event in result.events {
+                                    yield Ok(event);
+                                }
+                                if result.done {
+                                    return;
+                                }
+                            }
+                            Err(error) => {
+                                yield Err(error);
+                                return;
+                            }
+                        }
+                    }
+                }
+                Err(error) => {
+                    yield Err(Error::stream_error(format!(
+                        "Transport error: {} | source: {:?}",
+                        error,
+                        error.source()
+                    )));
+                    return;
+                }
+            }
+        }
+
+        if !buffer.is_empty() {
+            let line = match String::from_utf8(std::mem::take(&mut buffer)) {
+                Ok(line) => line.trim_end_matches(['\r', '\n']).to_string(),
+                Err(error) => {
+                    yield Err(Error::stream_error(format!(
+                        "UTF-8 decode error in stream: {}",
+                        error
+                    )));
+                    return;
+                }
+            };
+
+            match parse_sse_line(&line, &mut event_type, &mut data_lines, &mut state, &mut started) {
+                Ok(result) => {
+                    for event in result.events {
+                        yield Ok(event);
+                    }
+                    if result.done {
+                        return;
+                    }
+                }
+                Err(error) => {
+                    yield Err(error);
+                    return;
+                }
+            }
+        }
+
+        match dispatch_sse_event(&mut event_type, &mut data_lines, &mut state, &mut started) {
+            Ok(result) => {
+                for event in result.events {
+                    yield Ok(event);
+                }
+            }
+            Err(error) => yield Err(error),
+        }
+    };
+
+    Ok(GenerateStream::new(Box::pin(stream)))
+}
+
 fn parse_responses_event(
     event_type: &str,
     data: &str,
@@ -860,5 +1033,55 @@ mod tests {
         } else {
             panic!("Expected Finish event");
         }
+    }
+
+    #[tokio::test]
+    async fn test_create_responses_stream_from_response_without_content_type() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/responses")
+            .with_status(200)
+            .with_body(
+                concat!(
+                    "event: response.output_item.added\n",
+                    "data: {\"item\":{\"type\":\"message\",\"id\":\"msg_1\"}}\n\n",
+                    "event: response.output_text.delta\n",
+                    "data: {\"delta\":\"Hello\"}\n\n",
+                    "event: response.completed\n",
+                    "data: {\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n"
+                ),
+            )
+            .create();
+
+        let response = reqwest::get(format!("{}/responses", server.url()))
+            .await
+            .expect("response");
+        let mut stream = create_responses_stream_from_response(response)
+            .await
+            .expect("stream");
+
+        let first = stream.next().await.expect("start event").expect("ok event");
+        assert!(matches!(first, StreamEvent::Start { .. }));
+
+        let second = stream.next().await.expect("text event").expect("ok event");
+        match second {
+            StreamEvent::TextDelta { delta, .. } => assert_eq!(delta, "Hello"),
+            _ => panic!("Expected TextDelta"),
+        }
+
+        let third = stream
+            .next()
+            .await
+            .expect("finish event")
+            .expect("ok event");
+        match third {
+            StreamEvent::Finish { usage, .. } => {
+                assert_eq!(usage.prompt_tokens, 1);
+                assert_eq!(usage.completion_tokens, 1);
+            }
+            _ => panic!("Expected Finish"),
+        }
+
+        mock.assert();
     }
 }

--- a/libs/ai/src/providers/openai/types.rs
+++ b/libs/ai/src/providers/openai/types.rs
@@ -1,5 +1,6 @@
 //! OpenAI-specific types
 
+use crate::types::{Headers, OpenAIOptions};
 use serde::{Deserialize, Serialize};
 
 /// Configuration for OpenAI provider
@@ -11,6 +12,10 @@ pub struct OpenAIConfig {
     pub base_url: String,
     /// Organization ID (optional)
     pub organization: Option<String>,
+    /// Provider-level headers applied to every request.
+    pub custom_headers: Headers,
+    /// Default OpenAI-specific options applied when a request does not specify any.
+    pub default_openai_options: Option<OpenAIOptions>,
 }
 
 impl OpenAIConfig {
@@ -20,6 +25,8 @@ impl OpenAIConfig {
             api_key: api_key.into(),
             base_url: "https://api.openai.com/v1".to_string(),
             organization: None,
+            custom_headers: Headers::new(),
+            default_openai_options: None,
         }
     }
 
@@ -32,6 +39,24 @@ impl OpenAIConfig {
     /// Set organization
     pub fn with_organization(mut self, org: impl Into<String>) -> Self {
         self.organization = Some(org.into());
+        self
+    }
+
+    /// Add a provider-level custom header.
+    pub fn with_custom_header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.custom_headers.insert(key, value);
+        self
+    }
+
+    /// Replace provider-level custom headers.
+    pub fn with_custom_headers(mut self, headers: Headers) -> Self {
+        self.custom_headers = headers;
+        self
+    }
+
+    /// Configure default OpenAI-specific request options.
+    pub fn with_default_openai_options(mut self, options: OpenAIOptions) -> Self {
+        self.default_openai_options = Some(options);
         self
     }
 }
@@ -236,6 +261,8 @@ pub struct ResponsesRequest {
     pub input: Vec<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub store: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_output_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/libs/ai/src/types/headers.rs
+++ b/libs/ai/src/types/headers.rs
@@ -1,16 +1,45 @@
 //! HTTP headers support for custom provider headers
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 
 /// HTTP headers map (single value per header name)
 /// Headers can be layered; later values override earlier ones
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize)]
 pub struct Headers {
     inner: HashMap<String, String>,
 }
 
+impl<'de> Deserialize<'de> for Headers {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum HeadersRepr {
+            Transparent(HashMap<String, String>),
+            Wrapped { inner: HashMap<String, String> },
+        }
+
+        let raw = match HeadersRepr::deserialize(deserializer)? {
+            HeadersRepr::Transparent(map) => map,
+            HeadersRepr::Wrapped { inner } => inner,
+        };
+
+        let mut headers = Headers::new();
+        for (key, value) in raw {
+            headers.insert(key, value);
+        }
+        Ok(headers)
+    }
+}
+
 impl Headers {
+    fn normalize_key(key: &str) -> String {
+        key.to_ascii_lowercase()
+    }
+
     /// Create a new empty headers map
     pub fn new() -> Self {
         Self::default()
@@ -18,26 +47,32 @@ impl Headers {
 
     /// Insert a header
     pub fn insert(&mut self, key: impl Into<String>, value: impl Into<String>) {
-        self.inner.insert(key.into(), value.into());
+        let key = key.into();
+        self.inner.insert(Self::normalize_key(&key), value.into());
     }
 
     /// Merge headers from overlay (consuming)
     pub fn merge(&mut self, overlay: Headers) {
         for (k, v) in overlay.inner {
-            self.inner.insert(k, v);
+            self.inner.insert(Self::normalize_key(&k), v);
         }
     }
 
     /// Merge headers from overlay (borrowing)
     pub fn merge_with(&mut self, overlay: &Headers) {
         for (k, v) in &overlay.inner {
-            self.inner.insert(k.clone(), v.clone());
+            self.inner.insert(Self::normalize_key(k), v.clone());
         }
     }
 
     /// Get a header value
     pub fn get(&self, key: &str) -> Option<&String> {
-        self.inner.get(key)
+        self.inner.get(&Self::normalize_key(key))
+    }
+
+    /// Remove a header and return the previous value, if any.
+    pub fn remove(&mut self, key: &str) -> Option<String> {
+        self.inner.remove(&Self::normalize_key(key))
     }
 
     /// Check if headers is empty
@@ -159,5 +194,36 @@ mod tests {
     fn test_headers_from_array() {
         let headers: Headers = [("key1", "val1"), ("key2", "val2")].into();
         assert_eq!(headers.len(), 2);
+    }
+
+    #[test]
+    fn test_headers_are_case_insensitive() {
+        let mut headers = Headers::new();
+        headers.insert("ChatGPT-Account-Id", "acct_test_123");
+
+        assert_eq!(
+            headers.get("chatgpt-account-id"),
+            Some(&"acct_test_123".to_string())
+        );
+        assert_eq!(
+            headers.get("ChatGPT-Account-Id"),
+            Some(&"acct_test_123".to_string())
+        );
+
+        let removed = headers.remove("CHATGPT-ACCOUNT-ID");
+        assert_eq!(removed.as_deref(), Some("acct_test_123"));
+        assert!(headers.get("chatgpt-account-id").is_none());
+    }
+
+    #[test]
+    fn test_headers_deserialization_remains_case_insensitive() {
+        let headers: Headers =
+            serde_json::from_str(r#"{"inner":{"ChatGPT-Account-Id":"acct_test_123"}}"#)
+                .expect("deserialize headers");
+
+        assert_eq!(
+            headers.get("chatgpt-account-id"),
+            Some(&"acct_test_123".to_string())
+        );
     }
 }

--- a/libs/shared/src/jwt.rs
+++ b/libs/shared/src/jwt.rs
@@ -1,0 +1,48 @@
+//! Small JWT helpers used for metadata extraction.
+//!
+//! These helpers intentionally do **not** verify signatures. They are only for
+//! reading non-authoritative claims that upstream APIs will validate again when
+//! the token is actually used.
+
+use serde_json::Value;
+
+/// Decode the payload segment of a JWT without signature verification.
+///
+/// This is appropriate only for extracting convenience metadata from tokens that
+/// will still be validated by the upstream provider on request execution.
+pub fn decode_jwt_payload_unverified(token: &str) -> Option<Value> {
+    let mut parts = token.split('.');
+    let _header = parts.next()?;
+    let payload = parts.next()?;
+    let _signature = parts.next()?;
+
+    use base64::Engine;
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .or_else(|_| base64::engine::general_purpose::URL_SAFE.decode(payload))
+        .ok()?;
+
+    serde_json::from_slice(&decoded).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+
+    #[test]
+    fn test_decode_jwt_payload_unverified_decodes_payload() {
+        let payload = serde_json::json!({"sub": "user_123"});
+        let encoded =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload.to_string().as_bytes());
+        let token = format!("header.{}.signature", encoded);
+
+        let decoded = decode_jwt_payload_unverified(&token).expect("decoded payload");
+        assert_eq!(decoded.get("sub").and_then(Value::as_str), Some("user_123"));
+    }
+
+    #[test]
+    fn test_decode_jwt_payload_unverified_returns_none_for_invalid_shape() {
+        assert!(decode_jwt_payload_unverified("not-a-jwt").is_none());
+    }
+}

--- a/libs/shared/src/lib.rs
+++ b/libs/shared/src/lib.rs
@@ -5,6 +5,7 @@ pub mod file_backup_manager;
 pub mod file_watcher;
 pub mod helper;
 pub mod hooks;
+pub mod jwt;
 pub mod local_store;
 pub mod models;
 pub mod oauth;

--- a/libs/shared/src/models/integrations/openai.rs
+++ b/libs/shared/src/models/integrations/openai.rs
@@ -29,6 +29,9 @@ pub struct OpenAIConfig {
 }
 
 impl OpenAIConfig {
+    pub const OPENAI_CODEX_BASE_URL: &'static str = "https://chatgpt.com/backend-api/codex";
+    const OPENAI_AUTH_CLAIM: &'static str = "https://api.openai.com/auth";
+
     /// Create config with API key
     pub fn with_api_key(api_key: impl Into<String>) -> Self {
         Self {
@@ -37,22 +40,31 @@ impl OpenAIConfig {
         }
     }
 
-    /// Create config from ProviderAuth (only supports API key for OpenAI)
-    pub fn from_provider_auth(auth: &crate::models::auth::ProviderAuth) -> Option<Self> {
-        match auth {
-            crate::models::auth::ProviderAuth::Api { key } => Some(Self::with_api_key(key)),
-            crate::models::auth::ProviderAuth::OAuth { .. } => None, // OpenAI doesn't support OAuth
-        }
-    }
+    /// Decode an OpenAI access token and extract the ChatGPT account ID.
+    ///
+    /// This intentionally reads the JWT payload without signature verification.
+    /// The claim is only used for request routing/header construction; OpenAI's
+    /// servers still validate the bearer token on use.
+    pub fn extract_chatgpt_account_id(access_token: &str) -> Option<String> {
+        let claims = crate::jwt::decode_jwt_payload_unverified(access_token)?;
+        let auth_claim = claims.get(Self::OPENAI_AUTH_CLAIM)?;
 
-    /// Merge with credentials from ProviderAuth, preserving existing endpoint
-    pub fn with_provider_auth(mut self, auth: &crate::models::auth::ProviderAuth) -> Option<Self> {
-        match auth {
-            crate::models::auth::ProviderAuth::Api { key } => {
-                self.api_key = Some(key.clone());
-                Some(self)
+        match auth_claim {
+            Value::Object(map) => map
+                .get("chatgpt_account_id")
+                .and_then(Value::as_str)
+                .map(ToString::to_string),
+            Value::String(raw_json) => {
+                serde_json::from_str::<Value>(raw_json)
+                    .ok()
+                    .and_then(|value| {
+                        value
+                            .get("chatgpt_account_id")
+                            .and_then(Value::as_str)
+                            .map(ToString::to_string)
+                    })
             }
-            crate::models::auth::ProviderAuth::OAuth { .. } => None, // OpenAI doesn't support OAuth
+            _ => None,
         }
     }
 }
@@ -1262,5 +1274,64 @@ mod tests {
             }
             _ => panic!("Expected List content"),
         }
+    }
+
+    #[test]
+    fn test_extract_chatgpt_account_id_from_access_token() {
+        use base64::Engine;
+
+        let claim = json!({
+            "chatgpt_account_id": "acct_test_123"
+        });
+        let payload = json!({
+            "https://api.openai.com/auth": claim
+        });
+        let encoded_payload =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload.to_string().as_bytes());
+        let access_token = format!("header.{}.signature", encoded_payload);
+
+        assert_eq!(
+            OpenAIConfig::extract_chatgpt_account_id(&access_token),
+            Some("acct_test_123".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_chatgpt_account_id_returns_none_for_missing_claim() {
+        use base64::Engine;
+
+        let payload = json!({
+            "sub": "user_123"
+        });
+        let encoded_payload =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload.to_string().as_bytes());
+        let access_token = format!("header.{}.signature", encoded_payload);
+
+        assert_eq!(
+            OpenAIConfig::extract_chatgpt_account_id(&access_token),
+            None
+        );
+    }
+
+    #[test]
+    fn test_extract_chatgpt_account_id_returns_none_for_invalid_token_shape() {
+        assert_eq!(OpenAIConfig::extract_chatgpt_account_id("not-a-jwt"), None);
+    }
+
+    #[test]
+    fn test_extract_chatgpt_account_id_returns_none_for_invalid_claim_json() {
+        use base64::Engine;
+
+        let payload = json!({
+            "https://api.openai.com/auth": "{not-json}"
+        });
+        let encoded_payload =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload.to_string().as_bytes());
+        let access_token = format!("header.{}.signature", encoded_payload);
+
+        assert_eq!(
+            OpenAIConfig::extract_chatgpt_account_id(&access_token),
+            None
+        );
     }
 }

--- a/libs/shared/src/models/mod.rs
+++ b/libs/shared/src/models/mod.rs
@@ -7,6 +7,7 @@ pub mod indexing;
 pub mod integrations;
 pub mod llm;
 pub mod model_pricing;
+pub mod openai_runtime;
 pub mod overrides;
 pub mod stakai_adapter;
 pub mod tools;

--- a/libs/shared/src/models/openai_runtime.rs
+++ b/libs/shared/src/models/openai_runtime.rs
@@ -1,0 +1,243 @@
+use crate::models::auth::ProviderAuth;
+use crate::models::integrations::openai::OpenAIConfig as InputOpenAIConfig;
+use crate::models::llm::ProviderConfig;
+pub use stakai::providers::openai::runtime::{
+    CodexBackendProfile, CompatibleBackendProfile, OfficialBackendProfile, OpenAIBackendProfile,
+};
+use stakai::types::{CompletionsConfig, OpenAIApiConfig, OpenAIOptions, ResponsesConfig};
+use thiserror::Error;
+
+const OFFICIAL_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OpenAIResolvedAuth {
+    ApiKey {
+        key: String,
+    },
+    OAuthBearer {
+        access_token: String,
+        refresh_token: Option<String>,
+        expires_at: Option<i64>,
+    },
+}
+
+impl OpenAIResolvedAuth {
+    pub fn authorization_token(&self) -> &str {
+        match self {
+            Self::ApiKey { key } => key,
+            Self::OAuthBearer { access_token, .. } => access_token,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct OpenAIResolvedConfig {
+    pub auth: OpenAIResolvedAuth,
+    pub backend: OpenAIBackendProfile,
+    pub default_api_mode: OpenAIApiConfig,
+}
+
+impl OpenAIResolvedConfig {
+    pub fn to_stakai_config(&self) -> stakai::providers::openai::OpenAIConfig {
+        let mut config = stakai::providers::openai::OpenAIConfig::new(
+            self.auth.authorization_token().to_string(),
+        );
+
+        match &self.backend {
+            OpenAIBackendProfile::Official(profile) => {
+                if profile.base_url != OFFICIAL_OPENAI_BASE_URL {
+                    config = config.with_base_url(profile.base_url.clone());
+                }
+            }
+            OpenAIBackendProfile::Compatible(profile) => {
+                config = config.with_base_url(profile.base_url.clone());
+            }
+            OpenAIBackendProfile::Codex(profile) => {
+                config = config
+                    .with_base_url(profile.base_url.clone())
+                    .with_custom_header("originator", profile.originator.clone())
+                    .with_custom_header("ChatGPT-Account-Id", profile.chatgpt_account_id.clone());
+            }
+        }
+
+        match self.default_api_mode {
+            OpenAIApiConfig::Responses(_) => {
+                config.with_default_openai_options(OpenAIOptions::responses())
+            }
+            OpenAIApiConfig::Completions(_) => config,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct OpenAIBackendResolutionInput {
+    provider_config: Option<ProviderConfig>,
+    auth: Option<ProviderAuth>,
+}
+
+impl OpenAIBackendResolutionInput {
+    pub fn new(provider_config: Option<ProviderConfig>, auth: Option<ProviderAuth>) -> Self {
+        Self {
+            provider_config,
+            auth,
+        }
+    }
+
+    fn provider_fields(&self) -> Result<OpenAIProviderFields, OpenAIResolutionError> {
+        match self.provider_config.as_ref() {
+            None => Ok(OpenAIProviderFields::default()),
+            Some(ProviderConfig::OpenAI { api_endpoint, .. }) => Ok(OpenAIProviderFields {
+                api_endpoint: api_endpoint.clone(),
+            }),
+            Some(other) => Err(OpenAIResolutionError::UnsupportedProviderConfig(
+                other.provider_type().to_string(),
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+struct OpenAIProviderFields {
+    api_endpoint: Option<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum OpenAIResolutionError {
+    #[error("OpenAI runtime resolution only supports openai provider config, got {0}")]
+    UnsupportedProviderConfig(String),
+    #[error("ChatGPT Plus/Pro OAuth credentials are missing required chatgpt_account_id claim")]
+    MissingCodexAccountId,
+}
+
+pub fn resolve_openai_runtime(
+    input: OpenAIBackendResolutionInput,
+) -> Result<Option<OpenAIResolvedConfig>, OpenAIResolutionError> {
+    let provider_fields = input.provider_fields()?;
+    let Some(auth) = input.auth else {
+        return Ok(None);
+    };
+
+    match auth {
+        ProviderAuth::Api { key } => {
+            let base_url = provider_fields
+                .api_endpoint
+                .unwrap_or_else(|| OFFICIAL_OPENAI_BASE_URL.to_string());
+            let (backend, default_api_mode) = if base_url == OFFICIAL_OPENAI_BASE_URL {
+                (
+                    OpenAIBackendProfile::Official(OfficialBackendProfile { base_url }),
+                    OpenAIApiConfig::Responses(ResponsesConfig::default()),
+                )
+            } else {
+                (
+                    OpenAIBackendProfile::Compatible(CompatibleBackendProfile { base_url }),
+                    OpenAIApiConfig::Completions(CompletionsConfig::default()),
+                )
+            };
+
+            Ok(Some(OpenAIResolvedConfig {
+                auth: OpenAIResolvedAuth::ApiKey { key },
+                backend,
+                default_api_mode,
+            }))
+        }
+        ProviderAuth::OAuth {
+            access,
+            refresh,
+            expires,
+            ..
+        } => {
+            let Some(chatgpt_account_id) = InputOpenAIConfig::extract_chatgpt_account_id(&access)
+            else {
+                return Err(OpenAIResolutionError::MissingCodexAccountId);
+            };
+
+            Ok(Some(OpenAIResolvedConfig {
+                auth: OpenAIResolvedAuth::OAuthBearer {
+                    access_token: access,
+                    refresh_token: if refresh.is_empty() {
+                        None
+                    } else {
+                        Some(refresh)
+                    },
+                    expires_at: Some(expires),
+                },
+                backend: OpenAIBackendProfile::Codex(CodexBackendProfile {
+                    base_url: provider_fields
+                        .api_endpoint
+                        .unwrap_or_else(|| InputOpenAIConfig::OPENAI_CODEX_BASE_URL.to_string()),
+                    originator: "stakpak".to_string(),
+                    chatgpt_account_id,
+                }),
+                default_api_mode: OpenAIApiConfig::Responses(ResponsesConfig::default()),
+            }))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+
+    #[test]
+    fn test_to_stakai_config_for_codex_oauth() {
+        let resolved = OpenAIResolvedConfig {
+            auth: OpenAIResolvedAuth::OAuthBearer {
+                access_token: "access-token".to_string(),
+                refresh_token: Some("refresh-token".to_string()),
+                expires_at: Some(123),
+            },
+            backend: OpenAIBackendProfile::Codex(CodexBackendProfile {
+                base_url: InputOpenAIConfig::OPENAI_CODEX_BASE_URL.to_string(),
+                originator: "stakpak".to_string(),
+                chatgpt_account_id: "acct_test_123".to_string(),
+            }),
+            default_api_mode: OpenAIApiConfig::Responses(ResponsesConfig::default()),
+        };
+
+        let config = resolved.to_stakai_config();
+
+        assert_eq!(config.api_key, "access-token");
+        assert_eq!(config.base_url, InputOpenAIConfig::OPENAI_CODEX_BASE_URL);
+        assert_eq!(
+            config.custom_headers.get("ChatGPT-Account-Id"),
+            Some(&"acct_test_123".to_string())
+        );
+        assert_eq!(
+            config.custom_headers.get("originator"),
+            Some(&"stakpak".to_string())
+        );
+        assert!(matches!(
+            config.default_openai_options,
+            Some(OpenAIOptions {
+                api_config: Some(OpenAIApiConfig::Responses(_)),
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn test_resolve_openai_runtime_for_oauth_codex() {
+        let payload = serde_json::json!({
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "acct_test_789"
+            }
+        });
+        let encoded_payload =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload.to_string().as_bytes());
+        let access_token = format!("header.{}.signature", encoded_payload);
+
+        let auth = ProviderAuth::oauth_with_name(
+            access_token,
+            "refresh-token",
+            i64::MAX,
+            "ChatGPT Plus/Pro",
+        );
+        let resolved = resolve_openai_runtime(OpenAIBackendResolutionInput::new(
+            Some(ProviderConfig::openai_with_auth(auth.clone())),
+            Some(auth),
+        ));
+
+        assert!(resolved.is_ok());
+    }
+}

--- a/libs/shared/src/models/stakai_adapter.rs
+++ b/libs/shared/src/models/stakai_adapter.rs
@@ -9,13 +9,15 @@ use crate::models::llm::{
     LLMMessage, LLMMessageContent, LLMMessageImageSource, LLMMessageTypedContent,
     LLMProviderConfig, LLMProviderOptions, LLMStreamInput, LLMTokenUsage, LLMTool, ProviderConfig,
 };
+use crate::models::openai_runtime::{OpenAIBackendResolutionInput, resolve_openai_runtime};
 use futures::StreamExt;
 use stakai::{
     AnthropicOptions, ContentPart, FinishReason, GenerateOptions, GenerateRequest,
     GenerateResponse, GoogleOptions, Headers, Inference, InferenceConfig, Message, MessageContent,
     Model, OpenAIApiConfig, OpenAIOptions, ProviderOptions, ReasoningEffort, ResponsesConfig, Role,
     StreamEvent, ThinkingOptions, Tool, ToolFunction, Usage,
-    providers::anthropic::AnthropicConfig as StakaiAnthropicConfig, registry::ProviderRegistry,
+    providers::anthropic::AnthropicConfig as StakaiAnthropicConfig,
+    providers::openai::OpenAIConfig as StakaiOpenAIConfig, registry::ProviderRegistry,
 };
 
 /// Convert CLI LLMMessage to StakAI Message
@@ -411,17 +413,27 @@ pub fn from_stakai_response(response: GenerateResponse, model: &str) -> LLMCompl
     }
 }
 
+fn resolve_stakai_openai_config(
+    provider_config: &ProviderConfig,
+) -> Result<Option<StakaiOpenAIConfig>, String> {
+    let resolved = resolve_openai_runtime(OpenAIBackendResolutionInput::new(
+        Some(provider_config.clone()),
+        provider_config.get_auth(),
+    ))
+    .map_err(|error| format!("Failed to resolve OpenAI runtime config: {}", error))?;
+
+    Ok(resolved.map(|config| config.to_stakai_config()))
+}
+
 /// Build StakAI InferenceConfig from CLI LLMProviderConfig
 pub fn build_inference_config(config: &LLMProviderConfig) -> Result<InferenceConfig, String> {
     let mut inference_config = InferenceConfig::new();
 
     for (name, provider_config) in &config.providers {
         match provider_config {
-            ProviderConfig::OpenAI { api_endpoint, .. } => {
-                // Use get_auth() to resolve credentials (checks auth field, then legacy api_key)
-                if let Some(api_key) = provider_config.api_key() {
-                    inference_config =
-                        inference_config.openai(api_key.to_string(), api_endpoint.clone());
+            ProviderConfig::OpenAI { .. } => {
+                if let Some(openai_config) = resolve_stakai_openai_config(provider_config)? {
+                    inference_config = inference_config.openai_config(openai_config);
                 }
             }
             ProviderConfig::Anthropic { api_endpoint, .. } => {
@@ -515,12 +527,8 @@ fn build_provider_registry_direct(config: &LLMProviderConfig) -> Result<Provider
 
     for (name, provider_config) in &config.providers {
         match provider_config {
-            ProviderConfig::OpenAI { api_endpoint, .. } => {
-                if let Some(api_key) = provider_config.api_key() {
-                    let mut openai_config = StakaiOpenAIConfig::new(api_key.to_string());
-                    if let Some(endpoint) = api_endpoint {
-                        openai_config = openai_config.with_base_url(endpoint.clone());
-                    }
+            ProviderConfig::OpenAI { .. } => {
+                if let Some(openai_config) = resolve_stakai_openai_config(provider_config)? {
                     let provider = OpenAIProvider::new(openai_config)
                         .map_err(|e| format!("Failed to create OpenAI provider: {}", e))?;
                     registry = registry.register("openai", provider);
@@ -1741,6 +1749,41 @@ mod tests {
         let registry = result.unwrap();
         assert!(registry.has_provider("litellm"));
         assert!(registry.has_provider("ollama"));
+    }
+
+    #[test]
+    fn test_build_provider_registry_registers_openai_from_oauth_auth() {
+        use crate::models::auth::ProviderAuth;
+        use crate::models::llm::ProviderConfig;
+        use base64::Engine;
+
+        let payload = serde_json::json!({
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "acct_test_789"
+            }
+        });
+        let encoded_payload =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload.to_string().as_bytes());
+        let access_token = format!("header.{}.signature", encoded_payload);
+
+        let mut config = LLMProviderConfig::new();
+        config.add_provider(
+            "openai",
+            ProviderConfig::OpenAI {
+                api_key: None,
+                api_endpoint: None,
+                auth: Some(ProviderAuth::oauth_with_name(
+                    access_token,
+                    "refresh-token",
+                    i64::MAX,
+                    "ChatGPT Plus/Pro",
+                )),
+            },
+        );
+
+        let registry = build_provider_registry_direct(&config).expect("registry should build");
+
+        assert!(registry.has_provider("openai"));
     }
 
     // ==================== Round-trip Tests ====================

--- a/libs/shared/src/oauth/config.rs
+++ b/libs/shared/src/oauth/config.rs
@@ -1,5 +1,25 @@
 //! OAuth configuration types
 
+/// Provider-specific authorization request shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AuthorizationRequestMode {
+    /// Standard OAuth 2.0 Authorization Code + PKCE request.
+    #[default]
+    StandardPkce,
+    /// Legacy request shape that includes `code=true`.
+    LegacyCode,
+}
+
+/// Provider-specific token request encoding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TokenRequestMode {
+    /// JSON request bodies used by legacy providers.
+    #[default]
+    Json,
+    /// `application/x-www-form-urlencoded` request bodies.
+    FormUrlEncoded,
+}
+
 /// Configuration for an OAuth 2.0 provider
 #[derive(Debug, Clone)]
 pub struct OAuthConfig {
@@ -13,6 +33,12 @@ pub struct OAuthConfig {
     pub redirect_url: String,
     /// Scopes to request
     pub scopes: Vec<String>,
+    /// Provider-specific authorization request mode.
+    pub authorization_request_mode: AuthorizationRequestMode,
+    /// Additional provider-specific authorization query parameters.
+    pub authorization_params: Vec<(String, String)>,
+    /// Provider-specific token request encoding.
+    pub token_request_mode: TokenRequestMode,
 }
 
 impl OAuthConfig {
@@ -30,7 +56,36 @@ impl OAuthConfig {
             token_url: token_url.into(),
             redirect_url: redirect_url.into(),
             scopes,
+            authorization_request_mode: AuthorizationRequestMode::StandardPkce,
+            authorization_params: Vec::new(),
+            token_request_mode: TokenRequestMode::Json,
         }
+    }
+
+    /// Override the authorization request mode for providers with non-standard requirements.
+    pub fn with_authorization_request_mode(mut self, mode: AuthorizationRequestMode) -> Self {
+        self.authorization_request_mode = mode;
+        self
+    }
+
+    /// Add provider-specific authorization query parameters.
+    pub fn with_authorization_params<K, V, I>(mut self, params: I) -> Self
+    where
+        K: Into<String>,
+        V: Into<String>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        self.authorization_params = params
+            .into_iter()
+            .map(|(key, value)| (key.into(), value.into()))
+            .collect();
+        self
+    }
+
+    /// Override the token request encoding for providers with non-standard requirements.
+    pub fn with_token_request_mode(mut self, mode: TokenRequestMode) -> Self {
+        self.token_request_mode = mode;
+        self
     }
 
     /// Get the scopes as a space-separated string
@@ -58,6 +113,63 @@ mod tests {
         assert_eq!(config.token_url, "https://example.com/token");
         assert_eq!(config.redirect_url, "https://example.com/callback");
         assert_eq!(config.scopes, vec!["scope1", "scope2"]);
+        assert_eq!(
+            config.authorization_request_mode,
+            AuthorizationRequestMode::StandardPkce
+        );
+        assert!(config.authorization_params.is_empty());
+        assert_eq!(config.token_request_mode, TokenRequestMode::Json);
+    }
+
+    #[test]
+    fn test_authorization_request_mode_builder() {
+        let config = OAuthConfig::new(
+            "client-id",
+            "https://example.com/auth",
+            "https://example.com/token",
+            "https://example.com/callback",
+            vec!["scope".to_string()],
+        )
+        .with_authorization_request_mode(AuthorizationRequestMode::LegacyCode);
+
+        assert_eq!(
+            config.authorization_request_mode,
+            AuthorizationRequestMode::LegacyCode
+        );
+    }
+
+    #[test]
+    fn test_authorization_params_builder() {
+        let config = OAuthConfig::new(
+            "client-id",
+            "https://example.com/auth",
+            "https://example.com/token",
+            "https://example.com/callback",
+            vec!["scope".to_string()],
+        )
+        .with_authorization_params(vec![("originator", "stakpak"), ("mode", "codex")]);
+
+        assert_eq!(
+            config.authorization_params,
+            vec![
+                ("originator".to_string(), "stakpak".to_string()),
+                ("mode".to_string(), "codex".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_token_request_mode_builder() {
+        let config = OAuthConfig::new(
+            "client-id",
+            "https://example.com/auth",
+            "https://example.com/token",
+            "https://example.com/callback",
+            vec!["scope".to_string()],
+        )
+        .with_token_request_mode(TokenRequestMode::FormUrlEncoded);
+
+        assert_eq!(config.token_request_mode, TokenRequestMode::FormUrlEncoded);
     }
 
     #[test]

--- a/libs/shared/src/oauth/flow.rs
+++ b/libs/shared/src/oauth/flow.rs
@@ -1,6 +1,6 @@
 //! OAuth 2.0 authorization code flow implementation
 
-use super::config::OAuthConfig;
+use super::config::{AuthorizationRequestMode, OAuthConfig, TokenRequestMode};
 use super::error::{OAuthError, OAuthResult};
 use super::pkce::PkceChallenge;
 use serde::{Deserialize, Serialize};
@@ -18,16 +18,26 @@ pub struct TokenResponse {
     pub token_type: String,
 }
 
+enum TokenRequest {
+    Json(serde_json::Value),
+    Form(Vec<(String, String)>),
+}
+
 /// OAuth 2.0 authorization code flow handler
 pub struct OAuthFlow {
     config: OAuthConfig,
     pkce: Option<PkceChallenge>,
+    state: Option<String>,
 }
 
 impl OAuthFlow {
     /// Create a new OAuth flow with the given configuration
     pub fn new(config: OAuthConfig) -> Self {
-        Self { config, pkce: None }
+        Self {
+            config,
+            pkce: None,
+            state: None,
+        }
     }
 
     /// Generate the authorization URL for the user to visit
@@ -36,53 +46,133 @@ impl OAuthFlow {
     /// that should be opened in the user's browser.
     pub fn generate_auth_url(&mut self) -> String {
         let pkce = PkceChallenge::generate();
+        let state = uuid::Uuid::new_v4().simple().to_string();
 
-        let url = format!(
-            "{}?code=true&client_id={}&response_type=code&redirect_uri={}&scope={}&code_challenge={}&code_challenge_method={}&state={}",
-            self.config.auth_url,
-            urlencoding::encode(&self.config.client_id),
-            urlencoding::encode(&self.config.redirect_url),
-            urlencoding::encode(&self.config.scopes_string()),
-            urlencoding::encode(&pkce.challenge),
-            PkceChallenge::challenge_method(),
-            urlencoding::encode(&pkce.verifier), // State contains verifier for validation
-        );
+        let mut query = vec![
+            format!("client_id={}", urlencoding::encode(&self.config.client_id)),
+            "response_type=code".to_string(),
+            format!(
+                "redirect_uri={}",
+                urlencoding::encode(&self.config.redirect_url)
+            ),
+            format!(
+                "scope={}",
+                urlencoding::encode(&self.config.scopes_string())
+            ),
+            format!("code_challenge={}", urlencoding::encode(&pkce.challenge)),
+            format!(
+                "code_challenge_method={}",
+                PkceChallenge::challenge_method()
+            ),
+            format!("state={}", urlencoding::encode(&state)),
+        ];
+
+        if self.config.authorization_request_mode == AuthorizationRequestMode::LegacyCode {
+            query.insert(0, "code=true".to_string());
+        }
+
+        query.extend(self.config.authorization_params.iter().map(|(key, value)| {
+            format!(
+                "{}={}",
+                urlencoding::encode(key),
+                urlencoding::encode(value)
+            )
+        }));
+
+        let url = format!("{}?{}", self.config.auth_url, query.join("&"));
 
         self.pkce = Some(pkce);
+        self.state = Some(state);
         url
     }
 
-    /// Exchange authorization code for tokens
-    ///
-    /// The code should be in the format "authorization_code#state" as returned by Anthropic.
-    pub async fn exchange_code(&self, code: &str) -> OAuthResult<TokenResponse> {
+    fn build_token_exchange_request(
+        &self,
+        auth_code: String,
+        state: String,
+    ) -> OAuthResult<TokenRequest> {
         let pkce = self.pkce.as_ref().ok_or(OAuthError::PkceNotInitialized)?;
 
-        // Parse the authorization code - format: "authorization_code#state"
-        let (auth_code, state) = parse_auth_code(code)?;
-
-        // Validate state matches our verifier
-        if state != pkce.verifier {
-            return Err(OAuthError::invalid_code_format(
-                "State mismatch - possible CSRF attack",
-            ));
-        }
-
-        let client =
-            crate::tls_client::create_tls_client(crate::tls_client::TlsClientConfig::default())
-                .expect("Failed to create TLS client for OAuth token exchange");
-        let response = client
-            .post(&self.config.token_url)
-            .json(&serde_json::json!({
+        Ok(match self.config.token_request_mode {
+            TokenRequestMode::Json => TokenRequest::Json(serde_json::json!({
                 "grant_type": "authorization_code",
                 "code": auth_code,
                 "state": state,
                 "client_id": self.config.client_id,
                 "redirect_uri": self.config.redirect_url,
                 "code_verifier": pkce.verifier,
-            }))
-            .send()
-            .await?;
+            })),
+            TokenRequestMode::FormUrlEncoded => TokenRequest::Form(vec![
+                // OpenAI's token endpoint rejects `state` in the form-encoded
+                // exchange request (`Unknown parameter: 'state'.`). State is
+                // still validated locally before building this request.
+                ("grant_type".to_string(), "authorization_code".to_string()),
+                ("code".to_string(), auth_code),
+                ("client_id".to_string(), self.config.client_id.clone()),
+                ("redirect_uri".to_string(), self.config.redirect_url.clone()),
+                ("code_verifier".to_string(), pkce.verifier.clone()),
+            ]),
+        })
+    }
+
+    fn build_token_refresh_request(&self, refresh_token: String) -> TokenRequest {
+        match self.config.token_request_mode {
+            TokenRequestMode::Json => TokenRequest::Json(serde_json::json!({
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": self.config.client_id,
+            })),
+            TokenRequestMode::FormUrlEncoded => TokenRequest::Form(vec![
+                ("grant_type".to_string(), "refresh_token".to_string()),
+                ("refresh_token".to_string(), refresh_token),
+                ("client_id".to_string(), self.config.client_id.clone()),
+            ]),
+        }
+    }
+
+    /// Exchange authorization code for tokens.
+    ///
+    /// The string form is kept for manual copy/paste flows that return
+    /// `authorization_code#state`. Programmatic callers should prefer
+    /// `exchange_code_with_state` when they already have separate values.
+    pub async fn exchange_code(&self, code: &str) -> OAuthResult<TokenResponse> {
+        let (auth_code, state) = parse_auth_code(code)?;
+        self.exchange_code_with_state(&auth_code, &state).await
+    }
+
+    /// Exchange authorization code for tokens using separately supplied code and state.
+    pub async fn exchange_code_with_state(
+        &self,
+        auth_code: &str,
+        state: &str,
+    ) -> OAuthResult<TokenResponse> {
+        let _pkce = self.pkce.as_ref().ok_or(OAuthError::PkceNotInitialized)?;
+
+        let expected_state = self
+            .state
+            .as_deref()
+            .ok_or(OAuthError::PkceNotInitialized)?;
+
+        // Validate state matches the authorization request state before the
+        // token exchange request is built.
+        if state != expected_state {
+            return Err(OAuthError::invalid_code_format(
+                "State mismatch - possible CSRF attack",
+            ));
+        }
+
+        let token_request =
+            self.build_token_exchange_request(auth_code.to_string(), state.to_string())?;
+
+        let client =
+            crate::tls_client::create_tls_client(crate::tls_client::TlsClientConfig::default())
+                .expect("Failed to create TLS client for OAuth token exchange");
+        let response = match token_request {
+            TokenRequest::Json(body) => client.post(&self.config.token_url).json(&body),
+            TokenRequest::Form(body) => client.post(&self.config.token_url).form(&body),
+        }
+        .send()
+        .await?;
 
         if !response.status().is_success() {
             let status = response.status();
@@ -100,18 +190,16 @@ impl OAuthFlow {
 
     /// Refresh an expired access token
     pub async fn refresh_token(&self, refresh_token: &str) -> OAuthResult<TokenResponse> {
+        let token_request = self.build_token_refresh_request(refresh_token.to_string());
         let client =
             crate::tls_client::create_tls_client(crate::tls_client::TlsClientConfig::default())
                 .expect("Failed to create TLS client for OAuth token refresh");
-        let response = client
-            .post(&self.config.token_url)
-            .json(&serde_json::json!({
-                "grant_type": "refresh_token",
-                "refresh_token": refresh_token,
-                "client_id": self.config.client_id,
-            }))
-            .send()
-            .await?;
+        let response = match token_request {
+            TokenRequest::Json(body) => client.post(&self.config.token_url).json(&body),
+            TokenRequest::Form(body) => client.post(&self.config.token_url).form(&body),
+        }
+        .send()
+        .await?;
 
         if !response.status().is_success() {
             let status = response.status();
@@ -133,9 +221,9 @@ impl OAuthFlow {
     }
 }
 
-/// Parse the authorization code from Anthropic's callback format
+/// Parse the authorization code from a provider callback format that embeds state.
 ///
-/// Anthropic returns codes in the format: "authorization_code#state"
+/// Some providers return codes in the format: "authorization_code#state".
 #[allow(clippy::string_slice)] // pos from find('#') on same string, '#' is ASCII
 fn parse_auth_code(code: &str) -> OAuthResult<(String, String)> {
     // Handle both "#" and "%23" (URL-encoded #)
@@ -162,6 +250,7 @@ fn parse_auth_code(code: &str) -> OAuthResult<(String, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::oauth::config::AuthorizationRequestMode;
 
     fn test_config() -> OAuthConfig {
         OAuthConfig::new(
@@ -174,7 +263,7 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_auth_url() {
+    fn test_generate_auth_url_standard_pkce() {
         let mut flow = OAuthFlow::new(test_config());
         let url = flow.generate_auth_url();
 
@@ -186,9 +275,93 @@ mod tests {
         assert!(url.contains("code_challenge="));
         assert!(url.contains("code_challenge_method=S256"));
         assert!(url.contains("state="));
+        assert!(!url.contains("code=true"));
 
         // PKCE should be initialized
         assert!(flow.pkce.is_some());
+    }
+
+    #[test]
+    fn test_generate_auth_url_legacy_mode_includes_code_param() {
+        let mut flow = OAuthFlow::new(
+            test_config().with_authorization_request_mode(AuthorizationRequestMode::LegacyCode),
+        );
+        let url = flow.generate_auth_url();
+
+        assert!(url.contains("code=true"));
+        assert!(url.contains("response_type=code"));
+    }
+
+    #[test]
+    fn test_generate_auth_url_includes_provider_specific_params() {
+        let mut flow = OAuthFlow::new(test_config().with_authorization_params(vec![
+            ("id_token_add_organizations", "true"),
+            ("codex_cli_simplified_flow", "true"),
+            ("originator", "stakpak"),
+        ]));
+        let url = flow.generate_auth_url();
+
+        assert!(url.contains("id_token_add_organizations=true"));
+        assert!(url.contains("codex_cli_simplified_flow=true"));
+        assert!(url.contains("originator=stakpak"));
+    }
+
+    #[test]
+    fn test_generate_auth_url_uses_separate_state_from_pkce_verifier() {
+        let mut flow = OAuthFlow::new(test_config());
+        let url = flow.generate_auth_url();
+        let parsed = reqwest::Url::parse(&url).expect("parse auth url");
+        let state = parsed
+            .query_pairs()
+            .find(|(key, _)| key == "state")
+            .map(|(_, value)| value.to_string())
+            .expect("state param");
+
+        assert_ne!(Some(state.as_str()), flow.pkce_verifier());
+    }
+
+    #[test]
+    fn test_openai_token_exchange_request_uses_form_encoding_without_state() {
+        let mut flow = OAuthFlow::new(
+            test_config()
+                .with_token_request_mode(crate::oauth::config::TokenRequestMode::FormUrlEncoded),
+        );
+        let _ = flow.generate_auth_url();
+        let request = flow
+            .build_token_exchange_request("auth-code".to_string(), "callback-state".to_string())
+            .expect("token exchange request");
+
+        match request {
+            TokenRequest::Form(params) => {
+                assert!(
+                    params.contains(&("grant_type".to_string(), "authorization_code".to_string()))
+                );
+                assert!(params.contains(&("code".to_string(), "auth-code".to_string())));
+                assert!(params.contains(&("client_id".to_string(), "test-client-id".to_string())));
+                assert!(params.iter().all(|(key, _)| key != "state"));
+            }
+            TokenRequest::Json(_) => panic!("expected form request"),
+        }
+    }
+
+    #[test]
+    fn test_openai_token_refresh_request_uses_form_encoding() {
+        let flow = OAuthFlow::new(
+            test_config()
+                .with_token_request_mode(crate::oauth::config::TokenRequestMode::FormUrlEncoded),
+        );
+        let request = flow.build_token_refresh_request("refresh-token".to_string());
+
+        match request {
+            TokenRequest::Form(params) => {
+                assert!(params.contains(&("grant_type".to_string(), "refresh_token".to_string())));
+                assert!(
+                    params.contains(&("refresh_token".to_string(), "refresh-token".to_string()))
+                );
+                assert!(params.contains(&("client_id".to_string(), "test-client-id".to_string())));
+            }
+            TokenRequest::Json(_) => panic!("expected form request"),
+        }
     }
 
     #[test]
@@ -226,6 +399,13 @@ mod tests {
     fn test_exchange_code_without_pkce() {
         let flow = OAuthFlow::new(test_config());
         let result = tokio_test::block_on(flow.exchange_code("code#state"));
+        assert!(matches!(result, Err(OAuthError::PkceNotInitialized)));
+    }
+
+    #[test]
+    fn test_exchange_code_with_state_without_pkce() {
+        let flow = OAuthFlow::new(test_config());
+        let result = tokio_test::block_on(flow.exchange_code_with_state("code", "state"));
         assert!(matches!(result, Err(OAuthError::PkceNotInitialized)));
     }
 

--- a/libs/shared/src/oauth/mod.rs
+++ b/libs/shared/src/oauth/mod.rs
@@ -50,5 +50,5 @@ pub use error::{OAuthError, OAuthResult};
 pub use flow::{OAuthFlow, TokenResponse};
 pub use pkce::PkceChallenge;
 pub use provider::{AuthMethod, AuthMethodType, OAuthProvider};
-pub use providers::{AnthropicProvider, GitHubCopilotProvider};
+pub use providers::{AnthropicProvider, GitHubCopilotProvider, OpenAICodexProvider};
 pub use registry::ProviderRegistry;

--- a/libs/shared/src/oauth/providers/anthropic.rs
+++ b/libs/shared/src/oauth/providers/anthropic.rs
@@ -76,33 +76,6 @@ impl AnthropicProvider {
 
         Ok(result.raw_key)
     }
-
-    /// Helper to decode JWT payload (without verification)
-    fn decode_jwt_payload(token: &str) -> Option<serde_json::Value> {
-        let parts: Vec<&str> = token.split('.').collect();
-        if parts.len() != 3 {
-            return None;
-        }
-
-        use base64::Engine;
-        let engine = base64::engine::general_purpose::URL_SAFE_NO_PAD;
-
-        let payload_part = parts[1];
-        let decoded = match engine.decode(payload_part) {
-            Ok(d) => d,
-            Err(_) => {
-                let rem = payload_part.len() % 4;
-                if rem > 0 {
-                    let padded = format!("{}{}", payload_part, "=".repeat(4 - rem));
-                    engine.decode(&padded).ok()?
-                } else {
-                    return None;
-                }
-            }
-        };
-
-        serde_json::from_slice(&decoded).ok()
-    }
 }
 
 impl Default for AnthropicProvider {
@@ -148,13 +121,18 @@ impl OAuthProvider for AnthropicProvider {
             _ => return None,
         };
 
-        Some(OAuthConfig::new(
-            Self::CLIENT_ID,
-            auth_url,
-            Self::TOKEN_URL,
-            Self::REDIRECT_URL,
-            Self::SCOPES.iter().map(|s| s.to_string()).collect(),
-        ))
+        Some(
+            OAuthConfig::new(
+                Self::CLIENT_ID,
+                auth_url,
+                Self::TOKEN_URL,
+                Self::REDIRECT_URL,
+                Self::SCOPES.iter().map(|s| s.to_string()).collect(),
+            )
+            .with_authorization_request_mode(
+                crate::oauth::config::AuthorizationRequestMode::LegacyCode,
+            ),
+        )
     }
 
     async fn post_authorize(
@@ -169,7 +147,8 @@ impl OAuthProvider for AnthropicProvider {
 
                 // Try to determine subscription tier from JWT claims
                 let mut name = "Claude Pro/Max".to_string();
-                if let Some(claims) = Self::decode_jwt_payload(&tokens.access_token)
+                if let Some(claims) =
+                    crate::jwt::decode_jwt_payload_unverified(&tokens.access_token)
                     && let Some(tier) = claims.get("tier").and_then(|v| v.as_str())
                 {
                     match tier {
@@ -236,6 +215,7 @@ impl OAuthProvider for AnthropicProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::oauth::config::AuthorizationRequestMode;
 
     #[test]
     fn test_provider_id_and_name() {
@@ -271,6 +251,10 @@ mod tests {
         assert_eq!(
             config.token_url,
             "https://console.anthropic.com/v1/oauth/token"
+        );
+        assert_eq!(
+            config.authorization_request_mode,
+            AuthorizationRequestMode::LegacyCode
         );
     }
 

--- a/libs/shared/src/oauth/providers/mod.rs
+++ b/libs/shared/src/oauth/providers/mod.rs
@@ -2,8 +2,10 @@
 
 mod anthropic;
 mod github_copilot;
+mod openai_codex;
 mod stakpak;
 
 pub use anthropic::AnthropicProvider;
 pub use github_copilot::GitHubCopilotProvider;
+pub use openai_codex::OpenAICodexProvider;
 pub use stakpak::StakpakProvider;

--- a/libs/shared/src/oauth/providers/openai_codex.rs
+++ b/libs/shared/src/oauth/providers/openai_codex.rs
@@ -1,0 +1,238 @@
+//! OpenAI OAuth provider for ChatGPT Plus/Pro Codex access
+
+use crate::models::auth::ProviderAuth;
+use crate::oauth::config::{AuthorizationRequestMode, OAuthConfig, TokenRequestMode};
+use crate::oauth::error::{OAuthError, OAuthResult};
+use crate::oauth::flow::TokenResponse;
+use crate::oauth::provider::{AuthMethod, OAuthProvider};
+use async_trait::async_trait;
+use reqwest::header::HeaderMap;
+
+/// OpenAI provider with ChatGPT Plus/Pro OAuth support.
+pub struct OpenAICodexProvider;
+
+impl OpenAICodexProvider {
+    pub const CLIENT_ID: &'static str = "app_EMoamEEZ73f0CkXaXp7hrann";
+    const AUTH_URL: &'static str = "https://auth.openai.com/oauth/authorize";
+    const TOKEN_URL: &'static str = "https://auth.openai.com/oauth/token";
+    const REDIRECT_URL: &'static str = "http://localhost:1455/auth/callback";
+    const SCOPES: &'static [&'static str] = &["openid", "profile", "email", "offline_access"];
+    const CODEX_METHOD_ID: &'static str = "chatgpt-plus-pro";
+    const CODEX_METHOD_LABEL: &'static str = "ChatGPT Plus/Pro";
+    const CLIENT_ID_OVERRIDE_ENV: &'static str = "STAKPAK_OPENAI_OAUTH_CLIENT_ID";
+
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn client_id() -> String {
+        std::env::var(Self::CLIENT_ID_OVERRIDE_ENV).unwrap_or_else(|_| Self::CLIENT_ID.to_string())
+    }
+}
+
+impl Default for OpenAICodexProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl OAuthProvider for OpenAICodexProvider {
+    fn id(&self) -> &'static str {
+        "openai"
+    }
+
+    fn name(&self) -> &'static str {
+        "OpenAI"
+    }
+
+    fn auth_methods(&self) -> Vec<AuthMethod> {
+        vec![
+            AuthMethod::oauth(
+                Self::CODEX_METHOD_ID,
+                Self::CODEX_METHOD_LABEL,
+                Some("Use your ChatGPT Plus/Pro subscription".to_string()),
+            ),
+            AuthMethod::api_key(
+                "api-key",
+                "API Key",
+                Some("Enter an existing OpenAI API key".to_string()),
+            ),
+        ]
+    }
+
+    fn oauth_config(&self, method_id: &str) -> Option<OAuthConfig> {
+        if method_id != Self::CODEX_METHOD_ID {
+            return None;
+        }
+
+        Some(
+            OAuthConfig::new(
+                Self::client_id(),
+                Self::AUTH_URL,
+                Self::TOKEN_URL,
+                Self::REDIRECT_URL,
+                Self::SCOPES.iter().map(|scope| scope.to_string()).collect(),
+            )
+            .with_authorization_request_mode(AuthorizationRequestMode::StandardPkce)
+            .with_authorization_params(vec![
+                ("id_token_add_organizations", "true"),
+                ("codex_cli_simplified_flow", "true"),
+                ("originator", "stakpak"),
+            ])
+            .with_token_request_mode(TokenRequestMode::FormUrlEncoded),
+        )
+    }
+
+    async fn post_authorize(
+        &self,
+        method_id: &str,
+        tokens: &TokenResponse,
+    ) -> OAuthResult<ProviderAuth> {
+        if method_id != Self::CODEX_METHOD_ID {
+            return Err(OAuthError::unknown_method(method_id));
+        }
+
+        let expires = chrono::Utc::now().timestamp_millis() + (tokens.expires_in * 1000);
+        Ok(ProviderAuth::oauth_with_name(
+            &tokens.access_token,
+            &tokens.refresh_token,
+            expires,
+            Self::CODEX_METHOD_LABEL,
+        ))
+    }
+
+    fn apply_auth_headers(&self, auth: &ProviderAuth, headers: &mut HeaderMap) -> OAuthResult<()> {
+        let bearer_token = match auth {
+            ProviderAuth::Api { key } => key,
+            ProviderAuth::OAuth { access, .. } => access,
+        };
+
+        headers.insert(
+            "authorization",
+            format!("Bearer {}", bearer_token)
+                .parse()
+                .map_err(|_| OAuthError::InvalidHeader)?,
+        );
+        Ok(())
+    }
+
+    fn api_key_env_var(&self) -> Option<&'static str> {
+        Some("OPENAI_API_KEY")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::oauth::config::AuthorizationRequestMode;
+    use std::sync::Mutex;
+
+    static OPENAI_CLIENT_ID_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn test_provider_id_and_name() {
+        let provider = OpenAICodexProvider::new();
+        assert_eq!(provider.id(), "openai");
+        assert_eq!(provider.name(), "OpenAI");
+    }
+
+    #[test]
+    fn test_auth_methods() {
+        let provider = OpenAICodexProvider::new();
+        let methods = provider.auth_methods();
+
+        assert_eq!(methods.len(), 2);
+        assert_eq!(methods[0].id, "chatgpt-plus-pro");
+        assert_eq!(methods[0].label, "ChatGPT Plus/Pro");
+        assert_eq!(methods[1].id, "api-key");
+    }
+
+    #[test]
+    fn test_oauth_config_for_codex() {
+        let _guard = OPENAI_CLIENT_ID_ENV_LOCK
+            .lock()
+            .expect("lock client id env");
+        unsafe {
+            std::env::remove_var("STAKPAK_OPENAI_OAUTH_CLIENT_ID");
+        }
+
+        let provider = OpenAICodexProvider::new();
+        let config = provider
+            .oauth_config("chatgpt-plus-pro")
+            .expect("oauth config");
+
+        assert_eq!(config.client_id, OpenAICodexProvider::CLIENT_ID);
+        assert_eq!(config.auth_url, "https://auth.openai.com/oauth/authorize");
+        assert_eq!(config.token_url, "https://auth.openai.com/oauth/token");
+        assert_eq!(config.redirect_url, "http://localhost:1455/auth/callback");
+        assert_eq!(
+            config.scopes.join(" "),
+            "openid profile email offline_access"
+        );
+        assert_eq!(
+            config.authorization_params,
+            vec![
+                ("id_token_add_organizations".to_string(), "true".to_string()),
+                ("codex_cli_simplified_flow".to_string(), "true".to_string()),
+                ("originator".to_string(), "stakpak".to_string()),
+            ]
+        );
+        assert_eq!(
+            config.authorization_request_mode,
+            AuthorizationRequestMode::StandardPkce
+        );
+        assert_eq!(config.token_request_mode, TokenRequestMode::FormUrlEncoded);
+    }
+
+    #[test]
+    fn test_oauth_config_uses_env_override_for_client_id() {
+        let _guard = OPENAI_CLIENT_ID_ENV_LOCK
+            .lock()
+            .expect("lock client id env");
+        let provider = OpenAICodexProvider::new();
+        unsafe {
+            std::env::set_var("STAKPAK_OPENAI_OAUTH_CLIENT_ID", "app_override_test");
+        }
+
+        let config = provider
+            .oauth_config("chatgpt-plus-pro")
+            .expect("oauth config");
+
+        assert_eq!(config.client_id, "app_override_test");
+
+        unsafe {
+            std::env::remove_var("STAKPAK_OPENAI_OAUTH_CLIENT_ID");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_post_authorize_returns_named_oauth_auth() {
+        let provider = OpenAICodexProvider::new();
+        let tokens = TokenResponse {
+            access_token: "access-token".to_string(),
+            refresh_token: "refresh-token".to_string(),
+            expires_in: 3600,
+            token_type: "Bearer".to_string(),
+        };
+
+        let auth = provider
+            .post_authorize("chatgpt-plus-pro", &tokens)
+            .await
+            .expect("oauth auth");
+
+        match auth {
+            ProviderAuth::OAuth {
+                access,
+                refresh,
+                name,
+                ..
+            } => {
+                assert_eq!(access, "access-token");
+                assert_eq!(refresh, "refresh-token");
+                assert_eq!(name.as_deref(), Some("ChatGPT Plus/Pro"));
+            }
+            _ => panic!("expected oauth auth"),
+        }
+    }
+}

--- a/libs/shared/src/oauth/registry.rs
+++ b/libs/shared/src/oauth/registry.rs
@@ -1,7 +1,9 @@
 //! OAuth provider registry
 
 use super::provider::OAuthProvider;
-use super::providers::{AnthropicProvider, GitHubCopilotProvider, StakpakProvider};
+use super::providers::{
+    AnthropicProvider, GitHubCopilotProvider, OpenAICodexProvider, StakpakProvider,
+};
 use std::collections::HashMap;
 
 /// Registry of OAuth providers
@@ -19,6 +21,7 @@ impl ProviderRegistry {
         // Register built-in providers
         registry.register(Box::new(StakpakProvider::new()));
         registry.register(Box::new(AnthropicProvider::new()));
+        registry.register(Box::new(OpenAICodexProvider::new()));
         registry.register(Box::new(GitHubCopilotProvider::new()));
 
         registry
@@ -106,5 +109,15 @@ mod tests {
 
         assert!(registry.has_provider("anthropic"));
         assert!(!registry.has_provider("unknown"));
+    }
+
+    #[test]
+    fn test_registry_registers_openai_with_codex_auth_method() {
+        let registry = ProviderRegistry::new();
+        let provider = registry.get("openai").expect("openai provider");
+        let methods = provider.auth_methods();
+
+        assert!(methods.iter().any(|method| method.id == "chatgpt-plus-pro"));
+        assert!(methods.iter().any(|method| method.id == "api-key"));
     }
 }


### PR DESCRIPTION
## Description
Add OpenAI ChatGPT Plus/Pro OAuth support, including local callback handling, Codex runtime resolution, and provider/runtime wiring needed to use OAuth credentials end-to-end.

## Related Issues
None

## Changes Made
- add an OpenAI Codex OAuth provider, OAuth request/refresh modes, and JWT-based ChatGPT account ID extraction
- wire OpenAI runtime/backend resolution through shared models, CLI config/auth flows, and StakAI provider setup
- add local OAuth callback listener support plus regression tests for login, config resolution, OAuth flow behavior, and OpenAI runtime handling

## Testing
- [x] All tests pass locally (`cargo test -p stakpak -p stakai -p stakpak-shared --all-targets`)
- [x] Added tests for new functionality
- [x] Tested on macOS

## Screenshots (if applicable)
N/A

## Breaking Changes
None
