### PR TITLE
chore: bump Rust toolchain references to 1.94.1

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -57,7 +57,7 @@ jobs:
             target: aarch64-unknown-linux-musl
             artifact_name: stakpak-linux-aarch64
             features: --features jemalloc
-            docker: rust:1.91-alpine3.21
+            docker: rust:1.94-alpine3.21
           - os: macos-15
             target: x86_64-apple-darwin
             artifact_name: stakpak-darwin-x86_64
@@ -75,7 +75,7 @@ jobs:
 
       - name: Install Rust
         if: ${{ !matrix.docker }}
-        uses: dtolnay/rust-toolchain@1.91.0
+        uses: dtolnay/rust-toolchain@1.94.1
         with:
           targets: ${{ matrix.target }}
 
@@ -208,7 +208,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.91.0
+        uses: dtolnay/rust-toolchain@1.94.1
 
       - name: Extract version from tag
         id: get_version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.91.0"
+          toolchain: "1.94.1"
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ Content creators will be featured on our social media and newsletter.
 
 ### Prerequisites
 
-- **Rust 1.91.0 or later** - Install from [rustup.rs](https://rustup.rs/)
+- **Rust 1.94.1 or later** - Install from [rustup.rs](https://rustup.rs/)
 - **Git** - For version control
 - **Cargo** - Comes with Rust
 - **OpenSSL development libraries** (Linux only):

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@
 #
 # =============================================================================
 
-FROM rust:1.91.0-slim-bookworm AS builder
+FROM rust:1.94.1-slim-bookworm AS builder
 RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
 WORKDIR /usr/src/app
 COPY . .

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.91.0"
+channel = "1.94.1"


### PR DESCRIPTION
## Description
- update the pinned Rust toolchain to 1.94.1 in `rust-toolchain.toml`
- align GitHub Actions and release Docker images with the same Rust version
- refresh contributor docs to match the new minimum Rust version

## Why
Keep local development, CI, release builds, and contributor guidance on the same supported Rust version.

## Testing
- YAML parse check for `.github/workflows/build-and-release.yml`
- YAML parse check for `.github/workflows/ci.yml`
- TOML parse check for `rust-toolchain.toml`