### PR TITLE
fix(config): tighten stakpak shell auto-approve allowlist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6275,7 +6275,7 @@ dependencies = [
 
 [[package]]
 name = "stakpak-mcp-config"
-version = "0.3.72"
+version = "0.3.74"
 dependencies = [
  "serde",
  "serde_json",

--- a/libs/shell-tool-approvals/src/resolver.rs
+++ b/libs/shell-tool-approvals/src/resolver.rs
@@ -53,8 +53,15 @@ fn resolve_command_in_scope<T: Clone + Ord>(
 
     let arg_prefix = format!("{scope}::{name}::");
     let arg_match = rules.iter().filter_map(|(key, action)| {
-        let pattern = key.strip_prefix(&arg_prefix)?;
-        let matched = cmd.args.iter().any(|arg| matches_pattern(pattern, arg));
+        let remainder = key.strip_prefix(&arg_prefix)?;
+        let segments: Vec<&str> = remainder.split("::").collect();
+        if segments.len() > cmd.args.len() {
+            return None;
+        }
+        let matched = segments
+            .iter()
+            .zip(cmd.args.iter())
+            .all(|(segment, arg)| matches_pattern(segment, arg));
         matched.then_some(action.clone())
     });
 
@@ -88,6 +95,128 @@ mod tests {
 
         let resolved =
             resolve_hierarchical_policy("git status", "run_command", &[], &rules, Action::Ask);
+
+        assert_eq!(resolved, Ok(Some(Action::Approve)));
+    }
+
+    #[test]
+    fn arg_single_segment_matches_args_first() {
+        let mut rules = HashMap::new();
+        rules.insert("run_command::git::status".to_string(), Action::Approve);
+
+        let resolved =
+            resolve_hierarchical_policy("git status", "run_command", &[], &rules, Action::Ask);
+
+        assert_eq!(resolved, Ok(Some(Action::Approve)));
+    }
+
+    #[test]
+    fn arg_single_segment_does_not_match_later_positions() {
+        let mut rules = HashMap::new();
+        rules.insert("run_command::stakpak::ak".to_string(), Action::Approve);
+
+        let resolved = resolve_hierarchical_policy(
+            "stakpak browser ak visit example.com",
+            "run_command",
+            &[],
+            &rules,
+            Action::Ask,
+        );
+
+        assert_eq!(resolved, Ok(Some(Action::Ask)));
+    }
+
+    #[test]
+    fn arg_multi_segment_matches_exact_path() {
+        let mut rules = HashMap::new();
+        rules.insert(
+            "run_command::stakpak::config::show".to_string(),
+            Action::Approve,
+        );
+
+        let resolved = resolve_hierarchical_policy(
+            "stakpak config show",
+            "run_command",
+            &[],
+            &rules,
+            Action::Ask,
+        );
+
+        assert_eq!(resolved, Ok(Some(Action::Approve)));
+    }
+
+    #[test]
+    fn arg_multi_segment_does_not_match_short_command() {
+        let mut rules = HashMap::new();
+        rules.insert(
+            "run_command::stakpak::config::show".to_string(),
+            Action::Approve,
+        );
+
+        let resolved =
+            resolve_hierarchical_policy("stakpak config", "run_command", &[], &rules, Action::Ask);
+
+        assert_eq!(resolved, Ok(Some(Action::Ask)));
+    }
+
+    #[test]
+    fn arg_multi_segment_does_not_match_different_middle() {
+        let mut rules = HashMap::new();
+        rules.insert(
+            "run_command::stakpak::config::show".to_string(),
+            Action::Approve,
+        );
+
+        let resolved = resolve_hierarchical_policy(
+            "stakpak config list",
+            "run_command",
+            &[],
+            &rules,
+            Action::Ask,
+        );
+
+        assert_eq!(resolved, Ok(Some(Action::Ask)));
+    }
+
+    #[test]
+    fn arg_namespace_rule_matches_trailing_args() {
+        let mut rules = HashMap::new();
+        rules.insert("run_command::stakpak::ak".to_string(), Action::Approve);
+
+        let resolved = resolve_hierarchical_policy(
+            "stakpak ak write notes.md",
+            "run_command",
+            &[],
+            &rules,
+            Action::Ask,
+        );
+
+        assert_eq!(resolved, Ok(Some(Action::Approve)));
+    }
+
+    #[test]
+    fn arg_namespace_and_sub_rule_both_match_most_restrictive_wins() {
+        let mut rules = HashMap::new();
+        rules.insert("run_command::stakpak::ak".to_string(), Action::Approve);
+        rules.insert("run_command::stakpak::ak::write".to_string(), Action::Ask);
+
+        let resolved = resolve_hierarchical_policy(
+            "stakpak ak write notes.md",
+            "run_command",
+            &[],
+            &rules,
+            Action::Deny,
+        );
+
+        assert_eq!(resolved, Ok(Some(Action::Ask)));
+    }
+
+    #[test]
+    fn arg_empty_args_command_falls_through_to_command_level() {
+        let mut rules = HashMap::new();
+        rules.insert("run_command::ls".to_string(), Action::Approve);
+
+        let resolved = resolve_hierarchical_policy("ls", "run_command", &[], &rules, Action::Ask);
 
         assert_eq!(resolved, Ok(Some(Action::Approve)));
     }

--- a/tui/src/services/auto_approve.rs
+++ b/tui/src/services/auto_approve.rs
@@ -694,6 +694,18 @@ mod tests {
     }
 
     #[test]
+    fn resolve_shell_scope_plugin_escape_hatch_no_longer_bypassable() {
+        let mut rules = HashMap::new();
+        rules.insert(
+            "run_command::stakpak::ak".to_string(),
+            AutoApprovePolicy::Auto,
+        );
+        let tc = make_run_command_tool_call("stakpak browser ak visit example.com");
+        let result = resolve_shell_scope(&tc, &rules, &AutoApprovePolicy::Prompt);
+        assert_eq!(result, Some(AutoApprovePolicy::Prompt));
+    }
+
+    #[test]
     fn resolve_shell_scope_run_command_task_rule_overrides_shared_scope() {
         let mut rules = HashMap::new();
         rules.insert("run_command_task".to_string(), AutoApprovePolicy::Never);

--- a/tui/src/services/auto_approve.rs
+++ b/tui/src/services/auto_approve.rs
@@ -57,6 +57,34 @@ impl Default for AutoApproveConfig {
         tools.insert("get_all_tasks".to_string(), AutoApprovePolicy::Auto);
         tools.insert("get_task_details".to_string(), AutoApprovePolicy::Auto);
         tools.insert("wait_for_tasks".to_string(), AutoApprovePolicy::Auto);
+        tools.insert(
+            "run_command::stakpak::version".to_string(),
+            AutoApprovePolicy::Auto,
+        );
+        tools.insert(
+            "run_command::stakpak::account".to_string(),
+            AutoApprovePolicy::Auto,
+        );
+        tools.insert(
+            "run_command::stakpak::completion".to_string(),
+            AutoApprovePolicy::Auto,
+        );
+        tools.insert(
+            "run_command::stakpak::ak".to_string(),
+            AutoApprovePolicy::Auto,
+        );
+        tools.insert(
+            "run_command::stakpak::sessions".to_string(),
+            AutoApprovePolicy::Auto,
+        );
+        tools.insert(
+            "run_command::stakpak::config::show".to_string(),
+            AutoApprovePolicy::Auto,
+        );
+        tools.insert(
+            "run_command::stakpak::config::sample".to_string(),
+            AutoApprovePolicy::Auto,
+        );
 
         // Prompt tools (always require confirmation):
         tools.insert("create".to_string(), AutoApprovePolicy::Prompt);
@@ -414,12 +442,17 @@ fn resolve_shell_scope(
     } else {
         Vec::new()
     };
+    let mut effective_rules = rules.clone();
+
+    if !fallback_scopes.is_empty() && effective_rules.get(tool_name) == Some(default) {
+        effective_rules.remove(tool_name);
+    }
 
     match stakpak_shell_tool_approvals::resolve_hierarchical_policy(
         command_str,
         tool_name,
         &fallback_scopes,
-        rules,
+        &effective_rules,
         default.clone(),
     ) {
         Ok(action) => action,
@@ -605,6 +638,33 @@ mod tests {
     }
 
     #[test]
+    fn default_config_includes_stakpak_allowlist_entries() {
+        let config = AutoApproveConfig::default();
+
+        for key in [
+            "run_command::stakpak::version",
+            "run_command::stakpak::account",
+            "run_command::stakpak::completion",
+            "run_command::stakpak::ak",
+            "run_command::stakpak::sessions",
+            "run_command::stakpak::config::show",
+            "run_command::stakpak::config::sample",
+        ] {
+            assert_eq!(
+                config.tools.get(key),
+                Some(&AutoApprovePolicy::Auto),
+                "missing or incorrect policy for {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn default_config_does_not_include_stakpak_scope_level_entry() {
+        let config = AutoApproveConfig::default();
+        assert_eq!(config.tools.get("run_command::stakpak"), None);
+    }
+
+    #[test]
     fn resolve_shell_scope_command_level_auto() {
         let mut rules = HashMap::new();
         rules.insert("run_command::git".to_string(), AutoApprovePolicy::Auto);
@@ -694,14 +754,58 @@ mod tests {
     }
 
     #[test]
-    fn resolve_shell_scope_plugin_escape_hatch_no_longer_bypassable() {
-        let mut rules = HashMap::new();
-        rules.insert(
-            "run_command::stakpak::ak".to_string(),
-            AutoApprovePolicy::Auto,
-        );
+    fn resolve_shell_scope_stakpak_version_auto_approved() {
+        let config = AutoApproveConfig::default();
+        let tc = make_run_command_tool_call("stakpak version");
+        let result = resolve_shell_scope(&tc, &config.tools, &config.default_policy);
+        assert_eq!(result, Some(AutoApprovePolicy::Auto));
+    }
+
+    #[test]
+    fn resolve_shell_scope_stakpak_ak_namespace_matches_trailing_args() {
+        let config = AutoApproveConfig::default();
+        let tc = make_run_command_tool_call("stakpak ak write notes.md");
+        let result = resolve_shell_scope(&tc, &config.tools, &config.default_policy);
+        assert_eq!(result, Some(AutoApprovePolicy::Auto));
+    }
+
+    #[test]
+    fn resolve_shell_scope_stakpak_config_show_two_segment_match() {
+        let config = AutoApproveConfig::default();
+        let tc = make_run_command_tool_call("stakpak config show");
+        let result = resolve_shell_scope(&tc, &config.tools, &config.default_policy);
+        assert_eq!(result, Some(AutoApprovePolicy::Auto));
+    }
+
+    #[test]
+    fn resolve_shell_scope_stakpak_config_list_still_prompts() {
+        let config = AutoApproveConfig::default();
+        let tc = make_run_command_tool_call("stakpak config list");
+        let result = resolve_shell_scope(&tc, &config.tools, &config.default_policy);
+        assert_eq!(result, Some(AutoApprovePolicy::Prompt));
+    }
+
+    #[test]
+    fn resolve_shell_scope_stakpak_update_still_prompts() {
+        let config = AutoApproveConfig::default();
+        let tc = make_run_command_tool_call("stakpak update");
+        let result = resolve_shell_scope(&tc, &config.tools, &config.default_policy);
+        assert_eq!(result, Some(AutoApprovePolicy::Prompt));
+    }
+
+    #[test]
+    fn resolve_shell_scope_stakpak_bare_still_prompts() {
+        let config = AutoApproveConfig::default();
+        let tc = make_run_command_tool_call("stakpak");
+        let result = resolve_shell_scope(&tc, &config.tools, &config.default_policy);
+        assert_eq!(result, Some(AutoApprovePolicy::Prompt));
+    }
+
+    #[test]
+    fn resolve_shell_scope_stakpak_browser_does_not_bypass_ak_allowlist() {
+        let config = AutoApproveConfig::default();
         let tc = make_run_command_tool_call("stakpak browser ak visit example.com");
-        let result = resolve_shell_scope(&tc, &rules, &AutoApprovePolicy::Prompt);
+        let result = resolve_shell_scope(&tc, &config.tools, &config.default_policy);
         assert_eq!(result, Some(AutoApprovePolicy::Prompt));
     }
 
@@ -722,6 +826,80 @@ mod tests {
         let tc = make_tool_call("run_command_task", "git status");
         let result = resolve_shell_scope(&tc, &rules, &AutoApprovePolicy::Prompt);
         assert_eq!(result, Some(AutoApprovePolicy::Auto));
+    }
+
+    #[test]
+    fn resolve_shell_scope_run_command_task_inherits_stakpak_ak_allowlist() {
+        let config = AutoApproveConfig::default();
+        let tc = make_tool_call("run_command_task", "stakpak ak tree");
+        let result = resolve_shell_scope(&tc, &config.tools, &config.default_policy);
+        assert_eq!(result, Some(AutoApprovePolicy::Auto));
+    }
+
+    #[test]
+    fn resolve_shell_scope_user_override_prompt_wins_over_allowlist() {
+        let mut config = AutoApproveConfig::default();
+        config.tools.insert(
+            "run_command::stakpak::ak".to_string(),
+            AutoApprovePolicy::Prompt,
+        );
+
+        let tc = make_run_command_tool_call("stakpak ak tree");
+        let result = resolve_shell_scope(&tc, &config.tools, &config.default_policy);
+        assert_eq!(result, Some(AutoApprovePolicy::Prompt));
+    }
+
+    #[test]
+    fn resolve_shell_scope_user_subrule_tightens_namespace_default() {
+        let mut config = AutoApproveConfig::default();
+        config.tools.insert(
+            "run_command::stakpak::ak::write".to_string(),
+            AutoApprovePolicy::Prompt,
+        );
+
+        let write_tc = make_run_command_tool_call("stakpak ak write notes.md");
+        let write_result = resolve_shell_scope(&write_tc, &config.tools, &config.default_policy);
+        assert_eq!(write_result, Some(AutoApprovePolicy::Prompt));
+
+        let tree_tc = make_run_command_tool_call("stakpak ak tree");
+        let tree_result = resolve_shell_scope(&tree_tc, &config.tools, &config.default_policy);
+        assert_eq!(tree_result, Some(AutoApprovePolicy::Auto));
+    }
+
+    #[test]
+    fn should_auto_approve_stakpak_ak_tree_with_fresh_defaults() {
+        let manager = AutoApproveManager {
+            config: AutoApproveConfig::default(),
+            config_path: PathBuf::from(AUTO_APPROVE_CONFIG_PATH),
+            input_tx: None,
+        };
+        let tc = make_run_command_tool_call("stakpak ak tree");
+
+        assert!(manager.should_auto_approve(&tc));
+    }
+
+    #[test]
+    fn should_not_auto_approve_stakpak_update_with_fresh_defaults() {
+        let manager = AutoApproveManager {
+            config: AutoApproveConfig::default(),
+            config_path: PathBuf::from(AUTO_APPROVE_CONFIG_PATH),
+            input_tx: None,
+        };
+        let tc = make_run_command_tool_call("stakpak update");
+
+        assert!(!manager.should_auto_approve(&tc));
+    }
+
+    #[test]
+    fn should_not_auto_approve_stakpak_browser_ak_visit_with_fresh_defaults() {
+        let manager = AutoApproveManager {
+            config: AutoApproveConfig::default(),
+            config_path: PathBuf::from(AUTO_APPROVE_CONFIG_PATH),
+            input_tx: None,
+        };
+        let tc = make_run_command_tool_call("stakpak browser ak visit example.com");
+
+        assert!(!manager.should_auto_approve(&tc));
     }
 
     #[test]


### PR DESCRIPTION
## Description
Tighten the auto-approve config behavior for `stakpak` shell commands so only explicitly allowlisted subcommands auto-approve, while broader or unrelated command paths still prompt.

## Related Issues
None.

## Changes Made
- add default auto-approve config entries for safe `stakpak` command paths
- adjust shell scope fallback handling so generic tool defaults do not bypass more specific command matching
- add regression coverage for allowlisted commands, rejected variants, inheritance, and user overrides

## Testing
- [x] Ran `cargo fmt --all --check -- tui/src/services/auto_approve.rs`
- [ ] Ran `cargo clippy --all-targets -- -D warnings`
  - blocked by existing unrelated clippy errors in `tui/src/services/board_tasks.rs`, `tui/src/services/detect_term.rs`, `tui/src/services/markdown_renderer.rs`, and `tui/src/services/textarea.rs`
- [x] Added tests for new functionality
- [x] Tested on macOS

## Screenshots (if applicable)
None.

## Breaking Changes
None.
