### PR TITLE
refactor(ak): redesign command surface — search, read, write, remove

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6193,6 +6193,10 @@ name = "stakpak-ak"
 version = "0.3.76"
 dependencies = [
  "dirs",
+ "globset",
+ "grep-matcher",
+ "grep-regex",
+ "regex",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/cli/README.md
+++ b/cli/README.md
@@ -164,6 +164,8 @@ stakpak autopilot schedule add --name retrospect --cron "0 3 * * *" --prompt "$(
 
 Each retrospect run processes candidate sessions newest-first and cites its sources in frontmatter. Idempotency falls out of those citations: sessions already cited are skipped on subsequent runs, so the schedule is safe to re-trigger and scale-insensitive to how many sessions have accumulated. See `stakpak ak skill retrospect` for the full workflow.
 
+`ak search`, `ak read`, `ak write`, `ak remove`, and `ak skill` are auto-approved by default for agent workflows.
+
 ### Add channels with profile
 
 ```bash

--- a/cli/src/commands/ak/mod.rs
+++ b/cli/src/commands/ak/mod.rs
@@ -1,7 +1,7 @@
 use clap::Subcommand;
 use stakpak_ak::search::SearchEngine;
 use stakpak_ak::skills::{SKILL_MAINTAIN, SKILL_RETROSPECT, SKILL_USAGE};
-use stakpak_ak::{LocalFsBackend, StorageBackend, TreeNavEngine};
+use stakpak_ak::{GrepResult, LocalFsBackend, PeekResult, StorageBackend, TreeNavEngine};
 use std::io::Read;
 use std::path::PathBuf;
 
@@ -12,26 +12,30 @@ default store root: ~/.stakpak/knowledge
 override: AK_STORE
 paths are relative to the store root
 
-Recommended read flow:
-- tree: discover structure
-- ls [path]: inspect one directory
-- peek <path>: preview frontmatter + first paragraph
-- cat <path>...: read full content
-- use `peek` before `cat` to save tokens
+Key commands:
+- ak search [path]: recursive preview by default; add --tree, --glob, --grep, or -i
+- ak read <path>...: read one or more files in full
+- ak write <path>: create a new file; use --force to overwrite intentionally
+- ak remove <path>: remove a file or directory recursively
+- ak skill <name>: print a built-in ak skill prompt
 
-Write behavior:
-- `write` creates a new file
-- `write` fails if the path already exists
-- use `--force` only when you want to overwrite intentionally";
+Recommended discovery flow:
+- start with `ak search [path]`
+- use `ak search --tree` for structure-only discovery
+- use `ak search --glob` or `ak search --grep` to narrow results
+- use `ak read` only after search tells you which files matter";
 
 pub const AK_AFTER_HELP: &str = "Examples:
-  stakpak ak tree
-  stakpak ak ls services/
-  stakpak ak peek services/rate-limits.md
-  stakpak ak cat services/rate-limits.md services/auth-flow.md
+  stakpak ak search
+  stakpak ak search services --tree
+  stakpak ak search --glob 'services/**/*.md'
+  stakpak ak search --grep 'rate.limit'
+  stakpak ak search --grep 'rate.limit' --glob '**/*.md'
+  stakpak ak read services/rate-limits.md
+  stakpak ak read services/rate-limits.md services/auth-flow.md
   echo 'Rate limit is 1000/min' | stakpak ak write services/rate-limits.md
   stakpak ak write notes.md --file /tmp/notes.md
-  stakpak ak write --force summaries/auth-overview.md";
+  stakpak ak remove services/rate-limits.md";
 
 #[derive(Subcommand, PartialEq, Debug)]
 #[command(
@@ -40,6 +44,56 @@ pub const AK_AFTER_HELP: &str = "Examples:
     after_help = AK_AFTER_HELP
 )]
 pub enum AkCommands {
+    #[command(
+        about = "Search the knowledge store",
+        long_about = "Search the ak store recursively.
+
+Default output is peek body per file (frontmatter, if present, plus the first paragraph). Use `--tree` for structure-only output, `--glob` to filter by path pattern, and `--grep` to filter by content regex. `--grep` matches frontmatter too. `-i` makes `--grep` case-insensitive.",
+        after_help = "Examples:
+  stakpak ak search
+  stakpak ak search services
+  stakpak ak search services --tree
+  stakpak ak search --glob 'services/**/*.md'
+  stakpak ak search --grep 'rate.limit'
+  stakpak ak search --grep 'rate.limit' -i
+  stakpak ak search --grep 'rate.limit' --glob '**/*.md'"
+    )]
+    Search {
+        /// Optional relative path to scope the search to a subtree or single file
+        path: Option<String>,
+
+        /// Regex to match against file content (including frontmatter)
+        #[arg(long)]
+        grep: Option<String>,
+
+        /// Glob to match against relative file paths
+        #[arg(long)]
+        glob: Option<String>,
+
+        /// Render a directory tree instead of file previews
+        #[arg(long, conflicts_with = "grep", conflicts_with = "glob")]
+        tree: bool,
+
+        /// Make `--grep` matching case-insensitive
+        #[arg(short = 'i')]
+        case_insensitive: bool,
+    },
+
+    #[command(
+        about = "Read one or more files in full",
+        long_about = "Print the full contents of one or more files from the ak store.
+
+When multiple paths are provided, each file is separated with a `---` delimiter. Reading a directory is not supported; use `ak search <path>` to preview content first.",
+        after_help = "Examples:
+  stakpak ak read services/rate-limits.md
+  stakpak ak read services/rate-limits.md services/auth-flow.md"
+    )]
+    Read {
+        /// One or more relative file paths to print in full
+        #[arg(required = true, num_args = 1..)]
+        paths: Vec<String>,
+    },
+
     #[command(
         about = "Create a new knowledge file",
         long_about = "Create only.
@@ -80,62 +134,15 @@ Behavior:
         about = "Remove a file or directory from the knowledge store",
         long_about = "Remove a file or an entire directory tree from the ak store.
 
-If you remove the last file in a directory, empty parent directories are cleaned up automatically until the store root."
+Removal is recursive for directories. Missing paths fail fast. If you remove the last file in a directory, empty parent directories are cleaned up automatically until the store root.",
+        after_help = "Examples:
+  stakpak ak remove services/rate-limits.md
+  stakpak ak remove services/old/"
     )]
-    Rm {
+    Remove {
         /// Relative path inside the knowledge store to remove
         path: String,
     },
-
-    #[command(
-        about = "Print the full directory tree of the knowledge store",
-        long_about = "Print the full directory tree of the ak store.
-
-This is the best starting point when you want to understand the overall structure before drilling into a specific directory or file."
-    )]
-    Tree,
-
-    #[command(
-        about = "List one directory with one-line file descriptions",
-        long_about = "List one directory at a time.
-
-Directories are shown first. File descriptions are extracted from frontmatter or the first non-empty body line."
-    )]
-    Ls {
-        /// Relative directory path inside the knowledge store. Omit to list the store root
-        path: Option<String>,
-    },
-
-    #[command(
-        about = "Show frontmatter and the first paragraph of a file",
-        long_about = "Show a lightweight preview of a file.
-
-`peek` is useful when you want enough context to decide whether you should read the whole file with `cat`."
-    )]
-    Peek {
-        /// Relative path of the file to summarize
-        path: String,
-    },
-
-    #[command(
-        about = "Print the full contents of one or more files",
-        long_about = "Print the full contents of one or more files from the ak store.
-
-When multiple paths are provided, each file is separated with a `---` delimiter so the output is still easy to parse or read."
-    )]
-    Cat {
-        /// One or more relative file paths to print in full
-        #[arg(required = true, num_args = 1..)]
-        paths: Vec<String>,
-    },
-
-    #[command(
-        about = "Show the store location and total file count",
-        long_about = "Show where the ak store currently lives and how many non-dotfiles it contains.
-
-This reflects the default root (~/.stakpak/knowledge) unless AK_STORE is set."
-    )]
-    Status,
 
     #[command(
         about = "Print one of the built-in ak skill prompts",
@@ -155,6 +162,57 @@ impl AkCommands {
         let search = TreeNavEngine::new(backend.clone());
 
         match self {
+            Self::Search {
+                path,
+                grep,
+                glob,
+                tree,
+                case_insensitive,
+            } => {
+                let path = path.unwrap_or_default();
+                if tree {
+                    let rendered = backend.tree(&path).map_err(|error| error.to_string())?;
+                    println!("{}", rendered.print());
+                } else if let (Some(regex), Some(glob)) = (grep.as_deref(), glob.as_deref()) {
+                    let results = search
+                        .search_grep_glob(&path, regex, glob, case_insensitive)
+                        .map_err(|error| error.to_string())?;
+                    print_rendered(&render_grep_results(&results));
+                } else if let Some(regex) = grep.as_deref() {
+                    let results = search
+                        .search_grep(&path, regex, case_insensitive)
+                        .map_err(|error| error.to_string())?;
+                    print_rendered(&render_grep_results(&results));
+                } else if let Some(glob) = glob.as_deref() {
+                    let results = search
+                        .search_glob(&path, glob)
+                        .map_err(|error| error.to_string())?;
+                    print_rendered(&render_peek_results(&results));
+                } else {
+                    let results = search
+                        .search_default(&path)
+                        .map_err(|error| error.to_string())?;
+                    print_rendered(&render_peek_results(&results));
+                }
+            }
+            Self::Read { paths } => {
+                for path in &paths {
+                    ensure_path_is_not_directory(&backend, path)?;
+                }
+
+                for (index, path) in paths.iter().enumerate() {
+                    if index > 0 {
+                        println!("---");
+                    }
+
+                    let content = backend.read(path).map_err(|error| error.to_string())?;
+                    let text = String::from_utf8_lossy(&content);
+                    print!("{text}");
+                    if index + 1 < paths.len() && !text.ends_with('\n') {
+                        println!();
+                    }
+                }
+            }
             Self::Write { path, file, force } => {
                 let content = read_input(file)?;
                 if force {
@@ -173,45 +231,13 @@ impl AkCommands {
                     })?;
                 }
             }
-            Self::Rm { path } => {
-                backend.remove(&path).map_err(|error| error.to_string())?;
-            }
-            Self::Tree => {
-                println!(
-                    "{}",
-                    backend.tree().map_err(|error| error.to_string())?.print()
-                );
-            }
-            Self::Ls { path } => {
-                let path = path.unwrap_or_default();
-                let entries = search
-                    .list_with_descriptions(&path)
-                    .map_err(|error| error.to_string())?;
-                print_entries(&entries);
-            }
-            Self::Peek { path } => {
-                println!("{}", search.peek(&path).map_err(|error| error.to_string())?);
-            }
-            Self::Cat { paths } => {
-                for (index, path) in paths.iter().enumerate() {
-                    if index > 0 {
-                        println!("---");
+            Self::Remove { path } => {
+                backend.remove(&path).map_err(|error| match error {
+                    stakpak_ak::Error::NotFound(missing) => {
+                        format!("path not found: {}", missing.display())
                     }
-
-                    let content = backend.read(path).map_err(|error| error.to_string())?;
-                    let text = String::from_utf8_lossy(&content);
-                    print!("{text}");
-                    if index + 1 < paths.len() && !text.ends_with('\n') {
-                        println!();
-                    }
-                }
-            }
-            Self::Status => {
-                println!("Store: {}", backend.root().display());
-                println!(
-                    "Files: {}",
-                    backend.file_count().map_err(|error| error.to_string())?
-                );
+                    other => other.to_string(),
+                })?;
             }
             Self::Skill { name } => match name.as_str() {
                 "usage" => println!("{SKILL_USAGE}"),
@@ -246,28 +272,46 @@ fn read_input(file: Option<PathBuf>) -> Result<Vec<u8>, String> {
     }
 }
 
-fn print_entries(entries: &[stakpak_ak::ListEntry]) {
-    let width = entries
-        .iter()
-        .map(display_name)
-        .map(|name| name.chars().count())
-        .max()
-        .unwrap_or(0);
-
-    for entry in entries {
-        let name = display_name(entry);
-        match &entry.description {
-            Some(description) => println!("{name:<width$}  — {description}"),
-            None => println!("{name}"),
-        }
+fn ensure_path_is_not_directory(backend: &LocalFsBackend, path: &str) -> Result<(), String> {
+    match backend.list(path) {
+        Ok(_) => Err(format!(
+            "{path} is a directory; use 'ak search {path}' to preview content"
+        )),
+        Err(stakpak_ak::Error::NotADirectory(_) | stakpak_ak::Error::NotFound(_)) => Ok(()),
+        Err(error) => Err(error.to_string()),
     }
 }
 
-fn display_name(entry: &stakpak_ak::ListEntry) -> String {
-    if entry.is_dir {
-        format!("{}/", entry.name)
-    } else {
-        entry.name.clone()
+fn render_peek_results(results: &[PeekResult]) -> String {
+    results
+        .iter()
+        .map(|result| format!("# {}\n{}", result.path, result.peek))
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn render_grep_results(results: &[GrepResult]) -> String {
+    results
+        .iter()
+        .map(render_grep_result)
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn render_grep_result(result: &GrepResult) -> String {
+    let lines = result
+        .matches
+        .iter()
+        .map(|(line_number, line)| format!("{line_number}: {line}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!("# {}\n{lines}", result.path)
+}
+
+fn print_rendered(rendered: &str) {
+    if !rendered.is_empty() {
+        println!("{rendered}");
     }
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1039,12 +1039,21 @@ mod tests {
 
     #[test]
     fn ak_command_does_not_require_auth() {
-        assert!(!Commands::Ak(commands::ak::AkCommands::Tree).requires_auth());
+        assert!(
+            !Commands::Ak(commands::ak::AkCommands::Search {
+                path: None,
+                grep: None,
+                glob: None,
+                tree: false,
+                case_insensitive: false,
+            })
+            .requires_auth()
+        );
     }
 
     #[test]
-    fn ak_cat_requires_at_least_one_path() {
-        let parsed = Cli::try_parse_from(["stakpak", "ak", "cat"]);
+    fn ak_read_requires_at_least_one_path() {
+        let parsed = Cli::try_parse_from(["stakpak", "ak", "read"]);
         assert!(parsed.is_err());
     }
 
@@ -1060,7 +1069,8 @@ mod tests {
         assert!(help.contains("default store root: ~/.stakpak/knowledge"));
         assert!(help.contains("override: AK_STORE"));
         assert!(help.contains("paths are relative to the store root"));
-        assert!(help.contains("use `peek` before `cat` to save tokens"));
+        assert!(help.contains("ak search [path]"));
+        assert!(help.contains("ak read <path>..."));
         assert!(!help.contains("ls --json"));
     }
 
@@ -1081,22 +1091,19 @@ mod tests {
     }
 
     #[test]
-    fn ak_ls_help_explains_directory_listing_behavior() {
-        let result = Cli::try_parse_from(["stakpak", "ak", "ls", "--help"]);
+    fn ak_search_help_explains_recursive_preview_and_filters() {
+        let result = Cli::try_parse_from(["stakpak", "ak", "search", "--help"]);
         let error = match result {
             Ok(_) => panic!("help output should exit via clap error"),
             Err(error) => error,
         };
         let help = error.to_string();
 
-        assert!(help.contains("one directory at a time"));
-        assert!(help.contains("frontmatter"));
+        assert!(help.contains("peek body"));
+        assert!(help.contains("--tree"));
+        assert!(help.contains("--grep"));
+        assert!(help.contains("--glob"));
+        assert!(help.contains("-i"));
         assert!(!help.contains("--json"));
-    }
-
-    #[test]
-    fn ak_ls_rejects_json_flag() {
-        let parsed = Cli::try_parse_from(["stakpak", "ak", "ls", "--json"]);
-        assert!(parsed.is_err());
     }
 }

--- a/cli/src/prompts/system_prompt.v1.md
+++ b/cli/src/prompts/system_prompt.v1.md
@@ -549,15 +549,17 @@ You have access to `ak`, a persistent markdown knowledge store that survives acr
 
 ## Commands
 ```bash
-stakpak ak status                    # Show store location and file count
-stakpak ak tree                      # Print full directory tree
-stakpak ak ls [path]                 # List one directory with descriptions
-stakpak ak peek <path>               # Read summary (frontmatter + first paragraph)
-stakpak ak cat <path> [<path>...]    # Read full content (multiple files separated by ---)
-stakpak ak write <path>              # Create new file (reads from stdin)
-stakpak ak write <path> -f <file>    # Create new file from local file
-stakpak ak write --force <path>      # Overwrite existing file
-stakpak ak rm <path>                 # Remove a file or directory
+stakpak ak search [path]                  # Recursive preview (peek body per file)
+stakpak ak search [path] --tree           # Print the directory tree (path-only)
+stakpak ak search [path] --glob <pattern> # Filter by relative path glob
+stakpak ak search [path] --grep <regex>   # Filter by content regex (includes frontmatter)
+stakpak ak search [path] --grep <regex> -i # Case-insensitive grep
+stakpak ak read <path> [<path>...]        # Read full content (multiple files separated by ---)
+stakpak ak write <path>                   # Create new file (reads from stdin)
+stakpak ak write <path> -f <file>         # Create new file from local file
+stakpak ak write --force <path>           # Overwrite existing file
+stakpak ak remove <path>                  # Remove a file or directory
+stakpak ak skill <name>                   # Print a built-in ak skill prompt
 ```
 
 Files are immutable by default — `ak write` errors if the file already exists. Use `--force` to overwrite mutable documents.
@@ -567,7 +569,7 @@ The first time you use the store (or find it empty), define your own storage phi
 
 Your philosophy should answer:
 - How do you structure directories and name files so you can **predict where something lives** without scanning everything?
-- What conventions make filenames and paths self-describing enough that `ak tree` alone tells you what's stored?
+- What conventions make filenames and paths self-describing enough that `ak search --tree` alone tells you what's stored?
 - How do you use frontmatter, cross-references, or indexes to make retrieval fast?
 - What's mutable vs immutable? What gets `--force` updates vs stays frozen?
 
@@ -605,7 +607,7 @@ Don't let knowledge tasks block your main work. When you learn something worth s
 
 **Keep in the main thread:**
 - Reading knowledge you need right now to make a decision
-- Quick `ak tree` or `ak peek` lookups that inform your next step
+- Quick `ak search --tree` or `ak search [path]` lookups that inform your next step
 
 The subagent should have access to `run_command` so it can execute `stakpak ak` commands. Include the output of `stakpak ak skill usage` in the subagent prompt — it contains the usage patterns and examples (like how `ak write` reads from stdin). Give the subagent enough context about what you learned and let it decide how to structure and store it.
 

--- a/cli/tests/ak_cli.rs
+++ b/cli/tests/ak_cli.rs
@@ -54,32 +54,129 @@ fn readme_autopilot_one_liner_matches_retrospect_prompt() {
 }
 
 #[test]
-fn ak_status_bootstraps_default_config_on_clean_home() {
+fn ak_search_tree_bootstraps_default_config_on_clean_home() {
     let temp_dir = tempfile::TempDir::new().expect("temp dir");
     let home = temp_dir.path();
 
     let output = Command::new(env!("CARGO_BIN_EXE_stakpak"))
         .arg("ak")
-        .arg("status")
+        .arg("search")
+        .arg("--tree")
         .env("HOME", home)
         .env("USERPROFILE", home)
         .env_remove("STAKPAK_PROFILE")
         .output()
-        .expect("run stakpak ak status");
+        .expect("run stakpak ak search --tree");
 
     assert!(
         output.status.success(),
-        "ak status failed: stdout={} stderr= {}",
+        "ak search --tree failed: stdout={} stderr= {}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Store:"), "stdout was: {stdout}");
-    assert!(stdout.contains("Files: 0"), "stdout was: {stdout}");
+    assert!(stdout.contains("."), "stdout was: {stdout}");
 
     assert!(
         home.join(".stakpak/config.toml").is_file(),
-        "expected ak status to bootstrap ~/.stakpak/config.toml"
+        "expected ak search --tree to bootstrap ~/.stakpak/config.toml"
+    );
+}
+
+#[test]
+fn ak_search_rejects_tree_with_grep() {
+    let output = Command::new(env!("CARGO_BIN_EXE_stakpak"))
+        .arg("ak")
+        .arg("search")
+        .arg("--tree")
+        .arg("--grep")
+        .arg("foo")
+        .output()
+        .expect("run stakpak ak search with invalid flags");
+
+    assert!(!output.status.success(), "command unexpectedly succeeded");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--tree"), "stderr was: {stderr}");
+    assert!(stderr.contains("--grep"), "stderr was: {stderr}");
+}
+
+#[test]
+fn ak_read_multiple_paths_uses_delimiter() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let home = temp_dir.path();
+    let store = temp_dir.path().join("knowledge");
+    std::fs::create_dir_all(&store).expect("create store");
+    std::fs::write(store.join("a.md"), "alpha\n").expect("write first file");
+    std::fs::write(store.join("b.md"), "beta\n").expect("write second file");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_stakpak"))
+        .arg("ak")
+        .arg("read")
+        .arg("a.md")
+        .arg("b.md")
+        .env("AK_STORE", &store)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .output()
+        .expect("run stakpak ak read");
+
+    assert!(
+        output.status.success(),
+        "ak read failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "alpha\n---\nbeta\n"
+    );
+}
+
+#[test]
+fn ak_read_on_directory_returns_search_hint() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let store = temp_dir.path().join("knowledge");
+    std::fs::create_dir_all(store.join("services")).expect("create services dir");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_stakpak"))
+        .arg("ak")
+        .arg("read")
+        .arg("services")
+        .env("AK_STORE", &store)
+        .output()
+        .expect("run stakpak ak read on directory");
+
+    assert!(!output.status.success(), "command unexpectedly succeeded");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("is a directory"), "stderr was: {stderr}");
+    assert!(
+        stderr.contains("ak search services"),
+        "stderr was: {stderr}"
+    );
+}
+
+#[test]
+fn ak_remove_missing_path_returns_clear_error() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let store = temp_dir.path().join("knowledge");
+    std::fs::create_dir_all(&store).expect("create store");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_stakpak"))
+        .arg("ak")
+        .arg("remove")
+        .arg("missing.md")
+        .env("AK_STORE", &store)
+        .output()
+        .expect("run stakpak ak remove on missing path");
+
+    assert!(!output.status.success(), "command unexpectedly succeeded");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("path not found: missing.md"),
+        "stderr was: {stderr}"
     );
 }

--- a/libs/ak/Cargo.toml
+++ b/libs/ak/Cargo.toml
@@ -13,6 +13,10 @@ serde_json = { workspace = true }
 serde_yaml = "0.9"
 walkdir = { workspace = true }
 dirs = "5.0"
+regex = { workspace = true }
+globset = { workspace = true }
+grep-matcher = { workspace = true }
+grep-regex = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/libs/ak/src/error.rs
+++ b/libs/ak/src/error.rs
@@ -6,6 +6,7 @@ pub enum Error {
     Io(std::io::Error),
     AlreadyExists(PathBuf),
     NotFound(PathBuf),
+    NotADirectory(PathBuf),
     UnsafePath(PathBuf),
     Parse(String),
 }
@@ -27,6 +28,9 @@ impl Display for Error {
                 "path not found: {}. check that the path is relative to the store root",
                 path.display()
             ),
+            Self::NotADirectory(path) => {
+                write!(f, "path is not a directory: {}", path.display())
+            }
             Self::UnsafePath(path) => write!(
                 f,
                 "unsafe path blocked: {}. ak paths must stay inside the store and cannot pass through symlinks",

--- a/libs/ak/src/lib.rs
+++ b/libs/ak/src/lib.rs
@@ -5,5 +5,5 @@ pub mod skills;
 pub mod store;
 
 pub use error::Error;
-pub use search::{ListEntry, SearchEngine, TreeNavEngine};
+pub use search::{GrepResult, PeekResult, SearchEngine, TreeNavEngine};
 pub use store::{Entry, LocalFsBackend, StorageBackend, TreeNode};

--- a/libs/ak/src/search.rs
+++ b/libs/ak/src/search.rs
@@ -1,20 +1,42 @@
 use crate::Error;
-use crate::format::{extract_description, extract_peek};
+use crate::format::extract_peek;
 use crate::store::StorageBackend;
+use globset::{GlobBuilder, GlobMatcher};
+use grep_matcher::Matcher;
+use grep_regex::{RegexMatcher, RegexMatcherBuilder};
 use serde::Serialize;
+use std::path::Path;
 
-const DESCRIPTION_READ_LIMIT_BYTES: usize = 16 * 1024;
+const BINARY_DETECTION_BYTES: usize = 8 * 1024;
 
 pub trait SearchEngine {
-    fn list_with_descriptions(&self, path: &str) -> Result<Vec<ListEntry>, Error>;
-    fn peek(&self, path: &str) -> Result<String, Error>;
+    fn search_default(&self, path: &str) -> Result<Vec<PeekResult>, Error>;
+    fn search_glob(&self, path: &str, glob: &str) -> Result<Vec<PeekResult>, Error>;
+    fn search_grep(
+        &self,
+        path: &str,
+        regex: &str,
+        case_insensitive: bool,
+    ) -> Result<Vec<GrepResult>, Error>;
+    fn search_grep_glob(
+        &self,
+        path: &str,
+        regex: &str,
+        glob: &str,
+        case_insensitive: bool,
+    ) -> Result<Vec<GrepResult>, Error>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct ListEntry {
-    pub name: String,
-    pub is_dir: bool,
-    pub description: Option<String>,
+pub struct PeekResult {
+    pub path: String,
+    pub peek: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GrepResult {
+    pub path: String,
+    pub matches: Vec<(usize, String)>,
 }
 
 pub struct TreeNavEngine<T> {
@@ -28,179 +50,304 @@ where
     pub fn new(store: T) -> Self {
         Self { store }
     }
+
+    fn search_peeks(
+        &self,
+        path: &str,
+        glob_matcher: Option<&GlobMatcher>,
+    ) -> Result<Vec<PeekResult>, Error> {
+        let mut results = Vec::new();
+
+        for relative_path in self.store.walk(path)? {
+            if !matches_glob(glob_matcher, &relative_path) {
+                continue;
+            }
+
+            let content = self.store.read(&relative_path)?;
+            results.push(PeekResult {
+                path: relative_path,
+                peek: extract_peek(&String::from_utf8_lossy(&content)),
+            });
+        }
+
+        Ok(results)
+    }
+
+    fn search_matches(
+        &self,
+        path: &str,
+        matcher: &RegexMatcher,
+        glob_matcher: Option<&GlobMatcher>,
+    ) -> Result<Vec<GrepResult>, Error> {
+        let mut results = Vec::new();
+
+        for relative_path in self.store.walk(path)? {
+            if !matches_glob(glob_matcher, &relative_path) {
+                continue;
+            }
+
+            let content = self.store.read(&relative_path)?;
+            if contains_nul_byte(&content[..content.len().min(BINARY_DETECTION_BYTES)]) {
+                continue;
+            }
+
+            let matches = grep_lines(matcher, &content)?;
+            if matches.is_empty() {
+                continue;
+            }
+
+            results.push(GrepResult {
+                path: relative_path,
+                matches,
+            });
+        }
+
+        Ok(results)
+    }
 }
 
 impl<T> SearchEngine for TreeNavEngine<T>
 where
     T: StorageBackend,
 {
-    fn list_with_descriptions(&self, path: &str) -> Result<Vec<ListEntry>, Error> {
-        self.store
-            .list(path)?
-            .into_iter()
-            .map(|entry| {
-                let description = if entry.is_dir {
-                    None
-                } else {
-                    let content = self
-                        .store
-                        .read_prefix(&join_path(path, &entry.name), DESCRIPTION_READ_LIMIT_BYTES)?;
-                    extract_description(&String::from_utf8_lossy(&content))
-                };
-
-                Ok(ListEntry {
-                    name: entry.name,
-                    is_dir: entry.is_dir,
-                    description,
-                })
-            })
-            .collect()
+    fn search_default(&self, path: &str) -> Result<Vec<PeekResult>, Error> {
+        self.search_peeks(path, None)
     }
 
-    fn peek(&self, path: &str) -> Result<String, Error> {
-        let content = self.store.read(path)?;
-        Ok(extract_peek(&String::from_utf8_lossy(&content)))
+    fn search_glob(&self, path: &str, glob: &str) -> Result<Vec<PeekResult>, Error> {
+        let matcher = compile_glob(glob)?;
+        self.search_peeks(path, Some(&matcher))
+    }
+
+    fn search_grep(
+        &self,
+        path: &str,
+        regex: &str,
+        case_insensitive: bool,
+    ) -> Result<Vec<GrepResult>, Error> {
+        let matcher = compile_regex(regex, case_insensitive)?;
+        self.search_matches(path, &matcher, None)
+    }
+
+    fn search_grep_glob(
+        &self,
+        path: &str,
+        regex: &str,
+        glob: &str,
+        case_insensitive: bool,
+    ) -> Result<Vec<GrepResult>, Error> {
+        let regex_matcher = compile_regex(regex, case_insensitive)?;
+        let glob_matcher = compile_glob(glob)?;
+        self.search_matches(path, &regex_matcher, Some(&glob_matcher))
     }
 }
 
-fn join_path(parent: &str, child: &str) -> String {
-    if parent.is_empty() {
-        child.to_string()
-    } else {
-        format!("{}/{}", parent.trim_end_matches('/'), child)
+fn compile_glob(glob: &str) -> Result<GlobMatcher, Error> {
+    GlobBuilder::new(glob)
+        .literal_separator(true)
+        .build()
+        .map(|compiled| compiled.compile_matcher())
+        .map_err(|error| Error::Parse(format!("invalid glob pattern: {error}")))
+}
+
+fn compile_regex(pattern: &str, case_insensitive: bool) -> Result<RegexMatcher, Error> {
+    let mut builder = RegexMatcherBuilder::new();
+    builder.case_insensitive(case_insensitive);
+    builder.line_terminator(Some(b'\n'));
+    builder
+        .build(pattern)
+        .map_err(|error| Error::Parse(format!("invalid regex pattern: {error}")))
+}
+
+fn matches_glob(glob_matcher: Option<&GlobMatcher>, path: &str) -> bool {
+    glob_matcher.is_none_or(|matcher| matcher.is_match(Path::new(path)))
+}
+
+fn grep_lines(matcher: &RegexMatcher, content: &[u8]) -> Result<Vec<(usize, String)>, Error> {
+    let text = String::from_utf8_lossy(content);
+    let mut matches = Vec::new();
+
+    for (index, line) in text.lines().enumerate() {
+        if matcher
+            .find(line.as_bytes())
+            .map_err(|error| Error::Parse(format!("failed to run regex search: {error}")))?
+            .is_some()
+        {
+            matches.push((index + 1, line.to_string()));
+        }
     }
+
+    Ok(matches)
+}
+
+fn contains_nul_byte(content: &[u8]) -> bool {
+    content.contains(&0)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{ListEntry, SearchEngine, TreeNavEngine};
-    use crate::Error;
-    use crate::store::{Entry, LocalFsBackend, StorageBackend, TreeNode};
-    use std::cell::Cell;
+    use super::{GrepResult, PeekResult, SearchEngine, TreeNavEngine};
+    use crate::store::{LocalFsBackend, StorageBackend};
 
-    #[test]
-    fn list_with_descriptions_reads_file_descriptions() {
+    fn engine() -> (
+        tempfile::TempDir,
+        LocalFsBackend,
+        TreeNavEngine<LocalFsBackend>,
+    ) {
         let root = tempfile::TempDir::new().expect("temp dir");
         let backend = LocalFsBackend::with_root(root.path().join("store"));
+        let engine = TreeNavEngine::new(backend.clone());
+        (root, backend, engine)
+    }
+
+    #[test]
+    fn search_default_returns_peeks_sorted_by_full_path() {
+        let (_root, backend, engine) = engine();
         backend
             .create(
-                "knowledge/rate-limits.md",
+                "services/rate-limits.md",
                 b"---\ndescription: API rate limits\n---\nBody\n",
             )
-            .expect("create described file");
+            .expect("create rate limits file");
         backend
-            .create("knowledge/auth-flow.md", b"OAuth2 PKCE flow\n\nMore\n")
-            .expect("create plain file");
-        std::fs::create_dir_all(backend.root().join("knowledge/subdir")).expect("create subdir");
-        let engine = TreeNavEngine::new(backend);
+            .create("notes/todo.md", b"First paragraph\n\nSecond paragraph\n")
+            .expect("create todo file");
 
         assert_eq!(
-            engine
-                .list_with_descriptions("knowledge")
-                .expect("list with descriptions"),
+            engine.search_default("").expect("default search"),
             vec![
-                ListEntry {
-                    name: "subdir".to_string(),
-                    is_dir: true,
-                    description: None,
+                PeekResult {
+                    path: "notes/todo.md".to_string(),
+                    peek: "First paragraph".to_string(),
                 },
-                ListEntry {
-                    name: "auth-flow.md".to_string(),
-                    is_dir: false,
-                    description: Some("OAuth2 PKCE flow".to_string()),
-                },
-                ListEntry {
-                    name: "rate-limits.md".to_string(),
-                    is_dir: false,
-                    description: Some("API rate limits".to_string()),
+                PeekResult {
+                    path: "services/rate-limits.md".to_string(),
+                    peek: "---\ndescription: API rate limits\n---\nBody".to_string(),
                 },
             ]
         );
     }
 
     #[test]
-    fn peek_returns_frontmatter_and_first_paragraph() {
-        let root = tempfile::TempDir::new().expect("temp dir");
-        let backend = LocalFsBackend::with_root(root.path().join("store"));
+    fn search_glob_filters_by_pattern() {
+        let (_root, backend, engine) = engine();
         backend
-            .create(
-                "knowledge/rate-limits.md",
-                b"---\ndescription: API rate limits\n---\nThe auth service rate limits at 1000 req/min.\nAfter hitting the limit, responses return 429.\n\nSecond paragraph.\n",
-            )
-            .expect("create file");
-        let engine = TreeNavEngine::new(backend);
+            .create("services/rate-limits.md", b"Body\n")
+            .expect("create service file");
+        backend
+            .create("notes/todo.md", b"Body\n")
+            .expect("create notes file");
 
         assert_eq!(
-            engine.peek("knowledge/rate-limits.md").expect("peek file"),
-            "---\ndescription: API rate limits\n---\nThe auth service rate limits at 1000 req/min.\nAfter hitting the limit, responses return 429."
+            engine
+                .search_glob("", "services/**/*.md")
+                .expect("glob search"),
+            vec![PeekResult {
+                path: "services/rate-limits.md".to_string(),
+                peek: "Body".to_string(),
+            }]
         );
-    }
-
-    #[derive(Default)]
-    struct PrefixOnlyBackend {
-        read_called: Cell<bool>,
-        read_prefix_called: Cell<bool>,
-    }
-
-    impl StorageBackend for PrefixOnlyBackend {
-        fn create(&self, _path: &str, _content: &[u8]) -> Result<(), Error> {
-            unimplemented!("not needed for this test")
-        }
-
-        fn overwrite(&self, _path: &str, _content: &[u8]) -> Result<(), Error> {
-            unimplemented!("not needed for this test")
-        }
-
-        fn read(&self, _path: &str) -> Result<Vec<u8>, Error> {
-            self.read_called.set(true);
-            Err(Error::Parse(
-                "full read should not be used for ls descriptions".to_string(),
-            ))
-        }
-
-        fn read_prefix(&self, _path: &str, _max_bytes: usize) -> Result<Vec<u8>, Error> {
-            self.read_prefix_called.set(true);
-            Ok(b"---\ndescription: Prefix description\n---\nBody\n".to_vec())
-        }
-
-        fn remove(&self, _path: &str) -> Result<(), Error> {
-            unimplemented!("not needed for this test")
-        }
-
-        fn list(&self, _path: &str) -> Result<Vec<Entry>, Error> {
-            Ok(vec![Entry {
-                name: "note.md".to_string(),
-                is_dir: false,
-            }])
-        }
-
-        fn tree(&self) -> Result<TreeNode, Error> {
-            unimplemented!("not needed for this test")
-        }
-
-        fn exists(&self, _path: &str) -> Result<bool, Error> {
-            unimplemented!("not needed for this test")
-        }
     }
 
     #[test]
-    fn list_with_descriptions_reads_only_prefixes() {
-        let backend = PrefixOnlyBackend::default();
-        let engine = TreeNavEngine::new(backend);
-
-        let entries = engine
-            .list_with_descriptions("")
-            .expect("list with prefix reads");
+    fn search_grep_returns_matching_lines_with_line_numbers() {
+        let (_root, backend, engine) = engine();
+        backend
+            .create(
+                "services/rate-limits.md",
+                b"first\nRate limit is 1000/min\nthird\n",
+            )
+            .expect("create service file");
 
         assert_eq!(
-            entries,
-            vec![ListEntry {
-                name: "note.md".to_string(),
-                is_dir: false,
-                description: Some("Prefix description".to_string()),
+            engine
+                .search_grep("", "Rate limit", false)
+                .expect("grep search"),
+            vec![GrepResult {
+                path: "services/rate-limits.md".to_string(),
+                matches: vec![(2, "Rate limit is 1000/min".to_string())],
             }]
         );
-        assert!(!engine.store.read_called.get());
-        assert!(engine.store.read_prefix_called.get());
+    }
+
+    #[test]
+    fn search_grep_honors_case_insensitive_flag() {
+        let (_root, backend, engine) = engine();
+        backend
+            .create("services/rate-limits.md", b"rate limit is 1000/min\n")
+            .expect("create service file");
+
+        assert_eq!(
+            engine
+                .search_grep("", "RATE LIMIT", true)
+                .expect("case insensitive grep"),
+            vec![GrepResult {
+                path: "services/rate-limits.md".to_string(),
+                matches: vec![(1, "rate limit is 1000/min".to_string())],
+            }]
+        );
+    }
+
+    #[test]
+    fn search_grep_matches_frontmatter_lines() {
+        let (_root, backend, engine) = engine();
+        backend
+            .create(
+                "services/rate-limits.md",
+                b"---\ndescription: API rate limits\n---\nBody\n",
+            )
+            .expect("create file");
+
+        assert_eq!(
+            engine
+                .search_grep("", "API rate", false)
+                .expect("frontmatter grep"),
+            vec![GrepResult {
+                path: "services/rate-limits.md".to_string(),
+                matches: vec![(2, "description: API rate limits".to_string())],
+            }]
+        );
+    }
+
+    #[test]
+    fn search_grep_skips_binary_files() {
+        let (_root, backend, engine) = engine();
+        backend
+            .create("services/binary.bin", b"text\0hidden\nRate limit\n")
+            .expect("create binary file");
+        backend
+            .create("services/rate-limits.md", b"Rate limit is 1000/min\n")
+            .expect("create text file");
+
+        assert_eq!(
+            engine
+                .search_grep("", "Rate limit", false)
+                .expect("grep search"),
+            vec![GrepResult {
+                path: "services/rate-limits.md".to_string(),
+                matches: vec![(1, "Rate limit is 1000/min".to_string())],
+            }]
+        );
+    }
+
+    #[test]
+    fn search_grep_glob_composes_filters() {
+        let (_root, backend, engine) = engine();
+        backend
+            .create("services/rate-limits.md", b"Rate limit\n")
+            .expect("create markdown file");
+        backend
+            .create("services/rate-limits.txt", b"Rate limit\n")
+            .expect("create text file");
+
+        assert_eq!(
+            engine
+                .search_grep_glob("", "Rate limit", "**/*.md", false)
+                .expect("grep glob search"),
+            vec![GrepResult {
+                path: "services/rate-limits.md".to_string(),
+                matches: vec![(1, "Rate limit".to_string())],
+            }]
+        );
     }
 }

--- a/libs/ak/src/skills.rs
+++ b/libs/ak/src/skills.rs
@@ -1,71 +1,8 @@
-pub const SKILL_USAGE: &str = r#"You have access to `ak`, a persistent knowledge store.
-It stores markdown files in a directory that survives across sessions.
-
-Key commands:
-- ak tree / ak ls        — see what exists (structure and listings)
-- ak peek <path>         — read summary (frontmatter + first paragraph)
-- ak cat <path>          — read full content
-- ak write <path>        — create new knowledge file (stdin or -f <file>)
-- ak write --force <path> — overwrite an existing file
-- ak rm <path>           — remove a knowledge file
-
-Files are immutable by default — `ak write` errors if the file
-already exists. Use this for extracted facts and knowledge.
-Use `--force` for mutable documents like summaries and indexes.
-
-Organize however you want — directories, naming conventions,
-frontmatter, cross-references. There are no rules.
-
-If you synthesize an answer from multiple files, consider
-writing the synthesis back as new knowledge.
-
-Source-citation convention
---------------------------
-When an entry is derived from a specific source (a session, a file
-read, a command output, or another identified resource), cite the
-source in YAML frontmatter under `sources:`. Each row carries three
-required fields — `session` (UUID), `checkpoint` (UUID), and
-`captured_at` (date in `YYYY-MM-DD` form) — plus an optional
-`message_range` field reserved for entries pinned to specific turns
-of a long session.
-
-```yaml
----
-description: Short sentence describing the entry.
-sources:
-  - session: 550e8400-e29b-41d4-a716-446655440000
-    checkpoint: 6ba7b810-9dad-11d1-80b4-00c04fd430c8
-    captured_at: 2026-04-24
-    # message_range: "14-27"   # optional; only when pinned to turns
----
-```
-
-If a later source supports an entry that already exists, append a new
-row to that file's existing `sources:` list and use `ak write --force`
-to save the update. Do not write a second file for content that
-belongs in an existing entry.
-
-Citations are both the audit trail for every evidence-derived entry
-and the idempotency anchor future retrospection scans to decide what
-has already been processed. They are not optional on evidence-derived
-writes."#;
+pub const SKILL_USAGE: &str = include_str!("skills/usage.v1.md");
 
 pub const SKILL_RETROSPECT: &str = include_str!("skills/retrospect.v1.md");
 
-pub const SKILL_MAINTAIN: &str = r#"Review your knowledge store for quality and accuracy.
-
-1. Run `ak tree` and `ak ls` to see what exists.
-2. Look for:
-   - Duplicate or near-duplicate entries → write a merged version,
-     remove the originals
-   - Contradictory facts → resolve or flag to the user
-   - Stale information (old dates, outdated facts) → remove and
-     write corrected versions
-   - Scattered facts that should be consolidated into a single file
-   - Overly broad files that should be split into atomic facts
-3. Use `ak write`, `ak write --force`, and `ak rm` to fix what
-   you find.
-4. Summarize what you changed and why."#;
+pub const SKILL_MAINTAIN: &str = include_str!("skills/maintain.v1.md");
 
 #[cfg(test)]
 mod tests {
@@ -140,6 +77,24 @@ mod tests {
             SKILL_RETROSPECT.contains("existing `ak` entries"),
             "SKILL_RETROSPECT must point the agent at existing ak entries as its reference"
         );
+    }
+
+    #[test]
+    fn usage_skill_contains_new_command_surface() {
+        for needle in [
+            "ak search [path]",
+            "ak search [path] --tree",
+            "ak search [path] --grep",
+            "ak search [path] --glob",
+            "ak read <path>...",
+            "ak write <path>",
+            "ak remove <path>",
+        ] {
+            assert!(
+                SKILL_USAGE.contains(needle),
+                "SKILL_USAGE is missing required command substring: {needle:?}"
+            );
+        }
     }
 
     #[test]

--- a/libs/ak/src/skills/maintain.v1.md
+++ b/libs/ak/src/skills/maintain.v1.md
@@ -1,0 +1,8 @@
+Review your knowledge store for quality and accuracy.
+
+1. Run `ak search` (and `ak search --tree` when structure matters) to see what exists.
+2. Use `ak search --grep` and `ak search --glob` to look for duplicates,
+   contradictions, stale facts, and entries that should be merged or split.
+3. Use `ak write`, `ak write --force`, and `ak remove` to fix what
+   you find.
+4. Summarize what you changed and why.

--- a/libs/ak/src/skills/retrospect.v1.md
+++ b/libs/ak/src/skills/retrospect.v1.md
@@ -16,15 +16,15 @@ rule, `write --force` for updates).
 
 ## Step 2 — orient in the store
 
-Run `stakpak ak tree` to see the full structure. Then use
-`stakpak ak peek` on likely containers — any `_schema.md`, project
+Run `stakpak ak search --tree` to see the full structure. Then use
+`stakpak ak search` on likely containers — any `_schema.md`, project
 roots, top-level indexes — to understand what is already known, how it
 is organized, and which sessions are already cited. Collect the set of
 every `session:` UUID that appears in any existing entry's frontmatter
 `sources:` list; that set is your "already processed" reference for
 this run.
 
-Use `stakpak ak cat` when `peek` is not enough to judge whether a
+Use `stakpak ak read` when `search` is not enough to judge whether a
 specific existing entry already covers a topic you are about to touch.
 
 ## Step 3 — list candidate sessions

--- a/libs/ak/src/skills/usage.v1.md
+++ b/libs/ak/src/skills/usage.v1.md
@@ -1,0 +1,56 @@
+You have access to `ak`, a persistent knowledge store.
+It stores markdown files in a directory that survives across sessions.
+
+Key commands:
+- ak search [path]            — recursively preview files with peek bodies
+- ak search [path] --tree     — inspect structure only
+- ak search [path] --grep ... — find files by matching content
+- ak search [path] --glob ... — find files by matching paths
+- ak read <path>...           — read full content
+- ak write <path>             — create new knowledge file (stdin or -f <file>)
+- ak remove <path>            — remove a knowledge file or directory
+
+Files are immutable by default — `ak write` errors if the file
+already exists. Use this for extracted facts and knowledge.
+Use `--force` for mutable documents like summaries and indexes.
+
+Organize however you want — directories, naming conventions,
+frontmatter, cross-references. There are no rules.
+
+Discovery flow: start with `ak search [path]`, narrow with
+`--tree`, `--grep`, or `--glob` when needed, then use
+`ak read` only for the files that matter.
+
+If you synthesize an answer from multiple files, consider
+writing the synthesis back as new knowledge.
+
+Source-citation convention
+--------------------------
+When an entry is derived from a specific source (a session, a file
+read, a command output, or another identified resource), cite the
+source in YAML frontmatter under `sources:`. Each row carries three
+required fields — `session` (UUID), `checkpoint` (UUID), and
+`captured_at` (date in `YYYY-MM-DD` form) — plus an optional
+`message_range` field reserved for entries pinned to specific turns
+of a long session.
+
+```yaml
+---
+description: Short sentence describing the entry.
+sources:
+  - session: 550e8400-e29b-41d4-a716-446655440000
+    checkpoint: 6ba7b810-9dad-11d1-80b4-00c04fd430c8
+    captured_at: 2026-04-24
+    # message_range: "14-27"   # optional; only when pinned to turns
+---
+```
+
+If a later source supports an entry that already exists, append a new
+row to that file's existing `sources:` list and use `ak write --force`
+to save the update. Do not write a second file for content that
+belongs in an existing entry.
+
+Citations are both the audit trail for every evidence-derived entry
+and the idempotency anchor future retrospection scans to decide what
+has already been processed. They are not optional on evidence-derived
+writes.

--- a/libs/ak/src/store.rs
+++ b/libs/ak/src/store.rs
@@ -13,7 +13,13 @@ pub trait StorageBackend {
     fn read_prefix(&self, path: &str, max_bytes: usize) -> Result<Vec<u8>, Error>;
     fn remove(&self, path: &str) -> Result<(), Error>;
     fn list(&self, path: &str) -> Result<Vec<Entry>, Error>;
-    fn tree(&self) -> Result<TreeNode, Error>;
+    /// Returns a directory tree rooted at `prefix` (empty string for the store root).
+    /// The root node's name is the prefix's last component, or `.` for the store root.
+    /// Missing prefixes return an empty directory node.
+    fn tree(&self, prefix: &str) -> Result<TreeNode, Error>;
+    /// Returns sorted store-relative file paths under `prefix`, excluding dotfiles.
+    /// Missing prefixes return an empty result.
+    fn walk(&self, prefix: &str) -> Result<Vec<String>, Error>;
     fn exists(&self, path: &str) -> Result<bool, Error>;
 }
 
@@ -314,10 +320,7 @@ impl StorageBackend for LocalFsBackend {
             };
         };
         if !metadata.is_dir() {
-            return Err(Error::Parse(format!(
-                "path is not a directory: {}",
-                self.relative_path(&target).display()
-            )));
+            return Err(Error::NotADirectory(self.relative_path(&target)));
         }
 
         read_sorted_children(&target, Some(&self.root)).map(|children| {
@@ -331,9 +334,56 @@ impl StorageBackend for LocalFsBackend {
         })
     }
 
-    fn tree(&self) -> Result<TreeNode, Error> {
-        self.ensure_no_symlinks_below_root(&self.root)?;
-        Self::build_tree_node(&self.root, ".".to_string())
+    fn tree(&self, prefix: &str) -> Result<TreeNode, Error> {
+        let trimmed = prefix.trim_matches('/');
+        let target = self.resolve_path(trimmed)?;
+        self.ensure_no_symlinks_below_root(&target)?;
+        let name = Path::new(trimmed)
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or_else(|| ".".to_string());
+        Self::build_tree_node(&target, name)
+    }
+
+    fn walk(&self, prefix: &str) -> Result<Vec<String>, Error> {
+        let target = self.resolve_path(prefix)?;
+        self.ensure_no_symlinks_below_root(&target)?;
+
+        let Some(metadata) = self.metadata_if_exists(&target)? else {
+            return Ok(vec![]);
+        };
+        if is_hidden_path(&target, &self.root) {
+            return Ok(vec![]);
+        }
+
+        let mut walked = Vec::new();
+        for entry in WalkDir::new(&target)
+            .into_iter()
+            .filter_entry(|entry| !is_hidden_path(entry.path(), &self.root))
+        {
+            let entry = entry.map_err(|error| Error::Io(std::io::Error::other(error)))?;
+            if entry.path() != target && entry.file_type().is_symlink() {
+                return Err(Error::UnsafePath(self.relative_path(entry.path())));
+            }
+            if metadata.is_file() || entry.file_type().is_file() {
+                walked.push(
+                    entry
+                        .path()
+                        .strip_prefix(&self.root)
+                        .map_err(|_| {
+                            Error::Parse(format!(
+                                "path is outside the configured store root: {}",
+                                self.relative_path(entry.path()).display()
+                            ))
+                        })?
+                        .to_string_lossy()
+                        .to_string(),
+                );
+            }
+        }
+
+        walked.sort();
+        Ok(walked)
     }
 
     fn exists(&self, path: &str) -> Result<bool, Error> {
@@ -538,7 +588,7 @@ mod tests {
             .expect("create entity file");
         std::fs::write(backend.root().join(".hidden.md"), "hidden").expect("write hidden file");
 
-        let tree = backend.tree().expect("build tree");
+        let tree = backend.tree("").expect("build tree");
 
         assert_eq!(
             tree,
@@ -565,6 +615,58 @@ mod tests {
                         }],
                     },
                 ],
+            }
+        );
+    }
+
+    #[test]
+    fn tree_returns_scoped_subtree() {
+        let (_temp_dir, backend) = backend();
+        backend
+            .create("services/auth/flows.md", b"Auth flow\n")
+            .expect("create auth file");
+        backend
+            .create("services/rate-limits.md", b"Rate limit\n")
+            .expect("create rate file");
+        backend
+            .create("notes/todo.md", b"Todo\n")
+            .expect("create notes file");
+
+        assert_eq!(
+            backend.tree("services").expect("scoped tree"),
+            TreeNode {
+                name: "services".to_string(),
+                is_dir: true,
+                children: vec![
+                    TreeNode {
+                        name: "auth".to_string(),
+                        is_dir: true,
+                        children: vec![TreeNode {
+                            name: "flows.md".to_string(),
+                            is_dir: false,
+                            children: vec![],
+                        }],
+                    },
+                    TreeNode {
+                        name: "rate-limits.md".to_string(),
+                        is_dir: false,
+                        children: vec![],
+                    },
+                ],
+            }
+        );
+    }
+
+    #[test]
+    fn tree_returns_empty_directory_for_missing_prefix() {
+        let (_temp_dir, backend) = backend();
+
+        assert_eq!(
+            backend.tree("missing").expect("missing tree"),
+            TreeNode {
+                name: "missing".to_string(),
+                is_dir: true,
+                children: vec![],
             }
         );
     }
@@ -746,5 +848,67 @@ mod tests {
             result.is_err(),
             "expected unreadable directory to return an error"
         );
+    }
+
+    #[test]
+    fn walk_returns_sorted_relative_files_from_store_root() {
+        let (_temp_dir, backend) = backend();
+        backend
+            .create("services/auth/flows.md", b"auth")
+            .expect("create nested file");
+        backend
+            .create("notes/todo.md", b"todo")
+            .expect("create top-level file");
+        std::fs::create_dir_all(backend.root().join("services/.private"))
+            .expect("create hidden dir");
+        std::fs::write(backend.root().join(".hidden.md"), "hidden")
+            .expect("write hidden root file");
+        std::fs::write(backend.root().join("services/.secret.md"), "hidden")
+            .expect("write hidden nested file");
+        std::fs::write(
+            backend.root().join("services/.private/ignored.md"),
+            "hidden",
+        )
+        .expect("write hidden-dir file");
+
+        let walked = backend.walk("").expect("walk store root");
+
+        assert_eq!(
+            walked,
+            vec![
+                "notes/todo.md".to_string(),
+                "services/auth/flows.md".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn walk_scopes_to_prefix() {
+        let (_temp_dir, backend) = backend();
+        backend
+            .create("services/auth/flows.md", b"auth")
+            .expect("create auth file");
+        backend
+            .create("services/billing/limits.md", b"limits")
+            .expect("create billing file");
+        backend
+            .create("notes/todo.md", b"todo")
+            .expect("create notes file");
+
+        let walked = backend.walk("services/auth").expect("walk subtree");
+
+        assert_eq!(walked, vec!["services/auth/flows.md".to_string()]);
+    }
+
+    #[test]
+    fn walk_returns_empty_for_missing_prefix() {
+        let (_temp_dir, backend) = backend();
+        backend
+            .create("notes/todo.md", b"todo")
+            .expect("create notes file");
+
+        let walked = backend.walk("missing").expect("walk missing prefix");
+
+        assert!(walked.is_empty());
     }
 }

--- a/libs/shell-tool-approvals/src/resolver.rs
+++ b/libs/shell-tool-approvals/src/resolver.rs
@@ -195,20 +195,24 @@ mod tests {
     }
 
     #[test]
-    fn arg_namespace_and_sub_rule_both_match_most_restrictive_wins() {
+    fn ak_verb_specific_rules_can_all_auto_approve() {
         let mut rules = HashMap::new();
-        rules.insert("run_command::stakpak::ak".to_string(), Action::Approve);
-        rules.insert("run_command::stakpak::ak::write".to_string(), Action::Ask);
+        for verb in ["search", "read", "write", "remove", "skill"] {
+            rules.insert(format!("run_command::stakpak::ak::{verb}"), Action::Approve);
+        }
 
-        let resolved = resolve_hierarchical_policy(
+        for command in [
+            "stakpak ak search services --tree",
+            "stakpak ak read notes.md",
             "stakpak ak write notes.md",
-            "run_command",
-            &[],
-            &rules,
-            Action::Deny,
-        );
+            "stakpak ak remove notes.md",
+            "stakpak ak skill usage",
+        ] {
+            let resolved =
+                resolve_hierarchical_policy(command, "run_command", &[], &rules, Action::Ask);
 
-        assert_eq!(resolved, Ok(Some(Action::Ask)));
+            assert_eq!(resolved, Ok(Some(Action::Approve)), "command: {command}");
+        }
     }
 
     #[test]

--- a/tui/src/services/auto_approve.rs
+++ b/tui/src/services/auto_approve.rs
@@ -879,13 +879,13 @@ mod tests {
             AutoApprovePolicy::Prompt,
         );
 
-        let tc = make_run_command_tool_call("stakpak ak tree");
+        let tc = make_run_command_tool_call("stakpak ak search --tree");
         let result = resolve_shell_scope(&tc, &config.tools, &config.default_policy);
         assert_eq!(result, Some(AutoApprovePolicy::Prompt));
     }
 
     #[test]
-    fn resolve_shell_scope_user_subrule_tightens_namespace_default() {
+    fn resolve_shell_scope_user_subrule_tightens_write_default_only() {
         let mut config = AutoApproveConfig::default();
         config.tools.insert(
             "run_command::stakpak::ak::write".to_string(),
@@ -896,20 +896,33 @@ mod tests {
         let write_result = resolve_shell_scope(&write_tc, &config.tools, &config.default_policy);
         assert_eq!(write_result, Some(AutoApprovePolicy::Prompt));
 
-        let tree_tc = make_run_command_tool_call("stakpak ak tree");
-        let tree_result = resolve_shell_scope(&tree_tc, &config.tools, &config.default_policy);
-        assert_eq!(tree_result, Some(AutoApprovePolicy::Auto));
+        let search_tc = make_run_command_tool_call("stakpak ak search --tree");
+        let search_result = resolve_shell_scope(&search_tc, &config.tools, &config.default_policy);
+        assert_eq!(search_result, Some(AutoApprovePolicy::Auto));
     }
 
     #[test]
-    fn should_auto_approve_stakpak_ak_tree_with_fresh_defaults() {
+    fn should_auto_approve_stakpak_ak_search_with_fresh_defaults() {
         let manager = AutoApproveManager {
             original_config: AutoApproveConfig::default(),
             config: AutoApproveConfig::default(),
             config_path: PathBuf::from(AUTO_APPROVE_CONFIG_PATH),
             input_tx: None,
         };
-        let tc = make_run_command_tool_call("stakpak ak tree");
+        let tc = make_run_command_tool_call("stakpak ak search --tree");
+
+        assert!(manager.should_auto_approve(&tc));
+    }
+
+    #[test]
+    fn should_auto_approve_stakpak_ak_write_with_fresh_defaults() {
+        let manager = AutoApproveManager {
+            original_config: AutoApproveConfig::default(),
+            config: AutoApproveConfig::default(),
+            config_path: PathBuf::from(AUTO_APPROVE_CONFIG_PATH),
+            input_tx: None,
+        };
+        let tc = make_run_command_tool_call("stakpak ak write notes.md");
 
         assert!(manager.should_auto_approve(&tc));
     }


### PR DESCRIPTION
## Description

Redesigns the `ak` knowledge store CLI to use a unified `search` command with filters, and renames legacy commands for clarity.

## Changes Made

### Command surface redesign
- **`ak search [path]`** — recursive preview (peek body per file), replaces `ls` + `peek`
- **`ak search --tree`** — path-only tree, replaces `ak tree`
- **`ak search --grep <regex>`** — filter by content regex (with `-i` for case-insensitive)
- **`ak search --glob <pattern>`** — filter by path glob
- **`ak read <path>...`** — full file content, replaces `ak cat` (multi-path with `---` delimiter)
- **`ak remove <path>`** — delete file/directory, replaces `ak rm`
- **`ak write <path>`** — unchanged
- **`ak skill <name>`** — print built-in skill prompts
- **`ak status`** — removed (tree bootstrapping folded into `search --tree`)

### Library API (`stakpak-ak`)
- `SearchEngine` trait: `search_default`, `search_glob`, `search_grep`, `search_grep_glob` replace `list_with_descriptions` and `peek`
- New `PeekResult` / `GrepResult` types replace `ListEntry`
- `StorageBackend::tree()` now takes `prefix` for scoped subtrees
- `StorageBackend::walk()` returns sorted file paths under prefix
- Added `regex`, `globset`, `grep-matcher`, `grep-regex` dependencies
- Added `NotADirectory` error variant

### Skills & prompts
- Usage, maintain, and retrospect skills updated for new command names
- System prompt updated
- Shell approval rules updated for new ak verbs (`search`, `read`, `write`, `remove`, `skill`)

## Testing
- [x] All tests pass (`cargo test --workspace`)
- [x] No clippy warnings (`cargo clippy --all-targets -- -D warnings`)
- [x] Formatted (`cargo fmt`)
- [x] `stakpak-ak` library tests — 45 passed
- [x] `ak_cli` integration tests — 7 passed
- [x] `stakpak-shell-tool-approvals` tests — 115 passed