### PR TITLE
fix(ci): add stakpak-mcp-config to release publish step

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -269,6 +269,7 @@ jobs:
           publish_package stakai
           publish_package stakpak-shared
           publish_package stakpak-api
+          publish_package stakpak-mcp-config
           publish_package stakpak-mcp-client
           publish_package stakpak-mcp-server
           publish_package stakpak-mcp-proxy


### PR DESCRIPTION
## Description
Adds the missing `stakpak-mcp-config` crate to the publish step in the build-and-release workflow so it is published alongside the other MCP packages on releases.

## Related Issues
N/A

## Changes Made
- Added `publish_package stakpak-mcp-config` to `.github/workflows/build-and-release.yml`

## Testing
- [x] Verified the workflow YAML syntax is valid
- [ ] N/A — CI-only change

## Breaking Changes
None