### PR TITLE
fix: add stakpak-ak to release package publishing

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -274,6 +274,7 @@ jobs:
           publish_package stakpak-mcp-server
           publish_package stakpak-mcp-proxy
           publish_package stakpak-shell-tool-approvals
+          publish_package stakpak-ak
           publish_package stakpak-agent-core
           publish_package stakpak-gateway
           publish_package stakpak-server


### PR DESCRIPTION
## Description
Adds `stakpak-ak` to the `build-and-release.yml` workflow so it gets published alongside other workspace crates during releases.

## Changes Made
- Added `publish_package stakpak-ak` to the release job

## Testing
- [x] Verified the package name matches the crate name in the workspace