### PR TITLE
feat(ak): add persistent knowledge store command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6134,6 +6134,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "stakai",
+ "stakpak-ak",
  "stakpak-api",
  "stakpak-gateway",
  "stakpak-mcp-client",
@@ -6174,6 +6175,18 @@ dependencies = [
  "tokio",
  "tokio-util",
  "uuid",
+]
+
+[[package]]
+name = "stakpak-ak"
+version = "0.3.73"
+dependencies = [
+ "dirs",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tempfile",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "libs/agent-core",
   "libs/server",
   "libs/gateway",
+  "libs/ak",
   "libs/mcp/client",
   "libs/mcp/server",
   "libs/mcp/proxy",
@@ -34,6 +35,7 @@ stakpak-mcp-client = { path = "libs/mcp/client", version = "0.3.73" }
 stakpak-mcp-proxy = { path = "libs/mcp/proxy", version = "0.3.73" }
 stakpak-agent-core = { path = "libs/agent-core", version = "0.3.73" }
 stakpak-gateway = { path = "libs/gateway", version = "0.3.73" }
+stakpak-ak = { path = "libs/ak", version = "0.3.73" }
 stakpak-server = { path = "libs/server", version = "0.3.73" }
 stakpak-tui = { path = "tui", version = "0.3.73" }
 stakpak-shared = { path = "libs/shared", version = "0.3.73" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,6 +23,7 @@ stakpak-tui = { workspace = true }
 stakpak-shared = { workspace = true, features = ["sqlite"] }
 stakpak-server = { workspace = true }
 stakpak-gateway = { workspace = true }
+stakpak-ak = { workspace = true }
 stakai = { workspace = true }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }

--- a/cli/src/commands/ak/mod.rs
+++ b/cli/src/commands/ak/mod.rs
@@ -1,0 +1,307 @@
+use clap::Subcommand;
+use stakpak_ak::search::SearchEngine;
+use stakpak_ak::skills::{SKILL_MAINTAIN, SKILL_USAGE};
+use stakpak_ak::{LocalFsBackend, StorageBackend, TreeNavEngine};
+use std::io::Read;
+use std::path::PathBuf;
+
+pub const AK_LONG_ABOUT: &str =
+    "LLM-oriented commands for reading and writing persistent knowledge.
+
+default store root: ~/.stakpak/knowledge
+override: AK_STORE
+paths are relative to the store root
+
+Recommended read flow:
+- tree: discover structure
+- ls [path]: inspect one directory
+- peek <path>: preview frontmatter + first paragraph
+- cat <path>...: read full content
+- use `peek` before `cat` to save tokens
+- prefer `ls --json` for programmatic use
+
+Write behavior:
+- `write` creates a new file
+- `write` fails if the path already exists
+- use `--force` only when you want to overwrite intentionally";
+
+pub const AK_AFTER_HELP: &str = "Examples:
+  stakpak ak tree
+  stakpak ak ls services/
+  stakpak ak ls --json services/
+  stakpak ak peek services/rate-limits.md
+  stakpak ak cat services/rate-limits.md services/auth-flow.md
+  echo 'Rate limit is 1000/min' | stakpak ak write services/rate-limits.md
+  stakpak ak write notes.md --file /tmp/notes.md
+  stakpak ak write --force summaries/auth-overview.md";
+
+#[derive(Subcommand, PartialEq, Debug)]
+#[command(
+    about = "Persistent knowledge store operations",
+    long_about = AK_LONG_ABOUT,
+    after_help = AK_AFTER_HELP
+)]
+pub enum AkCommands {
+    #[command(
+        about = "Create a new knowledge file",
+        long_about = "Create only.
+
+This command reads content from stdin by default. Use `--file` to read from a local file instead.
+
+Behavior:
+- fails if the destination already exists
+- use `--force` to overwrite intentionally
+- paths are relative to the store root",
+        after_help = "Examples:
+  echo 'Rate limit is 1000/min' | stakpak ak write services/rate-limits.md
+  stakpak ak write notes.md --file /tmp/notes.md
+  stakpak ak write --force summaries/auth-overview.md"
+    )]
+    Write {
+        /// Relative path inside the knowledge store where the new file should be created
+        path: String,
+
+        /// Read content from a local file instead of stdin
+        #[arg(
+            short = 'f',
+            long = "file",
+            help = "Path to a local file to read and store instead of reading from stdin"
+        )]
+        file: Option<PathBuf>,
+
+        /// Overwrite the destination if it already exists
+        #[arg(
+            long,
+            default_value_t = false,
+            help = "Replace an existing file at the destination path. Without this flag, write fails if the path already exists"
+        )]
+        force: bool,
+    },
+
+    #[command(
+        about = "Remove a file or directory from the knowledge store",
+        long_about = "Remove a file or an entire directory tree from the ak store.
+
+If you remove the last file in a directory, empty parent directories are cleaned up automatically until the store root."
+    )]
+    Rm {
+        /// Relative path inside the knowledge store to remove
+        path: String,
+    },
+
+    #[command(
+        about = "Print the full directory tree of the knowledge store",
+        long_about = "Print the full directory tree of the ak store.
+
+This is the best starting point when you want to understand the overall structure before drilling into a specific directory or file."
+    )]
+    Tree,
+
+    #[command(
+        about = "List one directory with one-line file descriptions",
+        long_about = "List one directory at a time.
+
+Directories are shown first. File descriptions are extracted from frontmatter or the first non-empty body line.
+
+prefer `--json` when another tool or agent will parse the output"
+    )]
+    Ls {
+        /// Relative directory path inside the knowledge store. Omit to list the store root
+        path: Option<String>,
+
+        /// Output the listing as structured JSON
+        #[arg(
+            long,
+            default_value_t = false,
+            help = "Print a JSON array with name, is_dir, and description fields. Prefer this when another tool or agent will parse the output"
+        )]
+        json: bool,
+    },
+
+    #[command(
+        about = "Show frontmatter and the first paragraph of a file",
+        long_about = "Show a lightweight preview of a file.
+
+`peek` is useful when you want enough context to decide whether you should read the whole file with `cat`."
+    )]
+    Peek {
+        /// Relative path of the file to summarize
+        path: String,
+    },
+
+    #[command(
+        about = "Print the full contents of one or more files",
+        long_about = "Print the full contents of one or more files from the ak store.
+
+When multiple paths are provided, each file is separated with a `---` delimiter so the output is still easy to parse or read."
+    )]
+    Cat {
+        /// One or more relative file paths to print in full
+        #[arg(required = true, num_args = 1..)]
+        paths: Vec<String>,
+    },
+
+    #[command(
+        about = "Show the store location and total file count",
+        long_about = "Show where the ak store currently lives and how many non-dotfiles it contains.
+
+This reflects the default root (~/.stakpak/knowledge) unless AK_STORE is set."
+    )]
+    Status,
+
+    #[command(
+        about = "Print one of the built-in ak skill prompts",
+        long_about = "Print one of the built-in behavior prompts for `ak`.
+
+Use `usage` to teach an agent how to navigate and write to the store. Use `maintain` to teach an agent how to audit, deduplicate, and clean up stored knowledge."
+    )]
+    Skill {
+        /// Built-in skill name: usage or maintain
+        name: String,
+    },
+}
+
+impl AkCommands {
+    pub fn run(self) -> Result<(), String> {
+        let backend = LocalFsBackend::new().map_err(|error| error.to_string())?;
+        let search = TreeNavEngine::new(backend.clone());
+
+        match self {
+            Self::Write { path, file, force } => {
+                let content = read_input(file)?;
+                if force {
+                    backend
+                        .overwrite(&path, &content)
+                        .map_err(|error| error.to_string())?;
+                } else {
+                    backend.create(&path, &content).map_err(|error| match error {
+                        stakpak_ak::Error::AlreadyExists(existing) => {
+                            format!(
+                                "destination already exists: {}. next action: choose a new path or rerun with `stakpak ak write --force {path}` if overwrite is intentional",
+                                existing.display()
+                            )
+                        }
+                        other => other.to_string(),
+                    })?;
+                }
+            }
+            Self::Rm { path } => {
+                backend.remove(&path).map_err(|error| error.to_string())?;
+            }
+            Self::Tree => {
+                println!(
+                    "{}",
+                    backend.tree().map_err(|error| error.to_string())?.print()
+                );
+            }
+            Self::Ls { path, json } => {
+                let path = path.unwrap_or_default();
+                let entries = search
+                    .list_with_descriptions(&path)
+                    .map_err(|error| error.to_string())?;
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&entries).map_err(|error| error.to_string())?
+                    );
+                } else {
+                    print_entries(&entries);
+                }
+            }
+            Self::Peek { path } => {
+                println!("{}", search.peek(&path).map_err(|error| error.to_string())?);
+            }
+            Self::Cat { paths } => {
+                for (index, path) in paths.iter().enumerate() {
+                    if index > 0 {
+                        println!("---");
+                    }
+
+                    let content = backend.read(path).map_err(|error| error.to_string())?;
+                    let text = String::from_utf8_lossy(&content);
+                    print!("{text}");
+                    if index + 1 < paths.len() && !text.ends_with('\n') {
+                        println!();
+                    }
+                }
+            }
+            Self::Status => {
+                println!("Store: {}", backend.root().display());
+                println!(
+                    "Files: {}",
+                    backend.file_count().map_err(|error| error.to_string())?
+                );
+            }
+            Self::Skill { name } => match name.as_str() {
+                "usage" => println!("{SKILL_USAGE}"),
+                "maintain" => println!("{SKILL_MAINTAIN}"),
+                other => {
+                    return Err(format!(
+                        "invalid skill: {other}. valid values: usage, maintain"
+                    ));
+                }
+            },
+        }
+
+        Ok(())
+    }
+}
+
+fn read_input(file: Option<PathBuf>) -> Result<Vec<u8>, String> {
+    if let Some(path) = file {
+        std::fs::read(&path).map_err(|error| {
+            format!(
+                "failed to read input file: {}. source error: {error}",
+                path.display()
+            )
+        })
+    } else {
+        let mut buffer = Vec::new();
+        std::io::stdin()
+            .read_to_end(&mut buffer)
+            .map_err(|error| error.to_string())?;
+        Ok(buffer)
+    }
+}
+
+fn print_entries(entries: &[stakpak_ak::ListEntry]) {
+    let width = entries
+        .iter()
+        .map(display_name)
+        .map(|name| name.chars().count())
+        .max()
+        .unwrap_or(0);
+
+    for entry in entries {
+        let name = display_name(entry);
+        match &entry.description {
+            Some(description) => println!("{name:<width$}  — {description}"),
+            None => println!("{name}"),
+        }
+    }
+}
+
+fn display_name(entry: &stakpak_ak::ListEntry) -> String {
+    if entry.is_dir {
+        format!("{}/", entry.name)
+    } else {
+        entry.name.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AkCommands;
+
+    #[test]
+    fn unknown_skill_error_lists_valid_values() {
+        let error = AkCommands::Skill {
+            name: "unknown".to_string(),
+        }
+        .run()
+        .expect_err("unknown skill should fail");
+
+        assert!(error.contains("invalid skill"));
+        assert!(error.contains("valid values: usage, maintain"));
+    }
+}

--- a/cli/src/commands/ak/mod.rs
+++ b/cli/src/commands/ak/mod.rs
@@ -18,7 +18,6 @@ Recommended read flow:
 - peek <path>: preview frontmatter + first paragraph
 - cat <path>...: read full content
 - use `peek` before `cat` to save tokens
-- prefer `ls --json` for programmatic use
 
 Write behavior:
 - `write` creates a new file
@@ -28,7 +27,6 @@ Write behavior:
 pub const AK_AFTER_HELP: &str = "Examples:
   stakpak ak tree
   stakpak ak ls services/
-  stakpak ak ls --json services/
   stakpak ak peek services/rate-limits.md
   stakpak ak cat services/rate-limits.md services/auth-flow.md
   echo 'Rate limit is 1000/min' | stakpak ak write services/rate-limits.md
@@ -101,21 +99,11 @@ This is the best starting point when you want to understand the overall structur
         about = "List one directory with one-line file descriptions",
         long_about = "List one directory at a time.
 
-Directories are shown first. File descriptions are extracted from frontmatter or the first non-empty body line.
-
-prefer `--json` when another tool or agent will parse the output"
+Directories are shown first. File descriptions are extracted from frontmatter or the first non-empty body line."
     )]
     Ls {
         /// Relative directory path inside the knowledge store. Omit to list the store root
         path: Option<String>,
-
-        /// Output the listing as structured JSON
-        #[arg(
-            long,
-            default_value_t = false,
-            help = "Print a JSON array with name, is_dir, and description fields. Prefer this when another tool or agent will parse the output"
-        )]
-        json: bool,
     },
 
     #[command(
@@ -194,19 +182,12 @@ impl AkCommands {
                     backend.tree().map_err(|error| error.to_string())?.print()
                 );
             }
-            Self::Ls { path, json } => {
+            Self::Ls { path } => {
                 let path = path.unwrap_or_default();
                 let entries = search
                     .list_with_descriptions(&path)
                     .map_err(|error| error.to_string())?;
-                if json {
-                    println!(
-                        "{}",
-                        serde_json::to_string_pretty(&entries).map_err(|error| error.to_string())?
-                    );
-                } else {
-                    print_entries(&entries);
-                }
+                print_entries(&entries);
             }
             Self::Peek { path } => {
                 println!("{}", search.peek(&path).map_err(|error| error.to_string())?);

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ use stakpak_api::{AgentClient, AgentClientConfig, AgentProvider, StakpakConfig};
 
 pub mod acp;
 pub mod agent;
+pub mod ak;
 pub mod auth;
 pub mod auto_update;
 pub mod autopilot;
@@ -181,6 +182,15 @@ pub enum Commands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+
+    /// Local persistent agent knowledge store
+    #[command(
+        subcommand,
+        about = "Persistent knowledge store operations",
+        long_about = ak::AK_LONG_ABOUT,
+        after_help = ak::AK_AFTER_HELP
+    )]
+    Ak(ak::AkCommands),
     /// Update Stakpak Agent to the latest version
     Update,
 
@@ -253,6 +263,7 @@ impl Commands {
                 | Commands::Autopilot(_)
                 | Commands::Up { .. }
                 | Commands::Down { .. }
+                | Commands::Ak(_)
         )
     }
     pub async fn run(self, config: AppConfig) -> Result<(), String> {
@@ -494,6 +505,9 @@ impl Commands {
             }
             Commands::Browser { args } => {
                 browser::run_browser(args).await?;
+            }
+            Commands::Ak(command) => {
+                command.run()?;
             }
             Commands::Update => {
                 auto_update::run_auto_update(false).await?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1025,4 +1025,76 @@ mod tests {
             .requires_auth()
         );
     }
+
+    #[test]
+    fn cli_parses_ak_skill_command() {
+        let parsed = Cli::try_parse_from(["stakpak", "ak", "skill", "usage"]);
+        assert!(parsed.is_ok());
+
+        if let Ok(cli) = parsed {
+            match cli.command {
+                Some(Commands::Ak(commands::ak::AkCommands::Skill { name })) => {
+                    assert_eq!(name, "usage");
+                }
+                _ => panic!("Expected ak skill command"),
+            }
+        }
+    }
+
+    #[test]
+    fn ak_command_does_not_require_auth() {
+        assert!(!Commands::Ak(commands::ak::AkCommands::Tree).requires_auth());
+    }
+
+    #[test]
+    fn ak_cat_requires_at_least_one_path() {
+        let parsed = Cli::try_parse_from(["stakpak", "ak", "cat"]);
+        assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn ak_help_explains_llm_first_operational_guidance() {
+        let result = Cli::try_parse_from(["stakpak", "ak", "--help"]);
+        let error = match result {
+            Ok(_) => panic!("help output should exit via clap error"),
+            Err(error) => error,
+        };
+        let help = error.to_string();
+
+        assert!(help.contains("default store root: ~/.stakpak/knowledge"));
+        assert!(help.contains("override: AK_STORE"));
+        assert!(help.contains("paths are relative to the store root"));
+        assert!(help.contains("use `peek` before `cat` to save tokens"));
+        assert!(help.contains("prefer `ls --json` for programmatic use"));
+    }
+
+    #[test]
+    fn ak_write_help_explains_create_only_and_force_semantics() {
+        let result = Cli::try_parse_from(["stakpak", "ak", "write", "--help"]);
+        let error = match result {
+            Ok(_) => panic!("help output should exit via clap error"),
+            Err(error) => error,
+        };
+        let help = error.to_string();
+
+        assert!(help.contains("Create only"));
+        assert!(help.contains("fails if the destination already exists"));
+        assert!(help.contains("use `--force` to overwrite intentionally"));
+        assert!(help.contains("reads content from stdin by default"));
+        assert!(help.contains("--file"));
+    }
+
+    #[test]
+    fn ak_ls_help_explains_json_preference_for_agents() {
+        let result = Cli::try_parse_from(["stakpak", "ak", "ls", "--help"]);
+        let error = match result {
+            Ok(_) => panic!("help output should exit via clap error"),
+            Err(error) => error,
+        };
+        let help = error.to_string();
+
+        assert!(help.contains("one directory at a time"));
+        assert!(help.contains("frontmatter"));
+        assert!(help.contains("prefer `--json` when another tool or agent will parse the output"));
+    }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1065,7 +1065,7 @@ mod tests {
         assert!(help.contains("override: AK_STORE"));
         assert!(help.contains("paths are relative to the store root"));
         assert!(help.contains("use `peek` before `cat` to save tokens"));
-        assert!(help.contains("prefer `ls --json` for programmatic use"));
+        assert!(!help.contains("ls --json"));
     }
 
     #[test]
@@ -1085,7 +1085,7 @@ mod tests {
     }
 
     #[test]
-    fn ak_ls_help_explains_json_preference_for_agents() {
+    fn ak_ls_help_explains_directory_listing_behavior() {
         let result = Cli::try_parse_from(["stakpak", "ak", "ls", "--help"]);
         let error = match result {
             Ok(_) => panic!("help output should exit via clap error"),
@@ -1095,6 +1095,12 @@ mod tests {
 
         assert!(help.contains("one directory at a time"));
         assert!(help.contains("frontmatter"));
-        assert!(help.contains("prefer `--json` when another tool or agent will parse the output"));
+        assert!(!help.contains("--json"));
+    }
+
+    #[test]
+    fn ak_ls_rejects_json_flag() {
+        let parsed = Cli::try_parse_from(["stakpak", "ak", "ls", "--json"]);
+        assert!(parsed.is_err());
     }
 }

--- a/cli/src/prompts/system_prompt.v1.md
+++ b/cli/src/prompts/system_prompt.v1.md
@@ -543,6 +543,72 @@ Per-schedule: `stakpak autopilot schedule add ... --sandbox`
 
 **Remote file operations:** When writing files to remote servers (configs, check scripts, autopilot.toml), use the `create` tool with remote path format (`user@host:/path`) instead of piping content through SSH commands. Same for `str_replace` and `view`. This is cleaner, safer, and doesn't require shell escaping.
 
+# Knowledge Store: `stakpak ak`
+
+You have access to `ak`, a persistent markdown knowledge store that survives across sessions. Think of it as your long-term memory — use it freely to store anything worth remembering and retrieve it whenever relevant.
+
+## Commands
+```bash
+stakpak ak status                    # Show store location and file count
+stakpak ak tree                      # Print full directory tree
+stakpak ak ls [path] [--json]        # List one directory with descriptions
+stakpak ak peek <path>               # Read summary (frontmatter + first paragraph)
+stakpak ak cat <path> [<path>...]    # Read full content (multiple files separated by ---)
+stakpak ak write <path>              # Create new file (reads from stdin)
+stakpak ak write <path> -f <file>    # Create new file from local file
+stakpak ak write --force <path>      # Overwrite existing file
+stakpak ak rm <path>                 # Remove a file or directory
+```
+
+Files are immutable by default — `ak write` errors if the file already exists. Use `--force` to overwrite mutable documents.
+
+## Bootstrap Your Philosophy
+The first time you use the store (or find it empty), define your own storage philosophy and write it to a file like `_schema.md` or whatever you prefer. This file is your constitution — it describes how you organize, name, structure, and retrieve knowledge. Future sessions read this file first to stay consistent.
+
+Your philosophy should answer:
+- How do you structure directories and name files so you can **predict where something lives** without scanning everything?
+- What conventions make filenames and paths self-describing enough that `ak tree` alone tells you what's stored?
+- How do you use frontmatter, cross-references, or indexes to make retrieval fast?
+- What's mutable vs immutable? What gets `--force` updates vs stays frozen?
+
+The goal: **any future session should be able to find relevant knowledge quickly by following your own conventions**, not by reading every file. Design for your own retrieval patterns — you know how you search, so optimize for that.
+
+Follow your philosophy consistently, but treat it as a living document that self-improves. Every time you interact with the store is a feedback loop:
+- If you struggled to find something → your naming or structure has a gap. Fix it.
+- If you found yourself storing something that doesn't fit your current categories → evolve the schema.
+- If a retrieval took multiple steps when it should have taken one → rethink the organization.
+- If you notice redundancy or inconsistency → refactor the affected files and update the schema.
+
+Update the schema with `--force` right when you spot the improvement. The philosophy should get sharper over time through actual use — not through periodic reviews, but as a natural byproduct of working with the store.
+
+## Store Early, Store Often
+Whenever you discover something that a future session would benefit from knowing, write it down immediately. Don't wait — knowledge is most valuable when captured fresh.
+
+This includes: infrastructure facts, configuration details, architecture decisions, troubleshooting findings, deployment procedures, root cause analyses, project context, service relationships, operational patterns — anything non-obvious that took effort to learn.
+
+**Never store**: secrets, credentials, tokens, or raw command output dumps.
+
+## Retrieve Before You Work
+Before diving into a task, check what you already know. Start with your schema file to remember your conventions, then navigate accordingly. Use `peek` for quick relevance checks, `cat` when you need the full picture. Your past self may have already done the hard work.
+
+## Keep It Alive
+When new information contradicts or supersedes existing knowledge, update or replace it. When you synthesize insights from multiple files, write the synthesis back. When a discovery touches multiple topics, update all the relevant files — a single finding might ripple across several knowledge entries. The store should reflect your current best understanding, not a frozen snapshot.
+
+## Background Knowledge Work
+Don't let knowledge tasks block your main work. When you learn something worth storing, spin up a background subagent to handle the writing, cross-referencing, and bookkeeping while you keep moving on the primary task.
+
+**Use background subagents for:**
+- Writing new knowledge files after a discovery
+- Updating multiple related files when something changes
+- Consolidating or reorganizing knowledge after a task
+- Checking the store for relevant context at session start
+
+**Keep in the main thread:**
+- Reading knowledge you need right now to make a decision
+- Quick `ak tree` or `ak peek` lookups that inform your next step
+
+The subagent should have access to `run_command` so it can execute `stakpak ak` commands. Include the output of `stakpak ak skill usage` in the subagent prompt — it contains the usage patterns and examples (like how `ak write` reads from stdin). Give the subagent enough context about what you learned and let it decide how to structure and store it.
+
 # Task Success Criteria
 1. Problem is thoroughly analyzed and understood.
 2. Solution is architected with proper consideration of trade-offs.

--- a/cli/src/prompts/system_prompt.v1.md
+++ b/cli/src/prompts/system_prompt.v1.md
@@ -551,7 +551,7 @@ You have access to `ak`, a persistent markdown knowledge store that survives acr
 ```bash
 stakpak ak status                    # Show store location and file count
 stakpak ak tree                      # Print full directory tree
-stakpak ak ls [path] [--json]        # List one directory with descriptions
+stakpak ak ls [path]                 # List one directory with descriptions
 stakpak ak peek <path>               # Read summary (frontmatter + first paragraph)
 stakpak ak cat <path> [<path>...]    # Read full content (multiple files separated by ---)
 stakpak ak write <path>              # Create new file (reads from stdin)

--- a/cli/tests/ak_cli.rs
+++ b/cli/tests/ak_cli.rs
@@ -1,0 +1,32 @@
+use std::process::Command;
+
+#[test]
+fn ak_status_bootstraps_default_config_on_clean_home() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let home = temp_dir.path();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_stakpak"))
+        .arg("ak")
+        .arg("status")
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env_remove("STAKPAK_PROFILE")
+        .output()
+        .expect("run stakpak ak status");
+
+    assert!(
+        output.status.success(),
+        "ak status failed: stdout={} stderr= {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Store:"), "stdout was: {stdout}");
+    assert!(stdout.contains("Files: 0"), "stdout was: {stdout}");
+
+    assert!(
+        home.join(".stakpak/config.toml").is_file(),
+        "expected ak status to bootstrap ~/.stakpak/config.toml"
+    );
+}

--- a/libs/ak/Cargo.toml
+++ b/libs/ak/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "stakpak-ak"
+version = { workspace = true }
+edition = { workspace = true }
+description = "Agent knowledge store library"
+license = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = "0.9"
+walkdir = { workspace = true }
+dirs = "5.0"
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/libs/ak/src/error.rs
+++ b/libs/ak/src/error.rs
@@ -1,0 +1,70 @@
+use std::fmt::{Display, Formatter};
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub enum Error {
+    Io(std::io::Error),
+    AlreadyExists(PathBuf),
+    NotFound(PathBuf),
+    UnsafePath(PathBuf),
+    Parse(String),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(error) => write!(
+                f,
+                "io error: {error}. check filesystem permissions, parent directories, and AK_STORE"
+            ),
+            Self::AlreadyExists(path) => write!(
+                f,
+                "path already exists: {}. choose a new path or overwrite intentionally",
+                path.display()
+            ),
+            Self::NotFound(path) => write!(
+                f,
+                "path not found: {}. check that the path is relative to the store root",
+                path.display()
+            ),
+            Self::UnsafePath(path) => write!(
+                f,
+                "unsafe path blocked: {}. ak paths must stay inside the store and cannot pass through symlinks",
+                path.display()
+            ),
+            Self::Parse(message) => write!(f, "invalid input: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<std::io::Error> for Error {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Error;
+    use std::path::PathBuf;
+
+    #[test]
+    fn not_found_error_explains_path_interpretation() {
+        let error = Error::NotFound(PathBuf::from("/tmp/store/knowledge/missing.md"));
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("path not found"));
+        assert!(rendered.contains("check that the path is relative to the store root"));
+    }
+
+    #[test]
+    fn already_exists_error_suggests_intentional_overwrite_or_new_path() {
+        let error = Error::AlreadyExists(PathBuf::from("/tmp/store/knowledge/existing.md"));
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("path already exists"));
+        assert!(rendered.contains("choose a new path or overwrite intentionally"));
+    }
+}

--- a/libs/ak/src/format.rs
+++ b/libs/ak/src/format.rs
@@ -1,0 +1,164 @@
+fn trim_line_endings(line: &str) -> &str {
+    line.trim_end_matches(['\r', '\n'])
+}
+
+fn frontmatter_sections(content: &str) -> Option<(serde_yaml::Value, &str, &str)> {
+    let mut segments = content.split_inclusive('\n');
+    let first = segments.next()?;
+    if trim_line_endings(first) != "---" {
+        return None;
+    }
+
+    let frontmatter_start = first.len();
+    let mut cursor = first.len();
+
+    for segment in segments {
+        let segment_start = cursor;
+        cursor += segment.len();
+
+        if trim_line_endings(segment) == "---" {
+            let yaml = content.get(frontmatter_start..segment_start)?;
+            let raw = content.get(..cursor)?;
+            let body = content.get(cursor..)?;
+            let frontmatter = serde_yaml::from_str::<serde_yaml::Value>(yaml).ok()?;
+            return Some((frontmatter, raw, body));
+        }
+    }
+
+    None
+}
+
+fn first_paragraph(content: &str) -> String {
+    let mut lines = Vec::new();
+    let mut started = false;
+
+    for line in content.lines() {
+        if line.trim().is_empty() {
+            if started {
+                break;
+            }
+            continue;
+        }
+
+        started = true;
+        lines.push(line);
+    }
+
+    lines.join("\n")
+}
+
+pub fn parse_frontmatter(content: &str) -> (Option<serde_yaml::Value>, &str) {
+    match frontmatter_sections(content) {
+        Some((frontmatter, _raw, body)) => (Some(frontmatter), body),
+        None => (None, content),
+    }
+}
+
+pub fn extract_description(content: &str) -> Option<String> {
+    let (frontmatter, body) = parse_frontmatter(content);
+
+    if let Some(frontmatter) = frontmatter
+        && let Some(description) = frontmatter
+            .get("description")
+            .and_then(serde_yaml::Value::as_str)
+            .map(str::trim)
+        && !description.is_empty()
+    {
+        return Some(description.to_string());
+    }
+
+    body.lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(ToString::to_string)
+}
+
+pub fn extract_peek(content: &str) -> String {
+    if let Some((_frontmatter, raw, body)) = frontmatter_sections(content) {
+        let paragraph = first_paragraph(body);
+        if paragraph.is_empty() {
+            raw.trim_end_matches(['\r', '\n']).to_string()
+        } else {
+            format!("{}\n{}", raw.trim_end_matches(['\r', '\n']), paragraph)
+        }
+    } else {
+        first_paragraph(content)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{extract_description, extract_peek, parse_frontmatter};
+
+    #[test]
+    fn parse_frontmatter_returns_yaml_and_body_for_valid_frontmatter() {
+        let content = "---\ndescription: API rate limits\ntags:\n  - api\n---\nBody text\n";
+
+        let (frontmatter, body) = parse_frontmatter(content);
+
+        let frontmatter = frontmatter.expect("frontmatter should parse");
+        assert_eq!(frontmatter["description"].as_str(), Some("API rate limits"));
+        assert_eq!(body, "Body text\n");
+    }
+
+    #[test]
+    fn parse_frontmatter_handles_missing_frontmatter() {
+        let content = "Body text\n";
+
+        let (frontmatter, body) = parse_frontmatter(content);
+
+        assert!(frontmatter.is_none());
+        assert_eq!(body, content);
+    }
+
+    #[test]
+    fn parse_frontmatter_treats_invalid_yaml_as_body() {
+        let content = "---\ndescription: [oops\n---\nBody text\n";
+
+        let (frontmatter, body) = parse_frontmatter(content);
+
+        assert!(frontmatter.is_none());
+        assert_eq!(body, content);
+    }
+
+    #[test]
+    fn extract_description_prefers_frontmatter_description() {
+        let content =
+            "---\ndescription: API rate limits\n---\nFirst body line\n\nSecond paragraph\n";
+
+        assert_eq!(
+            extract_description(content),
+            Some("API rate limits".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_description_falls_back_to_first_non_empty_body_line() {
+        let content = "\n\nThe auth service uses OAuth2 PKCE\n\nDetails\n";
+
+        assert_eq!(
+            extract_description(content),
+            Some("The auth service uses OAuth2 PKCE".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_peek_returns_frontmatter_and_first_paragraph() {
+        let content = "---\ndescription: API rate limits\n---\nThe auth service rate limits at 1000 req/min.\nAfter hitting the limit, responses return 429.\n\nSecond paragraph.\n";
+
+        assert_eq!(
+            extract_peek(content),
+            "---\ndescription: API rate limits\n---\nThe auth service rate limits at 1000 req/min.\nAfter hitting the limit, responses return 429."
+        );
+    }
+
+    #[test]
+    fn extract_peek_returns_first_paragraph_without_frontmatter() {
+        let content = "First paragraph line one.\nStill first paragraph.\n\nSecond paragraph.\n";
+
+        assert_eq!(
+            extract_peek(content),
+            "First paragraph line one.\nStill first paragraph."
+        );
+    }
+}

--- a/libs/ak/src/lib.rs
+++ b/libs/ak/src/lib.rs
@@ -1,0 +1,9 @@
+mod error;
+pub mod format;
+pub mod search;
+pub mod skills;
+pub mod store;
+
+pub use error::Error;
+pub use search::{ListEntry, SearchEngine, TreeNavEngine};
+pub use store::{Entry, LocalFsBackend, StorageBackend, TreeNode};

--- a/libs/ak/src/search.rs
+++ b/libs/ak/src/search.rs
@@ -1,0 +1,206 @@
+use crate::Error;
+use crate::format::{extract_description, extract_peek};
+use crate::store::StorageBackend;
+use serde::Serialize;
+
+const DESCRIPTION_READ_LIMIT_BYTES: usize = 16 * 1024;
+
+pub trait SearchEngine {
+    fn list_with_descriptions(&self, path: &str) -> Result<Vec<ListEntry>, Error>;
+    fn peek(&self, path: &str) -> Result<String, Error>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ListEntry {
+    pub name: String,
+    pub is_dir: bool,
+    pub description: Option<String>,
+}
+
+pub struct TreeNavEngine<T> {
+    store: T,
+}
+
+impl<T> TreeNavEngine<T>
+where
+    T: StorageBackend,
+{
+    pub fn new(store: T) -> Self {
+        Self { store }
+    }
+}
+
+impl<T> SearchEngine for TreeNavEngine<T>
+where
+    T: StorageBackend,
+{
+    fn list_with_descriptions(&self, path: &str) -> Result<Vec<ListEntry>, Error> {
+        self.store
+            .list(path)?
+            .into_iter()
+            .map(|entry| {
+                let description = if entry.is_dir {
+                    None
+                } else {
+                    let content = self
+                        .store
+                        .read_prefix(&join_path(path, &entry.name), DESCRIPTION_READ_LIMIT_BYTES)?;
+                    extract_description(&String::from_utf8_lossy(&content))
+                };
+
+                Ok(ListEntry {
+                    name: entry.name,
+                    is_dir: entry.is_dir,
+                    description,
+                })
+            })
+            .collect()
+    }
+
+    fn peek(&self, path: &str) -> Result<String, Error> {
+        let content = self.store.read(path)?;
+        Ok(extract_peek(&String::from_utf8_lossy(&content)))
+    }
+}
+
+fn join_path(parent: &str, child: &str) -> String {
+    if parent.is_empty() {
+        child.to_string()
+    } else {
+        format!("{}/{}", parent.trim_end_matches('/'), child)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ListEntry, SearchEngine, TreeNavEngine};
+    use crate::Error;
+    use crate::store::{Entry, LocalFsBackend, StorageBackend, TreeNode};
+    use std::cell::Cell;
+
+    #[test]
+    fn list_with_descriptions_reads_file_descriptions() {
+        let root = tempfile::TempDir::new().expect("temp dir");
+        let backend = LocalFsBackend::with_root(root.path().join("store"));
+        backend
+            .create(
+                "knowledge/rate-limits.md",
+                b"---\ndescription: API rate limits\n---\nBody\n",
+            )
+            .expect("create described file");
+        backend
+            .create("knowledge/auth-flow.md", b"OAuth2 PKCE flow\n\nMore\n")
+            .expect("create plain file");
+        std::fs::create_dir_all(backend.root().join("knowledge/subdir")).expect("create subdir");
+        let engine = TreeNavEngine::new(backend);
+
+        assert_eq!(
+            engine
+                .list_with_descriptions("knowledge")
+                .expect("list with descriptions"),
+            vec![
+                ListEntry {
+                    name: "subdir".to_string(),
+                    is_dir: true,
+                    description: None,
+                },
+                ListEntry {
+                    name: "auth-flow.md".to_string(),
+                    is_dir: false,
+                    description: Some("OAuth2 PKCE flow".to_string()),
+                },
+                ListEntry {
+                    name: "rate-limits.md".to_string(),
+                    is_dir: false,
+                    description: Some("API rate limits".to_string()),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn peek_returns_frontmatter_and_first_paragraph() {
+        let root = tempfile::TempDir::new().expect("temp dir");
+        let backend = LocalFsBackend::with_root(root.path().join("store"));
+        backend
+            .create(
+                "knowledge/rate-limits.md",
+                b"---\ndescription: API rate limits\n---\nThe auth service rate limits at 1000 req/min.\nAfter hitting the limit, responses return 429.\n\nSecond paragraph.\n",
+            )
+            .expect("create file");
+        let engine = TreeNavEngine::new(backend);
+
+        assert_eq!(
+            engine.peek("knowledge/rate-limits.md").expect("peek file"),
+            "---\ndescription: API rate limits\n---\nThe auth service rate limits at 1000 req/min.\nAfter hitting the limit, responses return 429."
+        );
+    }
+
+    #[derive(Default)]
+    struct PrefixOnlyBackend {
+        read_called: Cell<bool>,
+        read_prefix_called: Cell<bool>,
+    }
+
+    impl StorageBackend for PrefixOnlyBackend {
+        fn create(&self, _path: &str, _content: &[u8]) -> Result<(), Error> {
+            unimplemented!("not needed for this test")
+        }
+
+        fn overwrite(&self, _path: &str, _content: &[u8]) -> Result<(), Error> {
+            unimplemented!("not needed for this test")
+        }
+
+        fn read(&self, _path: &str) -> Result<Vec<u8>, Error> {
+            self.read_called.set(true);
+            Err(Error::Parse(
+                "full read should not be used for ls descriptions".to_string(),
+            ))
+        }
+
+        fn read_prefix(&self, _path: &str, _max_bytes: usize) -> Result<Vec<u8>, Error> {
+            self.read_prefix_called.set(true);
+            Ok(b"---\ndescription: Prefix description\n---\nBody\n".to_vec())
+        }
+
+        fn remove(&self, _path: &str) -> Result<(), Error> {
+            unimplemented!("not needed for this test")
+        }
+
+        fn list(&self, _path: &str) -> Result<Vec<Entry>, Error> {
+            Ok(vec![Entry {
+                name: "note.md".to_string(),
+                is_dir: false,
+            }])
+        }
+
+        fn tree(&self) -> Result<TreeNode, Error> {
+            unimplemented!("not needed for this test")
+        }
+
+        fn exists(&self, _path: &str) -> Result<bool, Error> {
+            unimplemented!("not needed for this test")
+        }
+    }
+
+    #[test]
+    fn list_with_descriptions_reads_only_prefixes() {
+        let backend = PrefixOnlyBackend::default();
+        let engine = TreeNavEngine::new(backend);
+
+        let entries = engine
+            .list_with_descriptions("")
+            .expect("list with prefix reads");
+
+        assert_eq!(
+            entries,
+            vec![ListEntry {
+                name: "note.md".to_string(),
+                is_dir: false,
+                description: Some("Prefix description".to_string()),
+            }]
+        );
+        assert!(!engine.store.read_called.get());
+        assert!(engine.store.read_prefix_called.get());
+    }
+}

--- a/libs/ak/src/skills.rs
+++ b/libs/ak/src/skills.rs
@@ -1,0 +1,35 @@
+pub const SKILL_USAGE: &str = r#"You have access to `ak`, a persistent knowledge store.
+It stores markdown files in a directory that survives across sessions.
+
+Key commands:
+- ak tree / ak ls        — see what exists (structure and listings)
+- ak peek <path>         — read summary (frontmatter + first paragraph)
+- ak cat <path>          — read full content
+- ak write <path>        — create new knowledge file (stdin or -f <file>)
+- ak write --force <path> — overwrite an existing file
+- ak rm <path>           — remove a knowledge file
+
+Files are immutable by default — `ak write` errors if the file
+already exists. Use this for extracted facts and knowledge.
+Use `--force` for mutable documents like summaries and indexes.
+
+Organize however you want — directories, naming conventions,
+frontmatter, cross-references. There are no rules.
+
+If you synthesize an answer from multiple files, consider
+writing the synthesis back as new knowledge."#;
+
+pub const SKILL_MAINTAIN: &str = r#"Review your knowledge store for quality and accuracy.
+
+1. Run `ak tree` and `ak ls` to see what exists.
+2. Look for:
+   - Duplicate or near-duplicate entries → write a merged version,
+     remove the originals
+   - Contradictory facts → resolve or flag to the user
+   - Stale information (old dates, outdated facts) → remove and
+     write corrected versions
+   - Scattered facts that should be consolidated into a single file
+   - Overly broad files that should be split into atomic facts
+3. Use `ak write`, `ak write --force`, and `ak rm` to fix what
+   you find.
+4. Summarize what you changed and why."#;

--- a/libs/ak/src/store.rs
+++ b/libs/ak/src/store.rs
@@ -64,6 +64,13 @@ pub struct LocalFsBackend {
 }
 
 impl LocalFsBackend {
+    /// Return the store-relative version of an absolute path for use in error messages.
+    fn relative_path(&self, path: &Path) -> PathBuf {
+        path.strip_prefix(&self.root)
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| path.to_path_buf())
+    }
+
     pub fn new() -> Result<Self, Error> {
         if let Some(root) = std::env::var_os("AK_STORE") {
             return Ok(Self {
@@ -98,7 +105,7 @@ impl LocalFsBackend {
         {
             let entry = entry.map_err(|error| Error::Io(std::io::Error::other(error)))?;
             if entry.path() != self.root && entry.file_type().is_symlink() {
-                return Err(Error::UnsafePath(entry.path().to_path_buf()));
+                return Err(Error::UnsafePath(self.relative_path(entry.path())));
             }
             if entry.file_type().is_file() {
                 count += 1;
@@ -136,7 +143,7 @@ impl LocalFsBackend {
         let relative = path.strip_prefix(&self.root).map_err(|_| {
             Error::Parse(format!(
                 "path is outside the configured store root: {}",
-                path.display()
+                self.relative_path(path).display()
             ))
         })?;
 
@@ -145,14 +152,14 @@ impl LocalFsBackend {
             let Component::Normal(part) = component else {
                 return Err(Error::Parse(format!(
                     "invalid resolved store path: {}",
-                    path.display()
+                    self.relative_path(path).display()
                 )));
             };
             current.push(part);
 
             match fs::symlink_metadata(&current) {
                 Ok(metadata) if metadata.file_type().is_symlink() => {
-                    return Err(Error::UnsafePath(current));
+                    return Err(Error::UnsafePath(self.relative_path(&current)));
                 }
                 Ok(_) => {}
                 Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
@@ -167,7 +174,7 @@ impl LocalFsBackend {
         match fs::symlink_metadata(path) {
             Ok(metadata) => {
                 if metadata.file_type().is_symlink() {
-                    Err(Error::UnsafePath(path.to_path_buf()))
+                    Err(Error::UnsafePath(self.relative_path(path)))
                 } else {
                     Ok(Some(metadata))
                 }
@@ -220,7 +227,7 @@ impl LocalFsBackend {
         }
 
         let mut children = Vec::new();
-        for child in read_sorted_children(path)? {
+        for child in read_sorted_children(path, None)? {
             children.push(Self::build_tree_node(&child.path, child.name)?);
         }
 
@@ -238,7 +245,7 @@ impl StorageBackend for LocalFsBackend {
         let target = self.resolve_path(path)?;
         self.ensure_no_symlinks_below_root(&target)?;
         if self.metadata_if_exists(&target)?.is_some() {
-            return Err(Error::AlreadyExists(target));
+            return Err(Error::AlreadyExists(self.relative_path(&target)));
         }
 
         if let Some(parent) = target.parent() {
@@ -264,7 +271,7 @@ impl StorageBackend for LocalFsBackend {
         let target = self.resolve_path(path)?;
         self.ensure_no_symlinks_below_root(&target)?;
         if self.metadata_if_exists(&target)?.is_none() {
-            return Err(Error::NotFound(target));
+            return Err(Error::NotFound(self.relative_path(&target)));
         }
         Ok(fs::read(target)?)
     }
@@ -273,7 +280,7 @@ impl StorageBackend for LocalFsBackend {
         let target = self.resolve_path(path)?;
         self.ensure_no_symlinks_below_root(&target)?;
         if self.metadata_if_exists(&target)?.is_none() {
-            return Err(Error::NotFound(target));
+            return Err(Error::NotFound(self.relative_path(&target)));
         }
         self.read_file_prefix(&target, max_bytes)
     }
@@ -283,7 +290,7 @@ impl StorageBackend for LocalFsBackend {
         self.ensure_no_symlinks_below_root(&target)?;
         let metadata = self
             .metadata_if_exists(&target)?
-            .ok_or_else(|| Error::NotFound(target.clone()))?;
+            .ok_or_else(|| Error::NotFound(self.relative_path(&target)))?;
 
         let parent = target.parent().map(Path::to_path_buf);
         if metadata.is_dir() {
@@ -303,17 +310,17 @@ impl StorageBackend for LocalFsBackend {
             return if path.is_empty() {
                 Ok(vec![])
             } else {
-                Err(Error::NotFound(target))
+                Err(Error::NotFound(self.relative_path(&target)))
             };
         };
         if !metadata.is_dir() {
             return Err(Error::Parse(format!(
                 "path is not a directory: {}",
-                target.display()
+                self.relative_path(&target).display()
             )));
         }
 
-        read_sorted_children(&target).map(|children| {
+        read_sorted_children(&target, Some(&self.root)).map(|children| {
             children
                 .into_iter()
                 .map(|child| Entry {
@@ -326,7 +333,7 @@ impl StorageBackend for LocalFsBackend {
 
     fn tree(&self) -> Result<TreeNode, Error> {
         self.ensure_no_symlinks_below_root(&self.root)?;
-        Self::build_tree_node(&self.root, self.root.display().to_string())
+        Self::build_tree_node(&self.root, ".".to_string())
     }
 
     fn exists(&self, path: &str) -> Result<bool, Error> {
@@ -346,7 +353,7 @@ struct ChildEntry {
     is_dir: bool,
 }
 
-fn read_sorted_children(path: &Path) -> Result<Vec<ChildEntry>, Error> {
+fn read_sorted_children(path: &Path, root: Option<&Path>) -> Result<Vec<ChildEntry>, Error> {
     let mut children = Vec::new();
     for entry in fs::read_dir(path)? {
         let entry = entry?;
@@ -358,7 +365,10 @@ fn read_sorted_children(path: &Path) -> Result<Vec<ChildEntry>, Error> {
         let file_type = entry.file_type()?;
         let child_path = entry.path();
         if file_type.is_symlink() {
-            return Err(Error::UnsafePath(child_path));
+            let display_path = root
+                .and_then(|r| child_path.strip_prefix(r).ok().map(PathBuf::from))
+                .unwrap_or_else(|| child_path.clone());
+            return Err(Error::UnsafePath(display_path));
         }
 
         children.push(ChildEntry {
@@ -533,7 +543,7 @@ mod tests {
         assert_eq!(
             tree,
             TreeNode {
-                name: backend.root().display().to_string(),
+                name: ".".to_string(),
                 is_dir: true,
                 children: vec![
                     TreeNode {
@@ -562,7 +572,7 @@ mod tests {
     #[test]
     fn tree_node_print_renders_connectors() {
         let tree = TreeNode {
-            name: "~/.stakpak/knowledge".to_string(),
+            name: ".".to_string(),
             is_dir: true,
             children: vec![
                 TreeNode {
@@ -584,7 +594,7 @@ mod tests {
 
         assert_eq!(
             tree.print(),
-            "~/.stakpak/knowledge\n├── knowledge\n│   └── rate-limits.md\n└── notes.md"
+            ".\n├── knowledge\n│   └── rate-limits.md\n└── notes.md"
         );
     }
 
@@ -671,6 +681,45 @@ mod tests {
 
         assert!(matches!(error, crate::Error::UnsafePath(_)));
         assert!(!outside.path().join("pwned.md").exists());
+    }
+
+    #[test]
+    fn create_rejects_parent_directory_traversal() {
+        let (temp_dir, backend) = backend();
+        let outside = temp_dir.path().join("outside.md");
+
+        let error = backend
+            .create("../outside.md", b"pwned")
+            .expect_err("parent traversal should fail");
+
+        assert!(matches!(error, crate::Error::Parse(_)));
+        assert!(!outside.exists());
+    }
+
+    #[test]
+    fn read_rejects_parent_directory_traversal() {
+        let (temp_dir, backend) = backend();
+        let outside = temp_dir.path().join("outside.md");
+        std::fs::write(&outside, "secret").expect("write outside file");
+
+        let error = backend
+            .read("../outside.md")
+            .expect_err("parent traversal read should fail");
+
+        assert!(matches!(error, crate::Error::Parse(_)));
+    }
+
+    #[test]
+    fn list_rejects_absolute_path_traversal() {
+        let (_temp_dir, backend) = backend();
+        let absolute = backend.root().join("knowledge");
+        let absolute = absolute.to_string_lossy().to_string();
+
+        let error = backend
+            .list(&absolute)
+            .expect_err("absolute path traversal should fail");
+
+        assert!(matches!(error, crate::Error::Parse(_)));
     }
 
     #[cfg(unix)]

--- a/libs/ak/src/store.rs
+++ b/libs/ak/src/store.rs
@@ -1,0 +1,701 @@
+use crate::Error;
+use serde::Serialize;
+use std::cmp::Ordering;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Component, Path, PathBuf};
+use walkdir::WalkDir;
+
+pub trait StorageBackend {
+    fn create(&self, path: &str, content: &[u8]) -> Result<(), Error>;
+    fn overwrite(&self, path: &str, content: &[u8]) -> Result<(), Error>;
+    fn read(&self, path: &str) -> Result<Vec<u8>, Error>;
+    fn read_prefix(&self, path: &str, max_bytes: usize) -> Result<Vec<u8>, Error>;
+    fn remove(&self, path: &str) -> Result<(), Error>;
+    fn list(&self, path: &str) -> Result<Vec<Entry>, Error>;
+    fn tree(&self) -> Result<TreeNode, Error>;
+    fn exists(&self, path: &str) -> Result<bool, Error>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Entry {
+    pub name: String,
+    pub is_dir: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TreeNode {
+    pub name: String,
+    pub is_dir: bool,
+    pub children: Vec<TreeNode>,
+}
+
+impl TreeNode {
+    pub fn print(&self) -> String {
+        let mut lines = vec![self.name.clone()];
+        self.render_children("", &mut lines);
+        lines.join("\n")
+    }
+
+    fn render_children(&self, prefix: &str, lines: &mut Vec<String>) {
+        let last_index = self.children.len().saturating_sub(1);
+
+        for (index, child) in self.children.iter().enumerate() {
+            let connector = if index == last_index {
+                "└──"
+            } else {
+                "├──"
+            };
+            lines.push(format!("{prefix}{connector} {}", child.name));
+
+            let next_prefix = if index == last_index {
+                format!("{prefix}    ")
+            } else {
+                format!("{prefix}│   ")
+            };
+            child.render_children(&next_prefix, lines);
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LocalFsBackend {
+    root: PathBuf,
+}
+
+impl LocalFsBackend {
+    pub fn new() -> Result<Self, Error> {
+        if let Some(root) = std::env::var_os("AK_STORE") {
+            return Ok(Self {
+                root: PathBuf::from(root),
+            });
+        }
+
+        let home = dirs::home_dir()
+            .ok_or_else(|| Error::Parse("could not determine home directory".to_string()))?;
+        Ok(Self {
+            root: default_store_root(&home),
+        })
+    }
+
+    pub fn with_root(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn file_count(&self) -> Result<usize, Error> {
+        if !self.root.exists() {
+            return Ok(0);
+        }
+
+        let mut count = 0;
+        for entry in WalkDir::new(&self.root)
+            .into_iter()
+            .filter_entry(|entry| !is_hidden_path(entry.path(), &self.root))
+        {
+            let entry = entry.map_err(|error| Error::Io(std::io::Error::other(error)))?;
+            if entry.path() != self.root && entry.file_type().is_symlink() {
+                return Err(Error::UnsafePath(entry.path().to_path_buf()));
+            }
+            if entry.file_type().is_file() {
+                count += 1;
+            }
+        }
+
+        Ok(count)
+    }
+
+    fn ensure_store(&self) -> Result<(), Error> {
+        fs::create_dir_all(&self.root)?;
+        Ok(())
+    }
+
+    fn resolve_path(&self, path: &str) -> Result<PathBuf, Error> {
+        if path.is_empty() {
+            return Ok(self.root.clone());
+        }
+
+        let mut relative = PathBuf::new();
+        for component in Path::new(path).components() {
+            match component {
+                Component::Normal(part) => relative.push(part),
+                Component::CurDir => {}
+                Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                    return Err(Error::Parse(format!("invalid store path: {path}")));
+                }
+            }
+        }
+
+        Ok(self.root.join(relative))
+    }
+
+    fn ensure_no_symlinks_below_root(&self, path: &Path) -> Result<(), Error> {
+        let relative = path.strip_prefix(&self.root).map_err(|_| {
+            Error::Parse(format!(
+                "path is outside the configured store root: {}",
+                path.display()
+            ))
+        })?;
+
+        let mut current = self.root.clone();
+        for component in relative.components() {
+            let Component::Normal(part) = component else {
+                return Err(Error::Parse(format!(
+                    "invalid resolved store path: {}",
+                    path.display()
+                )));
+            };
+            current.push(part);
+
+            match fs::symlink_metadata(&current) {
+                Ok(metadata) if metadata.file_type().is_symlink() => {
+                    return Err(Error::UnsafePath(current));
+                }
+                Ok(_) => {}
+                Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+                Err(error) => return Err(Error::Io(error)),
+            }
+        }
+
+        Ok(())
+    }
+
+    fn metadata_if_exists(&self, path: &Path) -> Result<Option<fs::Metadata>, Error> {
+        match fs::symlink_metadata(path) {
+            Ok(metadata) => {
+                if metadata.file_type().is_symlink() {
+                    Err(Error::UnsafePath(path.to_path_buf()))
+                } else {
+                    Ok(Some(metadata))
+                }
+            }
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(Error::Io(error)),
+        }
+    }
+
+    fn read_file_prefix(&self, path: &Path, max_bytes: usize) -> Result<Vec<u8>, Error> {
+        let mut file = fs::File::open(path)?;
+        let mut buffer = vec![0; max_bytes];
+        let bytes_read = std::io::Read::read(&mut file, &mut buffer)?;
+        buffer.truncate(bytes_read);
+        Ok(buffer)
+    }
+
+    fn cleanup_empty_parents(&self, mut current: Option<&Path>) -> Result<(), Error> {
+        while let Some(path) = current {
+            if path == self.root {
+                break;
+            }
+            if !path.exists() || !path.is_dir() || fs::read_dir(path)?.next().is_some() {
+                break;
+            }
+
+            fs::remove_dir(path)?;
+            current = path.parent();
+        }
+
+        Ok(())
+    }
+
+    fn build_tree_node(path: &Path, name: String) -> Result<TreeNode, Error> {
+        if !path.exists() {
+            return Ok(TreeNode {
+                name,
+                is_dir: true,
+                children: vec![],
+            });
+        }
+
+        let metadata = fs::metadata(path)?;
+        if !metadata.is_dir() {
+            return Ok(TreeNode {
+                name,
+                is_dir: false,
+                children: vec![],
+            });
+        }
+
+        let mut children = Vec::new();
+        for child in read_sorted_children(path)? {
+            children.push(Self::build_tree_node(&child.path, child.name)?);
+        }
+
+        Ok(TreeNode {
+            name,
+            is_dir: true,
+            children,
+        })
+    }
+}
+
+impl StorageBackend for LocalFsBackend {
+    fn create(&self, path: &str, content: &[u8]) -> Result<(), Error> {
+        self.ensure_store()?;
+        let target = self.resolve_path(path)?;
+        self.ensure_no_symlinks_below_root(&target)?;
+        if self.metadata_if_exists(&target)?.is_some() {
+            return Err(Error::AlreadyExists(target));
+        }
+
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(target, content)?;
+        Ok(())
+    }
+
+    fn overwrite(&self, path: &str, content: &[u8]) -> Result<(), Error> {
+        self.ensure_store()?;
+        let target = self.resolve_path(path)?;
+        self.ensure_no_symlinks_below_root(&target)?;
+        let _ = self.metadata_if_exists(&target)?;
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(target, content)?;
+        Ok(())
+    }
+
+    fn read(&self, path: &str) -> Result<Vec<u8>, Error> {
+        let target = self.resolve_path(path)?;
+        self.ensure_no_symlinks_below_root(&target)?;
+        if self.metadata_if_exists(&target)?.is_none() {
+            return Err(Error::NotFound(target));
+        }
+        Ok(fs::read(target)?)
+    }
+
+    fn read_prefix(&self, path: &str, max_bytes: usize) -> Result<Vec<u8>, Error> {
+        let target = self.resolve_path(path)?;
+        self.ensure_no_symlinks_below_root(&target)?;
+        if self.metadata_if_exists(&target)?.is_none() {
+            return Err(Error::NotFound(target));
+        }
+        self.read_file_prefix(&target, max_bytes)
+    }
+
+    fn remove(&self, path: &str) -> Result<(), Error> {
+        let target = self.resolve_path(path)?;
+        self.ensure_no_symlinks_below_root(&target)?;
+        let metadata = self
+            .metadata_if_exists(&target)?
+            .ok_or_else(|| Error::NotFound(target.clone()))?;
+
+        let parent = target.parent().map(Path::to_path_buf);
+        if metadata.is_dir() {
+            fs::remove_dir_all(&target)?;
+        } else {
+            fs::remove_file(&target)?;
+        }
+
+        self.cleanup_empty_parents(parent.as_deref())
+    }
+
+    fn list(&self, path: &str) -> Result<Vec<Entry>, Error> {
+        let target = self.resolve_path(path)?;
+        self.ensure_no_symlinks_below_root(&target)?;
+
+        let Some(metadata) = self.metadata_if_exists(&target)? else {
+            return if path.is_empty() {
+                Ok(vec![])
+            } else {
+                Err(Error::NotFound(target))
+            };
+        };
+        if !metadata.is_dir() {
+            return Err(Error::Parse(format!(
+                "path is not a directory: {}",
+                target.display()
+            )));
+        }
+
+        read_sorted_children(&target).map(|children| {
+            children
+                .into_iter()
+                .map(|child| Entry {
+                    name: child.name,
+                    is_dir: child.is_dir,
+                })
+                .collect()
+        })
+    }
+
+    fn tree(&self) -> Result<TreeNode, Error> {
+        self.ensure_no_symlinks_below_root(&self.root)?;
+        Self::build_tree_node(&self.root, self.root.display().to_string())
+    }
+
+    fn exists(&self, path: &str) -> Result<bool, Error> {
+        let target = self.resolve_path(path)?;
+        self.ensure_no_symlinks_below_root(&target)?;
+        Ok(self.metadata_if_exists(&target)?.is_some())
+    }
+}
+
+fn default_store_root(home: &Path) -> PathBuf {
+    home.join(".stakpak/knowledge")
+}
+
+struct ChildEntry {
+    path: PathBuf,
+    name: String,
+    is_dir: bool,
+}
+
+fn read_sorted_children(path: &Path) -> Result<Vec<ChildEntry>, Error> {
+    let mut children = Vec::new();
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with('.') {
+            continue;
+        }
+
+        let file_type = entry.file_type()?;
+        let child_path = entry.path();
+        if file_type.is_symlink() {
+            return Err(Error::UnsafePath(child_path));
+        }
+
+        children.push(ChildEntry {
+            path: child_path,
+            name,
+            is_dir: file_type.is_dir(),
+        });
+    }
+
+    children.sort_by(compare_entries);
+    Ok(children)
+}
+
+fn compare_entries(left: &ChildEntry, right: &ChildEntry) -> Ordering {
+    match right.is_dir.cmp(&left.is_dir) {
+        Ordering::Equal => left.name.cmp(&right.name),
+        other => other,
+    }
+}
+
+fn is_hidden_path(path: &Path, root: &Path) -> bool {
+    path.strip_prefix(root)
+        .map(|relative| {
+            relative
+                .components()
+                .any(|component| matches!(component, Component::Normal(part) if part.to_string_lossy().starts_with('.')))
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Entry, LocalFsBackend, StorageBackend, TreeNode};
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
+
+    fn backend() -> (tempfile::TempDir, LocalFsBackend) {
+        let temp_dir = tempfile::TempDir::new().expect("temp dir");
+        let backend = LocalFsBackend::with_root(temp_dir.path().join("store"));
+        (temp_dir, backend)
+    }
+
+    #[test]
+    fn create_writes_new_file() {
+        let (_temp_dir, backend) = backend();
+
+        backend
+            .create("knowledge/rate-limits.md", b"1000/min")
+            .expect("create file");
+
+        let content = std::fs::read_to_string(backend.root().join("knowledge/rate-limits.md"))
+            .expect("read file from disk");
+        assert_eq!(content, "1000/min");
+    }
+
+    #[test]
+    fn create_fails_when_file_already_exists() {
+        let (_temp_dir, backend) = backend();
+        backend
+            .create("knowledge/rate-limits.md", b"first")
+            .expect("create initial file");
+
+        let error = backend
+            .create("knowledge/rate-limits.md", b"second")
+            .expect_err("duplicate create should fail");
+
+        assert!(matches!(error, crate::Error::AlreadyExists(_)));
+    }
+
+    #[test]
+    fn overwrite_replaces_existing_content() {
+        let (_temp_dir, backend) = backend();
+        backend
+            .create("summaries/auth.md", b"old")
+            .expect("create initial summary");
+
+        backend
+            .overwrite("summaries/auth.md", b"new")
+            .expect("overwrite file");
+
+        let content = backend
+            .read("summaries/auth.md")
+            .expect("read overwritten file");
+        assert_eq!(content, b"new");
+    }
+
+    #[test]
+    fn read_returns_not_found_for_missing_file() {
+        let (_temp_dir, backend) = backend();
+
+        let error = backend
+            .read("knowledge/missing.md")
+            .expect_err("missing file should fail");
+
+        assert!(matches!(error, crate::Error::NotFound(_)));
+    }
+
+    #[test]
+    fn remove_deletes_file() {
+        let (_temp_dir, backend) = backend();
+        backend
+            .create("knowledge/old.md", b"old")
+            .expect("create file");
+
+        backend.remove("knowledge/old.md").expect("remove file");
+
+        assert!(!backend.root().join("knowledge/old.md").exists());
+    }
+
+    #[test]
+    fn remove_cleans_empty_parent_directories() {
+        let (_temp_dir, backend) = backend();
+        backend
+            .create("deep/nested/only-file.md", b"old")
+            .expect("create nested file");
+
+        backend
+            .remove("deep/nested/only-file.md")
+            .expect("remove nested file");
+
+        assert!(!backend.root().join("deep/nested").exists());
+        assert!(!backend.root().join("deep").exists());
+        assert!(backend.root().exists());
+    }
+
+    #[test]
+    fn list_returns_sorted_entries_without_dotfiles() {
+        let (_temp_dir, backend) = backend();
+        std::fs::create_dir_all(backend.root().join("knowledge/subdir")).expect("create subdir");
+        std::fs::write(backend.root().join("knowledge/z-last.md"), "z").expect("write z file");
+        std::fs::write(backend.root().join("knowledge/a-first.md"), "a").expect("write a file");
+        std::fs::write(backend.root().join("knowledge/.hidden.md"), "h")
+            .expect("write hidden file");
+
+        let entries = backend.list("knowledge").expect("list directory");
+
+        assert_eq!(
+            entries,
+            vec![
+                Entry {
+                    name: "subdir".to_string(),
+                    is_dir: true,
+                },
+                Entry {
+                    name: "a-first.md".to_string(),
+                    is_dir: false,
+                },
+                Entry {
+                    name: "z-last.md".to_string(),
+                    is_dir: false,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn tree_builds_recursive_sorted_structure_without_dotfiles() {
+        let (_temp_dir, backend) = backend();
+        backend
+            .create("knowledge/rate-limits.md", b"1000/min")
+            .expect("create knowledge file");
+        backend
+            .create("entities/auth-service.md", b"OAuth")
+            .expect("create entity file");
+        std::fs::write(backend.root().join(".hidden.md"), "hidden").expect("write hidden file");
+
+        let tree = backend.tree().expect("build tree");
+
+        assert_eq!(
+            tree,
+            TreeNode {
+                name: backend.root().display().to_string(),
+                is_dir: true,
+                children: vec![
+                    TreeNode {
+                        name: "entities".to_string(),
+                        is_dir: true,
+                        children: vec![TreeNode {
+                            name: "auth-service.md".to_string(),
+                            is_dir: false,
+                            children: vec![],
+                        }],
+                    },
+                    TreeNode {
+                        name: "knowledge".to_string(),
+                        is_dir: true,
+                        children: vec![TreeNode {
+                            name: "rate-limits.md".to_string(),
+                            is_dir: false,
+                            children: vec![],
+                        }],
+                    },
+                ],
+            }
+        );
+    }
+
+    #[test]
+    fn tree_node_print_renders_connectors() {
+        let tree = TreeNode {
+            name: "~/.stakpak/knowledge".to_string(),
+            is_dir: true,
+            children: vec![
+                TreeNode {
+                    name: "knowledge".to_string(),
+                    is_dir: true,
+                    children: vec![TreeNode {
+                        name: "rate-limits.md".to_string(),
+                        is_dir: false,
+                        children: vec![],
+                    }],
+                },
+                TreeNode {
+                    name: "notes.md".to_string(),
+                    is_dir: false,
+                    children: vec![],
+                },
+            ],
+        };
+
+        assert_eq!(
+            tree.print(),
+            "~/.stakpak/knowledge\n├── knowledge\n│   └── rate-limits.md\n└── notes.md"
+        );
+    }
+
+    #[test]
+    fn exists_reports_whether_path_exists() {
+        let (_temp_dir, backend) = backend();
+        backend
+            .create("knowledge/rate-limits.md", b"1000/min")
+            .expect("create file");
+
+        assert!(
+            backend
+                .exists("knowledge/rate-limits.md")
+                .expect("existing path check")
+        );
+        assert!(
+            !backend
+                .exists("knowledge/missing.md")
+                .expect("missing path check")
+        );
+    }
+
+    #[test]
+    fn file_count_counts_non_dotfiles_only() {
+        let (_temp_dir, backend) = backend();
+        backend
+            .create("knowledge/rate-limits.md", b"1000/min")
+            .expect("create knowledge file");
+        backend
+            .create("entities/auth-service.md", b"OAuth")
+            .expect("create entity file");
+        std::fs::write(backend.root().join(".hidden.md"), "hidden").expect("write hidden file");
+
+        assert_eq!(backend.file_count().expect("count files"), 2);
+    }
+
+    #[test]
+    fn new_defaults_to_stakpak_knowledge_store() {
+        let home = std::path::Path::new("/tmp/test-home");
+
+        assert_eq!(
+            super::default_store_root(home),
+            home.join(".stakpak/knowledge")
+        );
+    }
+
+    #[test]
+    fn list_root_returns_empty_when_store_does_not_exist() {
+        let temp_dir = tempfile::TempDir::new().expect("temp dir");
+        let backend = LocalFsBackend::with_root(temp_dir.path().join("missing-store"));
+
+        let entries = backend.list("").expect("list missing root");
+
+        assert!(entries.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_rejects_symlinked_file_inside_store() {
+        let (_temp_dir, backend) = backend();
+        let outside = tempfile::NamedTempFile::new().expect("outside temp file");
+        std::fs::write(outside.path(), "secret").expect("write outside file");
+        std::fs::create_dir_all(backend.root()).expect("create store root");
+        symlink(outside.path(), backend.root().join("leak.md")).expect("create symlink");
+
+        let error = backend
+            .read("leak.md")
+            .expect_err("symlink read should fail");
+
+        assert!(matches!(error, crate::Error::UnsafePath(_)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_rejects_symlinked_parent_directory_inside_store() {
+        let (_temp_dir, backend) = backend();
+        let outside = tempfile::TempDir::new().expect("outside temp dir");
+        std::fs::create_dir_all(backend.root()).expect("create store root");
+        symlink(outside.path(), backend.root().join("knowledge")).expect("create symlink dir");
+
+        let error = backend
+            .create("knowledge/pwned.md", b"hello")
+            .expect_err("symlink parent should fail");
+
+        assert!(matches!(error, crate::Error::UnsafePath(_)));
+        assert!(!outside.path().join("pwned.md").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn file_count_returns_error_for_unreadable_directory() {
+        let (_temp_dir, backend) = backend();
+        backend
+            .create("knowledge/readable.md", b"ok")
+            .expect("create readable file");
+        std::fs::create_dir_all(backend.root().join("knowledge/private"))
+            .expect("create private dir");
+
+        let private_dir = backend.root().join("knowledge/private");
+        let original_permissions = std::fs::metadata(&private_dir)
+            .expect("read metadata")
+            .permissions();
+        std::fs::set_permissions(&private_dir, std::fs::Permissions::from_mode(0o0))
+            .expect("remove permissions");
+
+        let result = backend.file_count();
+
+        std::fs::set_permissions(&private_dir, original_permissions).expect("restore permissions");
+        assert!(
+            result.is_err(),
+            "expected unreadable directory to return an error"
+        );
+    }
+}

--- a/libs/api/src/local/hooks/task_board_context/system_prompt.txt
+++ b/libs/api/src/local/hooks/task_board_context/system_prompt.txt
@@ -461,6 +461,91 @@ stakpak autopilot channel add discord --token $DISCORD_BOT_TOKEN
 
 **Remote file operations:** When writing files to remote servers (configs, check scripts, autopilot.toml), use the `create` tool with remote path format (`user@host:/path`) instead of piping content through SSH commands. Same for `str_replace` and `view`. This is cleaner, safer, and doesn't require shell escaping.
 
+# Knowledge Store: `stakpak ak`
+
+You have access to `ak`, a persistent markdown knowledge store that survives across sessions. Think of it as your long-term memory — use it freely to store anything worth remembering and retrieve it whenever relevant.
+
+## Commands
+```bash
+stakpak ak status                    # Show store location and file count
+stakpak ak tree                      # Print full directory tree
+stakpak ak ls [path]                 # List one directory with descriptions
+stakpak ak peek <path>               # Read summary (frontmatter + first paragraph)
+stakpak ak cat <path> [<path>...]    # Read full content (multiple files separated by ---)
+stakpak ak write <path>              # Create new file (reads from stdin)
+stakpak ak write <path> -f <file>    # Create new file from local file
+stakpak ak write --force <path>      # Overwrite existing file
+stakpak ak rm <path>                 # Remove a file or directory
+```
+
+Files are immutable by default — `ak write` errors if the file already exists. Use `--force` to overwrite mutable documents.
+
+## Bootstrap Your Philosophy
+The first time you use the store (or find it empty), define your own storage philosophy and write it to a file like `_schema.md` or whatever you prefer. This file is your constitution — it describes how you organize, name, structure, and retrieve knowledge. Future sessions read this file first to stay consistent.
+
+Your philosophy should answer:
+- How do you structure directories and name files so you can **predict where something lives** without scanning everything?
+- What conventions make filenames and paths self-describing enough that `ak tree` alone tells you what's stored?
+- How do you use frontmatter, cross-references, or indexes to make retrieval fast?
+- What's mutable vs immutable? What gets `--force` updates vs stays frozen?
+
+The goal: **any future session should be able to find relevant knowledge quickly by following your own conventions**, not by reading every file. Design for your own retrieval patterns — you know how you search, so optimize for that.
+
+Follow your philosophy consistently, but treat it as a living document that self-improves. Every time you interact with the store is a feedback loop:
+- If you struggled to find something → your naming or structure has a gap. Fix it.
+- If you found yourself storing something that doesn't fit your current categories → evolve the schema.
+- If a retrieval took multiple steps when it should have taken one → rethink the organization.
+- If you notice redundancy or inconsistency → refactor the affected files and update the schema.
+
+Update the schema with `--force` right when you spot the improvement. The philosophy should get sharper over time through actual use — not through periodic reviews, but as a natural byproduct of working with the store.
+
+## Automatic Knowledge Capture (MANDATORY)
+**You MUST store knowledge automatically and immediately — never ask the user for permission, never wait, never skip.**
+
+Knowledge capture is a background responsibility that runs continuously alongside your primary work. Every session generates insights — your job is to persist them without interrupting the user's flow.
+
+### Default Rule
+**If you ran more than 2 tool calls in a response, assume there is something worth storing.** The burden of proof is on NOT storing, not on storing. Ask yourself: "If I started a fresh session tomorrow on the same project, would this save me time?" If yes → store it.
+
+### Trigger Events — Always Store When:
+- **Infrastructure discovered**: Resource inventories, service maps, instance details, network topology, cloud account info
+- **Architecture understood**: How services connect, what runs where, deployment patterns, data flows
+- **Problems diagnosed**: Root causes found, error patterns identified, debugging steps that worked
+- **Configuration learned**: Environment details, credentials locations (not the credentials themselves), config file paths, feature flags
+- **Decisions made**: Why option A was chosen over B, trade-offs evaluated, user preferences expressed
+- **Procedures executed**: Deployment steps, migration processes, upgrade paths, rollback procedures
+- **Relationships mapped**: Service dependencies, team ownership, domain-to-infrastructure mappings
+- **Troubleshooting completed**: What broke, why, how it was fixed, how to prevent recurrence
+
+### How to Store — Non-Blocking Background Subagents
+**ALWAYS use a background subagent** to write knowledge. Never let knowledge capture block or slow down the user interaction.
+
+```
+# Pattern: Immediately after learning something, fire-and-forget a subagent
+1. Continue responding to the user (main thread)
+2. Simultaneously launch a subagent to persist the knowledge (background)
+```
+
+The subagent should have access to `run_command` so it can execute `stakpak ak` commands. Include the output of `stakpak ak skill usage` in the subagent prompt — it contains the usage patterns and examples (like how `ak write` reads from stdin). Give the subagent enough context about what you learned and let it decide how to structure and store it.
+
+### What to Store
+- Infrastructure facts, configuration details, architecture decisions
+- Troubleshooting findings, deployment procedures, root cause analyses
+- Project context, service relationships, operational patterns
+- User preferences, environment-specific quirks, team conventions
+- Anything non-obvious that took effort to learn
+
+### What to NEVER Store
+- Secrets, credentials, tokens, API keys, passwords
+- Raw unprocessed command output dumps (synthesize first)
+- Trivial or ephemeral information (typos, one-off commands)
+
+### Updating Existing Knowledge
+When new information contradicts or supersedes existing knowledge, update or replace it immediately (use `--force`). When a discovery touches multiple topics, update all relevant files — a single finding might ripple across several knowledge entries. The store should reflect your current best understanding, not a frozen snapshot.
+
+## Retrieve Before You Work
+Before diving into a task, check what you already know. Start with your schema file to remember your conventions, then navigate accordingly. Use `peek` for quick relevance checks, `cat` when you need the full picture. Your past self may have already done the hard work.
+
 # Task Success Criteria
 1. Problem is thoroughly analyzed and understood.
 2. Solution is architected with proper consideration of trade-offs.
@@ -541,6 +626,17 @@ stakpak autopilot channel add discord --token $DISCORD_BOT_TOKEN
 - Use standard GitHub-style markdown
 - Functional symbols OK (✓✗⚠) but avoid decorative emojis
 - Keep responses brief for terminal display
+
+# Pre-Response Knowledge Check (MANDATORY)
+**Before finishing ANY response that involved tool calls, commands, or investigation, you MUST complete this checklist:**
+
+1. **Scan your response**: Did you discover, diagnose, configure, or learn anything non-trivial?
+2. **If yes**: Have you already launched a background subagent to store it? If not, **launch one NOW before responding**.
+3. **If unsure**: Default to storing. A redundant write is cheap; lost knowledge is expensive.
+
+**This is not optional.** Skipping this check is equivalent to forgetting to save your work. If you catch yourself about to respond without storing discovered knowledge, STOP and launch the subagent first.
+
+Failure mode to avoid: "I'll store it later" — there is no later. Each response is potentially your last in this session.
 
 # Post Finishing a Task
 Ask the user for next steps using bullet points. Suggestions may include:


### PR DESCRIPTION
## Description
Adds a local persistent knowledge store to the CLI via `stakpak ak`.

## Changes Made
- add the new `stakpak-ak` workspace crate for filesystem-backed knowledge storage
- wire `stakpak ak` into the CLI with commands for tree/list/peek/cat/write/remove/status/skill
- document AK usage in the default system prompt and CLI help text
- add unit/integration coverage, including `ak status` bootstrapping behavior on a clean home directory

## Testing
- [x] `cargo fmt --check -- cli/src/commands/ak/mod.rs cli/src/commands/mod.rs cli/src/main.rs cli/tests/ak_cli.rs libs/ak/src/error.rs libs/ak/src/format.rs libs/ak/src/lib.rs libs/ak/src/search.rs libs/ak/src/skills.rs libs/ak/src/store.rs`
- [x] `cargo clippy -p stakpak-ak --all-targets -- -D warnings`
- [x] `cargo clippy -p stakpak --test ak_cli -- -D warnings`
- [x] `cargo test -p stakpak --test ak_cli -- --nocapture`

## Breaking Changes
None
