### PR TITLE
refactor(mcp-server): remove search_memory tool

### DIFF
--- a/cli/src/commands/agent/run/mode_interactive.rs
+++ b/cli/src/commands/agent/run/mode_interactive.rs
@@ -1135,18 +1135,6 @@ pub async fn run_interactive(
                             continue;
                         }
                     }
-                    OutputEvent::Memorize => {
-                        let checkpoint_id = extract_checkpoint_id_from_messages(&messages);
-                        if let Some(checkpoint_id) = checkpoint_id {
-                            let client_clone = client.clone();
-                            tokio::spawn(async move {
-                                if let Ok(checkpoint_id) = Uuid::parse_str(&checkpoint_id) {
-                                    let _ = client_clone.memorize_session(checkpoint_id).await;
-                                }
-                            });
-                        }
-                        continue;
-                    }
                     OutputEvent::RequestProfileSwitch(new_profile) => {
                         // Send progress event
                         send_input_event(

--- a/libs/mcp/server/src/remote_tools.rs
+++ b/libs/mcp/server/src/remote_tools.rs
@@ -1,13 +1,10 @@
 use crate::tool_container::ToolContainer;
-use chrono::{DateTime, Utc};
 use rmcp::{
     ErrorData as McpError, handler::server::wrapper::Parameters, model::*, schemars, tool,
     tool_router,
 };
 use serde::Deserialize;
-use stakpak_api::models::{
-    SearchDocsRequest as ApiSearchDocsRequest, SearchMemoryRequest as ApiSearchMemoryRequest,
-};
+use stakpak_api::models::SearchDocsRequest as ApiSearchDocsRequest;
 use stakpak_shared::utils::{handle_large_output, sanitize_text_output};
 // use stakpak_api::models::CodeIndex;
 // use stakpak_shared::local_store::LocalStore;
@@ -201,35 +198,35 @@ fn search_docs_validation_error_result(error: SearchDocsValidationError) -> Call
     CallToolResult::error(vec![Content::text(code), Content::text(message)])
 }
 
-#[derive(Debug, Deserialize, schemars::JsonSchema)]
-pub struct SearchMemoryRequest {
-    #[schemars(
-        description = "Space-separated keywords to search for in your memory (e.g., 'kubernetes deployment config'). Searches against the title, tags, and content of your memory."
-    )]
-    pub keywords: String,
-    #[schemars(
-        description = "Start time for filtering memories by creation time (inclusive range, ISO 8601 format)"
-    )]
-    pub start_time: Option<DateTime<Utc>>,
-    #[schemars(
-        description = "End time for filtering memories by creation time (inclusive range, ISO 8601 format)"
-    )]
-    pub end_time: Option<DateTime<Utc>>,
-}
+// #[derive(Debug, Deserialize, schemars::JsonSchema)]
+// pub struct SearchMemoryRequest {
+//     #[schemars(
+//         description = "Space-separated keywords to search for in your memory (e.g., 'kubernetes deployment config'). Searches against the title, tags, and content of your memory."
+//     )]
+//     pub keywords: String,
+//     #[schemars(
+//         description = "Start time for filtering memories by creation time (inclusive range, ISO 8601 format)"
+//     )]
+//     pub start_time: Option<DateTime<Utc>>,
+//     #[schemars(
+//         description = "End time for filtering memories by creation time (inclusive range, ISO 8601 format)"
+//     )]
+//     pub end_time: Option<DateTime<Utc>>,
+// }
 
-impl From<SearchMemoryRequest> for ApiSearchMemoryRequest {
-    fn from(req: SearchMemoryRequest) -> Self {
-        Self {
-            keywords: req
-                .keywords
-                .split_whitespace()
-                .map(|s| s.to_string())
-                .collect(),
-            start_time: req.start_time,
-            end_time: req.end_time,
-        }
-    }
-}
+// impl From<SearchMemoryRequest> for ApiSearchMemoryRequest {
+//     fn from(req: SearchMemoryRequest) -> Self {
+//         Self {
+//             keywords: req
+//                 .keywords
+//                 .split_whitespace()
+//                 .map(|s| s.to_string())
+//                 .collect(),
+//             start_time: req.start_time,
+//             end_time: req.end_time,
+//         }
+//     }
+// }
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct LoadSkillRequest {
     #[schemars(
@@ -342,35 +339,35 @@ If your goal requires understanding multiple distinct topics or technologies, ma
         Ok(CallToolResult::success(processed))
     }
 
-    #[tool(
-        description = "Search your memory for relevant information from previous conversations and code generation steps to accelerate request fulfillment."
-    )]
-    pub async fn search_memory(
-        &self,
-        Parameters(request): Parameters<SearchMemoryRequest>,
-    ) -> Result<CallToolResult, McpError> {
-        let client = match self.get_client() {
-            Some(client) => client,
-            None => {
-                return Ok(CallToolResult::error(vec![
-                    Content::text("CLIENT_NOT_FOUND"),
-                    Content::text("Client not found"),
-                ]));
-            }
-        };
+    // #[tool(
+    //     description = "Search your memory for relevant information from previous conversations and code generation steps to accelerate request fulfillment."
+    // )]
+    // pub async fn search_memory(
+    //     &self,
+    //     Parameters(request): Parameters<SearchMemoryRequest>,
+    // ) -> Result<CallToolResult, McpError> {
+    //     let client = match self.get_client() {
+    //         Some(client) => client,
+    //         None => {
+    //             return Ok(CallToolResult::error(vec![
+    //                 Content::text("CLIENT_NOT_FOUND"),
+    //                 Content::text("Client not found"),
+    //             ]));
+    //         }
+    //     };
 
-        let response = match client.search_memory(&request.into()).await {
-            Ok(response) => response,
-            Err(e) => {
-                return Ok(CallToolResult::error(vec![
-                    Content::text("SEARCH_MEMORY_ERROR"),
-                    Content::text(format!("Failed to search for memory: {}", e)),
-                ]));
-            }
-        };
+    //     let response = match client.search_memory(&request.into()).await {
+    //         Ok(response) => response,
+    //         Err(e) => {
+    //             return Ok(CallToolResult::error(vec![
+    //                 Content::text("SEARCH_MEMORY_ERROR"),
+    //                 Content::text(format!("Failed to search for memory: {}", e)),
+    //             ]));
+    //         }
+    //     };
 
-        Ok(CallToolResult::success(response))
-    }
+    //     Ok(CallToolResult::success(response))
+    // }
 
     #[tool(
         description = "Load a skill's full instructions by its URI. Use this to retrieve the complete content of any skill listed in the <available_skills> block. For local skills the URI is a file path; for remote skills the URI is the rulebook URI. This tool is auto-approved and does not require user confirmation."

--- a/tui/src/app/events.rs
+++ b/tui/src/app/events.rs
@@ -294,7 +294,6 @@ pub enum OutputEvent {
     ListSessions,
     SwitchToSession(String),
     NewSession,
-    Memorize,
     SendToolResult(ToolCallResult, bool, Vec<ToolCall>),
     ResumeSession,
     RequestProfileSwitch(String),

--- a/tui/src/services/commands.rs
+++ b/tui/src/services/commands.rs
@@ -14,8 +14,8 @@ use crate::services::auto_approve::AutoApprovePolicy;
 use crate::services::detect_term::ThemeColors;
 use crate::services::helper_block::{
     push_clear_message, push_error_message, push_help_message, push_issue_message,
-    push_memorize_message, push_status_message, push_styled_message, push_support_message,
-    push_usage_message, render_system_message, welcome_messages,
+    push_status_message, push_styled_message, push_support_message, push_usage_message,
+    render_system_message, welcome_messages,
 };
 use crate::services::layout::centered_rect;
 use crate::services::message::{Message, MessageContent};
@@ -53,7 +53,6 @@ pub enum CommandAction {
     OpenShellMode,
     ResumeSession,
     ShowStatus,
-    MemorizeConversation,
     SubmitIssue,
     GetSupport,
     NewSession,
@@ -69,7 +68,6 @@ impl CommandAction {
             CommandAction::OpenSessions => Some("/sessions"),
             CommandAction::ResumeSession => Some("/resume"),
             CommandAction::ShowStatus => Some("/status"),
-            CommandAction::MemorizeConversation => Some("/memorize"),
             CommandAction::SubmitIssue => Some("/issue"),
             CommandAction::GetSupport => Some("/support"),
             CommandAction::NewSession => Some("/new"),
@@ -169,12 +167,6 @@ pub fn get_all_commands() -> Vec<Command> {
             CommandAction::ShowStatus,
         ),
         Command::new(
-            "Memorize",
-            "Save conversation to memory",
-            "/memorize",
-            CommandAction::MemorizeConversation,
-        ),
-        Command::new(
             "Submit Issue",
             "Submit issue on GitHub repo",
             "/issue",
@@ -238,11 +230,6 @@ pub fn commands_to_helper_commands() -> Vec<HelperCommand> {
         HelperCommand {
             command: "/new".into(),
             description: "Start a new session".into(),
-            source: CommandSource::BuiltIn,
-        },
-        HelperCommand {
-            command: "/memorize".into(),
-            description: "Memorize the current conversation history".into(),
             source: CommandSource::BuiltIn,
         },
         HelperCommand {
@@ -374,13 +361,6 @@ pub fn execute_command(command_id: CommandId<'_>, ctx: CommandContext) -> Result
         }
         "/new" => {
             new_session(ctx.state, ctx.output_tx);
-            Ok(())
-        }
-        "/memorize" => {
-            push_memorize_message(ctx.state);
-            let _ = ctx.output_tx.try_send(OutputEvent::Memorize);
-            ctx.state.input_state.text_area.set_text("");
-            ctx.state.input_state.show_helper_dropdown = false;
             Ok(())
         }
         "/summarize" => {

--- a/tui/src/services/helper_block.rs
+++ b/tui/src/services/helper_block.rs
@@ -203,33 +203,6 @@ pub fn format_number_with_separator(n: u32) -> String {
     result.chars().rev().collect()
 }
 
-pub fn push_memorize_message(state: &mut AppState) {
-    let lines = vec![
-        Line::from(vec![Span::styled(
-            "📝 Memorizing conversation history...",
-            Style::default()
-                .fg(ThemeColors::warning())
-                .add_modifier(Modifier::BOLD),
-        )]),
-        Line::from(""),
-        Line::from(vec![Span::styled(
-            "We're extracting important information from your conversation in the background.",
-            Style::default().fg(Color::Reset),
-        )]),
-        Line::from(vec![Span::styled(
-            "Feel free to continue talking to the agent while this happens!",
-            Style::default().fg(ThemeColors::green()),
-        )]),
-        Line::from(""),
-    ];
-    state.messages_scrolling_state.messages.push(Message {
-        id: uuid::Uuid::new_v4(),
-        content: MessageContent::StyledBlock(lines),
-        is_collapsed: None,
-    });
-    invalidate_message_lines_cache(state);
-}
-
 pub fn push_help_message(state: &mut AppState) {
     use ratatui::style::{Color, Modifier, Style};
     use ratatui::text::{Line, Span};

--- a/tui/src/services/shortcuts_popup.rs
+++ b/tui/src/services/shortcuts_popup.rs
@@ -77,7 +77,6 @@ pub fn get_all_shortcuts() -> Vec<Shortcut> {
         Shortcut::new("/status", "Show account status", "Commands"),
         Shortcut::new("/sessions", "List available sessions", "Commands"),
         Shortcut::new("/resume", "Resume last session", "Commands"),
-        Shortcut::new("/memorize", "Memorize conversation", "Commands"),
         Shortcut::new("/model", "Switch model", "Commands"),
         Shortcut::new(
             "/summarize",


### PR DESCRIPTION
## Description
Removes legacy knowledge/memory surface areas that are no longer needed. Knowledge management is now handled through tool calling (ak) rather than direct prompt context injection or the old `search_memory` MCP tool.

## Changes Made
- **MCP server**: Comment out `search_memory` tool method and `SearchMemoryRequest` struct; remove unused `chrono` and `ApiSearchMemoryRequest` imports
- **Interactive mode**: Remove `/memorize` slash command and `OutputEvent::Memorize` variant
- **TUI services**: Remove memorize-related command handling, helper block rendering, and shortcut popup entry

## Testing
- [x] `cargo fmt` — no changes needed
- [x] `cargo clippy -p stakpak-mcp-server --all-targets -- -D warnings` — clean

## Breaking Changes
None — these were internal-only features. No consumer-facing CLI or API contracts are affected.