### PR TITLE
feat(ak): add retrospect skill prompt

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -154,6 +154,16 @@ stakpak autopilot schedule add health-check \
 `check` script paths support `~`, which resolves against the HOME of the user running autopilot.
 For systemd/launchd/container deployments, prefer absolute paths (for example, `/home/ec2-user/.stakpak/checks/endpoints.sh`).
 
+### Example: nightly retrospect
+
+`stakpak ak skill retrospect` prints a prompt that walks the agent through turning past `stakpak sessions` into durable entries in the `ak` store. Schedule it nightly so knowledge accumulates without manual effort:
+
+```bash
+stakpak autopilot schedule add --name retrospect --cron "0 3 * * *" --prompt "$(stakpak ak skill retrospect)"
+```
+
+Each retrospect run processes candidate sessions newest-first and cites its sources in frontmatter. Idempotency falls out of those citations: sessions already cited are skipped on subsequent runs, so the schedule is safe to re-trigger and scale-insensitive to how many sessions have accumulated. See `stakpak ak skill retrospect` for the full workflow.
+
 ### Add channels with profile
 
 ```bash

--- a/cli/src/commands/ak/mod.rs
+++ b/cli/src/commands/ak/mod.rs
@@ -1,6 +1,6 @@
 use clap::Subcommand;
 use stakpak_ak::search::SearchEngine;
-use stakpak_ak::skills::{SKILL_MAINTAIN, SKILL_USAGE};
+use stakpak_ak::skills::{SKILL_MAINTAIN, SKILL_RETROSPECT, SKILL_USAGE};
 use stakpak_ak::{LocalFsBackend, StorageBackend, TreeNavEngine};
 use std::io::Read;
 use std::path::PathBuf;
@@ -141,10 +141,10 @@ This reflects the default root (~/.stakpak/knowledge) unless AK_STORE is set."
         about = "Print one of the built-in ak skill prompts",
         long_about = "Print one of the built-in behavior prompts for `ak`.
 
-Use `usage` to teach an agent how to navigate and write to the store. Use `maintain` to teach an agent how to audit, deduplicate, and clean up stored knowledge."
+Use `usage` to teach an agent how to navigate and write to the store. Use `maintain` to teach an agent how to audit, deduplicate, and clean up stored knowledge. Use `retrospect` to teach an agent how to turn past sessions into durable entries in the store (pipe its output into `stakpak autopilot schedule add --prompt ...` to run it on cron)."
     )]
     Skill {
-        /// Built-in skill name: usage or maintain
+        /// Built-in skill name: usage, maintain, or retrospect
         name: String,
     },
 }
@@ -216,9 +216,10 @@ impl AkCommands {
             Self::Skill { name } => match name.as_str() {
                 "usage" => println!("{SKILL_USAGE}"),
                 "maintain" => println!("{SKILL_MAINTAIN}"),
+                "retrospect" => println!("{SKILL_RETROSPECT}"),
                 other => {
                     return Err(format!(
-                        "invalid skill: {other}. valid values: usage, maintain"
+                        "invalid skill: {other}. valid values: usage, maintain, retrospect"
                     ));
                 }
             },
@@ -283,6 +284,8 @@ mod tests {
         .expect_err("unknown skill should fail");
 
         assert!(error.contains("invalid skill"));
-        assert!(error.contains("valid values: usage, maintain"));
+        assert!(error.contains("usage"));
+        assert!(error.contains("maintain"));
+        assert!(error.contains("retrospect"));
     }
 }

--- a/cli/tests/ak_cli.rs
+++ b/cli/tests/ak_cli.rs
@@ -1,5 +1,58 @@
 use std::process::Command;
 
+const RETROSPECT_MARKDOWN: &str = include_str!("../../libs/ak/src/skills/retrospect.v1.md");
+
+const AUTOPILOT_ONE_LINER: &str = r#"stakpak autopilot schedule add --name retrospect --cron "0 3 * * *" --prompt "$(stakpak ak skill retrospect)""#;
+
+#[test]
+fn ak_skill_retrospect_prints_bundled_prompt() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let home = temp_dir.path();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_stakpak"))
+        .arg("ak")
+        .arg("skill")
+        .arg("retrospect")
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env_remove("STAKPAK_PROFILE")
+        .output()
+        .expect("run stakpak ak skill retrospect");
+
+    assert!(
+        output.status.success(),
+        "ak skill retrospect failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout is utf8");
+    // `println!` appends a trailing newline after the content; the bundled
+    // file may or may not end with one, so compare on a trim-end basis.
+    assert_eq!(
+        stdout.trim_end_matches('\n'),
+        RETROSPECT_MARKDOWN.trim_end_matches('\n'),
+        "stakpak ak skill retrospect output does not match bundled retrospect.v1.md"
+    );
+}
+
+#[test]
+fn readme_autopilot_one_liner_matches_retrospect_prompt() {
+    // Prevent drift between the autopilot docs and the one-liner embedded
+    // in the skill prompt itself.
+    assert!(
+        RETROSPECT_MARKDOWN.contains(AUTOPILOT_ONE_LINER),
+        "bundled retrospect.v1.md must contain the canonical autopilot one-liner"
+    );
+
+    let root_readme = include_str!("../../README.md");
+    let cli_readme = include_str!("../README.md");
+    assert!(
+        root_readme.contains(AUTOPILOT_ONE_LINER) || cli_readme.contains(AUTOPILOT_ONE_LINER),
+        "the canonical `autopilot schedule add` one-liner must appear in the autopilot docs (README.md or cli/README.md) so the docs and SKILL_RETROSPECT stay in sync"
+    );
+}
+
 #[test]
 fn ak_status_bootstraps_default_config_on_clean_home() {
     let temp_dir = tempfile::TempDir::new().expect("temp dir");

--- a/libs/ak/src/skills.rs
+++ b/libs/ak/src/skills.rs
@@ -17,7 +17,40 @@ Organize however you want — directories, naming conventions,
 frontmatter, cross-references. There are no rules.
 
 If you synthesize an answer from multiple files, consider
-writing the synthesis back as new knowledge."#;
+writing the synthesis back as new knowledge.
+
+Source-citation convention
+--------------------------
+When an entry is derived from a specific source (a session, a file
+read, a command output, or another identified resource), cite the
+source in YAML frontmatter under `sources:`. Each row carries three
+required fields — `session` (UUID), `checkpoint` (UUID), and
+`captured_at` (date in `YYYY-MM-DD` form) — plus an optional
+`message_range` field reserved for entries pinned to specific turns
+of a long session.
+
+```yaml
+---
+description: Short sentence describing the entry.
+sources:
+  - session: 550e8400-e29b-41d4-a716-446655440000
+    checkpoint: 6ba7b810-9dad-11d1-80b4-00c04fd430c8
+    captured_at: 2026-04-24
+    # message_range: "14-27"   # optional; only when pinned to turns
+---
+```
+
+If a later source supports an entry that already exists, append a new
+row to that file's existing `sources:` list and use `ak write --force`
+to save the update. Do not write a second file for content that
+belongs in an existing entry.
+
+Citations are both the audit trail for every evidence-derived entry
+and the idempotency anchor future retrospection scans to decide what
+has already been processed. They are not optional on evidence-derived
+writes."#;
+
+pub const SKILL_RETROSPECT: &str = include_str!("skills/retrospect.v1.md");
 
 pub const SKILL_MAINTAIN: &str = r#"Review your knowledge store for quality and accuracy.
 
@@ -33,3 +66,97 @@ pub const SKILL_MAINTAIN: &str = r#"Review your knowledge store for quality and 
 3. Use `ak write`, `ak write --force`, and `ak rm` to fix what
    you find.
 4. Summarize what you changed and why."#;
+
+#[cfg(test)]
+mod tests {
+    use super::{SKILL_RETROSPECT, SKILL_USAGE};
+
+    const AUTOPILOT_ONE_LINER: &str = r#"stakpak autopilot schedule add --name retrospect --cron "0 3 * * *" --prompt "$(stakpak ak skill retrospect)""#;
+
+    #[test]
+    fn retrospect_skill_matches_bundled_markdown() {
+        // Golden-file: the constant must be exactly the bundled file byte-for-byte.
+        // If someone wraps `include_str!` with `.trim()` / `.replace(...)` / etc.,
+        // this test will fail.
+        let bundled = include_str!("skills/retrospect.v1.md");
+        assert_eq!(
+            SKILL_RETROSPECT, bundled,
+            "SKILL_RETROSPECT must match bundled retrospect.v1.md byte-for-byte"
+        );
+        assert!(
+            SKILL_RETROSPECT.starts_with("You are running retrospection:"),
+            "SKILL_RETROSPECT appears to have been trimmed or mutated at its head"
+        );
+        assert!(
+            SKILL_RETROSPECT.trim_end().ends_with(
+                r#"stakpak autopilot schedule add --name retrospect --cron "0 3 * * *" --prompt "$(stakpak ak skill retrospect)""#
+            ),
+            "SKILL_RETROSPECT appears to have been trimmed or mutated at its tail"
+        );
+    }
+
+    #[test]
+    fn retrospect_skill_contains_required_substrings() {
+        for needle in [
+            "stakpak ak skill usage",
+            "stakpak ak skill maintain",
+            "stakpak sessions list --json",
+            "stakpak sessions show",
+            "sources:",
+            "session:",
+            "checkpoint:",
+            "captured_at:",
+            "write --force",
+            "newest-first",
+            AUTOPILOT_ONE_LINER,
+        ] {
+            assert!(
+                SKILL_RETROSPECT.contains(needle),
+                "SKILL_RETROSPECT is missing required substring: {needle:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn retrospect_skill_has_no_forbidden_substrings() {
+        // Hard-forbidden markers of a pinned retrospect-owned layout.
+        for needle in ["retrospect/<", "patterns/<", "_index.md"] {
+            assert!(
+                !SKILL_RETROSPECT.contains(needle),
+                "SKILL_RETROSPECT contains forbidden substring: {needle:?}"
+            );
+        }
+        // Antipattern check: an enumerated numbered list of "things worth
+        // writing" (decisions / failure modes / verified facts / ...) would
+        // pre-enumerate content categories instead of deferring to ak. The
+        // prompt must explicitly tell the agent NOT to follow a fixed
+        // taxonomy and must point the agent at existing ak entries as the
+        // live reference for what qualifies.
+        assert!(
+            SKILL_RETROSPECT.contains("fixed taxonomy"),
+            "SKILL_RETROSPECT must reject a fixed taxonomy for 'worth extracting'"
+        );
+        assert!(
+            SKILL_RETROSPECT.contains("existing `ak` entries"),
+            "SKILL_RETROSPECT must point the agent at existing ak entries as its reference"
+        );
+    }
+
+    #[test]
+    fn usage_skill_contains_citation_convention() {
+        for needle in [
+            "sources:",
+            "session",
+            "checkpoint",
+            "captured_at",
+            "message_range",
+            "audit trail",
+            "idempotency",
+        ] {
+            assert!(
+                SKILL_USAGE.contains(needle),
+                "SKILL_USAGE is missing required citation-convention substring: {needle:?}"
+            );
+        }
+    }
+}

--- a/libs/ak/src/skills/retrospect.v1.md
+++ b/libs/ak/src/skills/retrospect.v1.md
@@ -1,0 +1,130 @@
+You are running retrospection: turn recent `stakpak sessions` into
+durable entries in the current `ak` store. The goal is long-term,
+auditable agent knowledge — not a log, not a digest.
+
+`ak` owns every convention you follow here: layout, what counts as
+long-term, how evidence is cited, when cleanup runs. This prompt is a
+thin orchestrator over those conventions. If anything below conflicts
+with what `stakpak ak skill usage` says, `ak skill usage` wins.
+
+## Step 1 — internalize ak's conventions
+
+Run `stakpak ak skill usage` and read it end-to-end, including the
+source-citation rules (frontmatter `sources:` list, required `session:`
+/ `checkpoint:` / `captured_at:` fields, the append-don't-duplicate
+rule, `write --force` for updates).
+
+## Step 2 — orient in the store
+
+Run `stakpak ak tree` to see the full structure. Then use
+`stakpak ak peek` on likely containers — any `_schema.md`, project
+roots, top-level indexes — to understand what is already known, how it
+is organized, and which sessions are already cited. Collect the set of
+every `session:` UUID that appears in any existing entry's frontmatter
+`sources:` list; that set is your "already processed" reference for
+this run.
+
+Use `stakpak ak cat` when `peek` is not enough to judge whether a
+specific existing entry already covers a topic you are about to touch.
+
+## Step 3 — list candidate sessions
+
+Run `stakpak sessions list --json`, paginating until you have the
+recent window you intend to cover in this run. For each candidate,
+keep `id`, `title`, `message_count`, `status`, `cwd`, and
+`updated_at`.
+
+Process candidates newest-first. Budget exhaustion (schedule timeout,
+max-step caps, context pressure) is expected on large stores; newest-
+first biases the run toward the most recent signal, and the citation
+convention guarantees the next retrospection picks up the remainder
+without rework.
+
+## Step 4 — triage
+
+Drop any session whose active checkpoint is already in the cited-session
+set from Step 2. For the remainder, open a session only when both of
+these hold:
+
+- its `title` plausibly describes substantive technical work, and
+- its content is likely to add signal beyond what the store already
+  covers, based on what you saw in Step 2.
+
+Soft floor: sessions with fewer than about 4 messages rarely carry
+durable signal; skip them unless the title is exceptionally specific.
+A `status` of `error` or `failed` is a positive signal — failure modes
+are often exactly what you want to capture — not a reason to filter.
+
+## Step 5 — open and extract
+
+For each session that survives triage, run
+`stakpak sessions show <id> --json` to fetch the full message history.
+Read through it and decide what, if anything, is durable. Do not work
+from a fixed taxonomy for "worth extracting"; use the shape,
+granularity, and subject matter of existing `ak` entries as your live
+reference for what qualifies. When in doubt, one well-cited atomic
+fact beats a vague summary.
+
+Treat each session's `cwd` as organizational context, not a filter.
+Consult the current `ak` schema to decide whether an insight belongs
+under a project-scoped path or a universal one. If `ak` is organized
+per-project, write per-project; if flat, write flat. Do not restrict
+yourself to the current `cwd`.
+
+Never extract secret-shaped content — tokens, passwords, API keys,
+credentials, signed URLs, private keys — even when it appears in tool
+output inside a session. If a durable fact is only meaningful with a
+secret attached, redact the secret or skip the fact.
+
+## Step 6 — write with citations
+
+Every entry you write MUST cite its source(s) per the `ak skill usage`
+convention:
+
+```yaml
+---
+description: Short sentence describing the entry.
+sources:
+  - session: 550e8400-e29b-41d4-a716-446655440000
+    checkpoint: 6ba7b810-9dad-11d1-80b4-00c04fd430c8
+    captured_at: 2026-04-24
+---
+```
+
+If the subject already has a home in `ak`, append a new row to that
+file's existing `sources:` list and use `stakpak ak write --force` to
+save. Do not create a new file for content that belongs in an existing
+entry. Add the optional `message_range` only when the entry is pinned
+to specific turns of a long session.
+
+When newer evidence conflicts with an older cited claim, prefer the
+newer evidence: supersede the older content with
+`stakpak ak write --force`, date the update via the new source's
+`captured_at`, and keep the prior citation in the `sources:` list so
+the trail of how the fact evolved remains intact.
+
+## Step 7 — discipline the store
+
+After you finish writing, run `stakpak ak skill maintain` and apply
+its guidance to the entries you just touched and their neighbors. A
+batch of fresh writes is exactly when consolidation, dedupe, and
+staleness-pruning are cheapest.
+
+## Step 8 — report
+
+Print a terse plain-text summary at the end of the run:
+
+- how many sessions were listed, triaged, opened, and skipped, plus
+  the dominant skip reason (already cited, too short, off-topic);
+- how many `ak` entries were created vs. updated, grouped by top-level
+  path;
+- any conflicts you surfaced for the user to adjudicate.
+
+Density beats prose — this lands in autopilot run logs on scheduled
+runs.
+
+---
+
+Schedule this skill via the canonical one-liner:
+
+    stakpak autopilot schedule add --name retrospect --cron "0 3 * * *" --prompt "$(stakpak ak skill retrospect)"


### PR DESCRIPTION
## Description
Add a built-in `stakpak ak skill retrospect` prompt so users can schedule nightly retrospection runs that turn past sessions into cited `ak` entries.

## Related Issues
None.

## Changes Made
- add bundled `retrospect.v1.md` and expose it via `SKILL_RETROSPECT`
- update `stakpak ak skill` help/output to support the new `retrospect` option
- document the canonical autopilot schedule one-liner in `cli/README.md`
- add tests to keep the bundled prompt and docs in sync

## Testing
- [x] `cargo fmt --all -- --check cli/src/commands/ak/mod.rs cli/tests/ak_cli.rs libs/ak/src/skills.rs`
- [x] `cargo clippy -p stakpak -p stakpak-ak --all-targets -- -D warnings`
- [ ] `cargo test --workspace`

## Breaking Changes
None.