### PR TITLE
fix(secrets): span-aware redaction to prevent double-skip and chain-replace bugs

### DIFF
--- a/cli/src/commands/agent/run/mode_async.rs
+++ b/cli/src/commands/agent/run/mode_async.rs
@@ -17,6 +17,7 @@ use stakpak_shared::local_store::LocalStore;
 use stakpak_shared::models::async_manifest::{AsyncManifest, PauseReason, PendingToolCall};
 use stakpak_shared::models::integrations::openai::{ChatMessage, MessageContent, Role};
 use stakpak_shared::models::llm::LLMTokenUsage;
+use stakpak_shared::secret_manager::SecretManager;
 use stakpak_shared::utils::{backward_compatibility_mapping, strip_tool_name};
 use std::collections::HashMap;
 use std::time::Instant;
@@ -185,6 +186,7 @@ pub async fn run_async(ctx: AppConfig, mut config: RunAsyncConfig) -> Result<Asy
     let mut chat_messages: Vec<ChatMessage> = Vec::new();
     let mut total_usage = LLMTokenUsage::default();
     let renderer = OutputRenderer::new(config.output_format.clone(), config.verbose);
+    let secret_manager = SecretManager::new(config.redact_secrets, config.privacy_mode);
 
     // Build auto-approve config if pause_on_approval is enabled
     let auto_approve = if config.pause_on_approval {
@@ -419,7 +421,8 @@ pub async fn run_async(ctx: AppConfig, mut config: RunAsyncConfig) -> Result<Asy
             config.prompt.clone()
         };
 
-        chat_messages.push(user_message(user_input));
+        let redacted_user_input = secret_manager.redact_and_store_secrets(&user_input, None);
+        chat_messages.push(user_message(redacted_user_input));
     }
 
     let mut step = 0;
@@ -470,7 +473,8 @@ pub async fn run_async(ctx: AppConfig, mut config: RunAsyncConfig) -> Result<Asy
         } else {
             feedback_text
         };
-        chat_messages.push(user_message(feedback_msg));
+        let redacted_feedback = secret_manager.redact_and_store_secrets(&feedback_msg, None);
+        chat_messages.push(user_message(redacted_feedback));
         print!("{}", renderer.render_info("Plan feedback loaded from file"));
     }
 

--- a/cli/src/commands/agent/run/mode_interactive.rs
+++ b/cli/src/commands/agent/run/mode_interactive.rs
@@ -29,6 +29,7 @@ use stakpak_shared::models::integrations::openai::{
     ChatMessage, MessageContent, Role, ToolCall, ToolCallResultStatus,
 };
 use stakpak_shared::models::llm::{LLMTokenUsage, PromptTokensDetails};
+use stakpak_shared::secret_manager::SecretManager;
 
 /// Bundled infrastructure analysis prompt (embedded at compile time)
 /// analyze the infrastructure and provide a summary of the current state
@@ -247,6 +248,7 @@ pub async fn run_interactive(
         let enabled_tools = config.enabled_tools.clone();
         let redact_secrets = config.redact_secrets;
         let privacy_mode = config.privacy_mode;
+        let secret_manager = SecretManager::new(redact_secrets, privacy_mode);
         let enable_mtls = config.enable_mtls;
         let is_git_repo = config.is_git_repo;
         let study_mode = config.study_mode;
@@ -640,16 +642,19 @@ pub async fn run_interactive(
                             user_input
                         };
 
+                        let redacted_user_input =
+                            secret_manager.redact_and_store_secrets(&user_input, None);
+
                         // Create message with ContentParts from TUI
                         let user_msg = if image_parts.is_empty() {
-                            user_message(user_input)
+                            user_message(redacted_user_input)
                         } else {
                             let mut parts = Vec::new();
-                            if !user_input.trim().is_empty() {
+                            if !redacted_user_input.trim().is_empty() {
                                 parts.push(
                                     stakpak_shared::models::integrations::openai::ContentPart {
                                         r#type: "text".to_string(),
-                                        text: Some(user_input),
+                                        text: Some(redacted_user_input),
                                         image_url: None,
                                     },
                                 );

--- a/libs/shared/src/secrets/mod.rs
+++ b/libs/shared/src/secrets/mod.rs
@@ -3,8 +3,31 @@ use crate::helper::generate_simple_id;
 /// Re-export the gitleaks initialization function for external access
 pub use gitleaks::initialize_gitleaks_config;
 use gitleaks::{DetectedSecret, detect_secrets};
+use regex::Regex;
 use std::collections::HashMap;
 use std::fmt;
+use std::sync::LazyLock;
+
+static REDACTED_SECRET_MARKER_RE: LazyLock<Regex> =
+    LazyLock::new(
+        || match Regex::new(r"\[REDACTED_SECRET:[^:\]]+:[^:\]]+\]") {
+            Ok(regex) => regex,
+            Err(error) => panic!("invalid redacted-secret marker regex: {error}"),
+        },
+    );
+
+fn find_protected_spans(content: &str) -> Vec<(usize, usize)> {
+    REDACTED_SECRET_MARKER_RE
+        .find_iter(content)
+        .map(|marker_match| (marker_match.start(), marker_match.end()))
+        .collect()
+}
+
+fn overlaps_protected_span(start: usize, end: usize, protected_spans: &[(usize, usize)]) -> bool {
+    protected_spans
+        .iter()
+        .any(|(protected_start, protected_end)| start < *protected_end && end > *protected_start)
+}
 
 /// A result containing both the redacted string and the mapping of redaction keys to original secrets
 #[derive(Debug, Clone)]
@@ -39,34 +62,44 @@ pub fn redact_secrets(
     old_redaction_map: &HashMap<String, String>,
     privacy_mode: bool,
 ) -> RedactionResult {
-    // Skip redaction if content already contains redacted secrets (avoid double redaction)
-    if content.contains("[REDACTED_SECRET:") {
-        return RedactionResult::new(content.to_string(), HashMap::new());
-    }
-
-    let mut secrets = detect_secrets(content, path, privacy_mode);
+    let protected_spans = find_protected_spans(content);
+    let mut secrets = detect_secrets(content, path, privacy_mode)
+        .into_iter()
+        .filter(|secret| {
+            !overlaps_protected_span(secret.start_pos, secret.end_pos, &protected_spans)
+        })
+        .collect::<Vec<_>>();
 
     let mut redaction_map = old_redaction_map.clone();
     let mut reverse_redaction_map: HashMap<String, String> = old_redaction_map
         .clone()
         .into_iter()
-        .map(|(k, v)| (v, k))
+        .map(|(key, value)| (value, key))
         .collect();
 
     for (original_secret, redaction_key) in &reverse_redaction_map {
-        // Extract rule_id from redaction_key format: [REDACTED_SECRET:rule_id:id]
+        if original_secret.is_empty() {
+            continue;
+        }
+
         let key_parts = redaction_key.split(':').collect::<Vec<&str>>();
-        if key_parts.len() == 3 {
-            let rule_id = key_parts[1].to_string();
-            if let Some(start) = content.find(original_secret) {
-                let end = start + original_secret.len();
-                secrets.push(DetectedSecret {
-                    rule_id,
-                    value: original_secret.clone(),
-                    start_pos: start,
-                    end_pos: end,
-                });
+        if key_parts.len() != 3 {
+            continue;
+        }
+
+        let rule_id = key_parts[1].to_string();
+        for (start_pos, _) in content.match_indices(original_secret) {
+            let end_pos = start_pos + original_secret.len();
+            if overlaps_protected_span(start_pos, end_pos, &protected_spans) {
+                continue;
             }
+
+            secrets.push(DetectedSecret {
+                rule_id: rule_id.clone(),
+                value: original_secret.clone(),
+                start_pos,
+                end_pos,
+            });
         }
     }
 
@@ -79,21 +112,19 @@ pub fn redact_secrets(
     // Deduplicate overlapping secrets - keep the longest one
     let mut deduplicated_secrets: Vec<DetectedSecret> = Vec::new();
     let mut sorted_by_start = secrets;
-    sorted_by_start.sort_by(|a, b| a.start_pos.cmp(&b.start_pos));
+    sorted_by_start.sort_by(|left, right| left.start_pos.cmp(&right.start_pos));
 
     for secret in sorted_by_start {
         let mut should_add = true;
         let mut to_remove = Vec::new();
 
-        for (i, existing) in deduplicated_secrets.iter().enumerate() {
-            // Check if secrets overlap
+        for (index, existing) in deduplicated_secrets.iter().enumerate() {
             let overlaps =
                 secret.start_pos < existing.end_pos && secret.end_pos > existing.start_pos;
 
             if overlaps {
-                // Keep the longer secret (more specific)
                 if secret.value.len() > existing.value.len() {
-                    to_remove.push(i);
+                    to_remove.push(index);
                 } else {
                     should_add = false;
                     break;
@@ -101,9 +132,8 @@ pub fn redact_secrets(
             }
         }
 
-        // Remove secrets that should be replaced by this longer one
-        for &i in to_remove.iter().rev() {
-            deduplicated_secrets.remove(i);
+        for &index in to_remove.iter().rev() {
+            deduplicated_secrets.remove(index);
         }
 
         if should_add {
@@ -111,34 +141,27 @@ pub fn redact_secrets(
         }
     }
 
-    // Sort by position in reverse order to avoid index shifting issues
-    deduplicated_secrets.sort_by(|a, b| b.start_pos.cmp(&a.start_pos));
+    deduplicated_secrets.sort_by(|left, right| right.start_pos.cmp(&left.start_pos));
 
     for secret in deduplicated_secrets {
-        // Validate character boundaries before replacement
         if !content.is_char_boundary(secret.start_pos) || !content.is_char_boundary(secret.end_pos)
         {
             continue;
         }
 
-        // Validate positions are within bounds
         if secret.start_pos >= redacted_string.len() || secret.end_pos > redacted_string.len() {
             continue;
         }
 
-        // make sure same secrets have the same redaction key within the same file
-        // without making the hash content dependent (content addressable)
         let redaction_key = if let Some(existing_key) = reverse_redaction_map.get(&secret.value) {
             existing_key.clone()
         } else {
             let key = generate_redaction_key(&secret.rule_id);
-            // Store the mapping (only once per unique secret value)
             redaction_map.insert(key.clone(), secret.value.clone());
             reverse_redaction_map.insert(secret.value, key.clone());
             key
         };
 
-        // Replace the secret in the string
         redacted_string.replace_range(secret.start_pos..secret.end_pos, &redaction_key);
     }
 
@@ -147,12 +170,29 @@ pub fn redact_secrets(
 
 /// Restores secrets in a redacted string using the provided redaction map
 pub fn restore_secrets(redacted_string: &str, redaction_map: &HashMap<String, String>) -> String {
-    let mut restored = redacted_string.to_string();
+    let mut restored = String::with_capacity(redacted_string.len());
+    let mut cursor = 0;
 
-    for (redaction_key, original_value) in redaction_map {
-        restored = restored.replace(redaction_key, original_value);
+    for marker_match in REDACTED_SECRET_MARKER_RE.find_iter(redacted_string) {
+        let Some(prefix) = redacted_string.get(cursor..marker_match.start()) else {
+            return redacted_string.to_string();
+        };
+        restored.push_str(prefix);
+
+        let marker = marker_match.as_str();
+        if let Some(original_value) = redaction_map.get(marker) {
+            restored.push_str(original_value);
+        } else {
+            restored.push_str(marker);
+        }
+
+        cursor = marker_match.end();
     }
 
+    let Some(suffix) = redacted_string.get(cursor..) else {
+        return redacted_string.to_string();
+    };
+    restored.push_str(suffix);
     restored
 }
 
@@ -166,8 +206,16 @@ pub fn redact_password(
         return RedactionResult::new(content.to_string(), HashMap::new());
     }
 
-    // Skip redaction if content already contains redacted secrets (avoid double redaction)
-    if content.contains("[REDACTED_SECRET:") {
+    let protected_spans = find_protected_spans(content);
+    let occurrences = content
+        .match_indices(password)
+        .map(|(start_pos, _)| (start_pos, start_pos + password.len()))
+        .filter(|(start_pos, end_pos)| {
+            !overlaps_protected_span(*start_pos, *end_pos, &protected_spans)
+        })
+        .collect::<Vec<_>>();
+
+    if occurrences.is_empty() && !protected_spans.is_empty() {
         return RedactionResult::new(content.to_string(), HashMap::new());
     }
 
@@ -176,22 +224,21 @@ pub fn redact_password(
     let mut reverse_redaction_map: HashMap<String, String> = old_redaction_map
         .clone()
         .into_iter()
-        .map(|(k, v)| (v, k))
+        .map(|(key, value)| (value, key))
         .collect();
 
-    // Check if we already have a redaction key for this password
     let redaction_key = if let Some(existing_key) = reverse_redaction_map.get(password) {
         existing_key.clone()
     } else {
         let key = generate_redaction_key("password");
-        // Store the mapping
         redaction_map.insert(key.clone(), password.to_string());
         reverse_redaction_map.insert(password.to_string(), key.clone());
         key
     };
 
-    // Replace all occurrences of the password
-    redacted_string = redacted_string.replace(password, &redaction_key);
+    for (start_pos, end_pos) in occurrences.iter().rev().copied() {
+        redacted_string.replace_range(start_pos..end_pos, &redaction_key);
+    }
 
     RedactionResult::new(redacted_string, redaction_map)
 }
@@ -278,10 +325,17 @@ mod tests {
     #[test]
     fn test_restore_secrets() {
         let mut redaction_map = HashMap::new();
-        redaction_map.insert("[REDACTED_abc123]".to_string(), "secret123".to_string());
-        redaction_map.insert("[REDACTED_def456]".to_string(), "api_key_xyz".to_string());
+        redaction_map.insert(
+            "[REDACTED_SECRET:test:abc123]".to_string(),
+            "secret123".to_string(),
+        );
+        redaction_map.insert(
+            "[REDACTED_SECRET:test:def456]".to_string(),
+            "api_key_xyz".to_string(),
+        );
 
-        let redacted = "Password is [REDACTED_abc123] and key is [REDACTED_def456]";
+        let redacted =
+            "Password is [REDACTED_SECRET:test:abc123] and key is [REDACTED_SECRET:test:def456]";
         let restored = restore_secrets(redacted, &redaction_map);
 
         assert_eq!(restored, "Password is secret123 and key is api_key_xyz");

--- a/libs/shared/tests/secret_redaction_regressions.rs
+++ b/libs/shared/tests/secret_redaction_regressions.rs
@@ -1,0 +1,400 @@
+//! Regression suite for redaction fixes reported by Abdalla.
+
+use rand::{SeedableRng, rngs::StdRng, seq::SliceRandom};
+use regex::Regex;
+use stakpak_shared::secrets::{redact_password, redact_secrets, restore_secrets};
+use std::collections::HashMap;
+
+fn fake_slack_bot_token_a() -> String {
+    [
+        "xoxb-",
+        "2154536101-1638566032918-",
+        "aBcDeFgHiJkLmNoPqRsTuVwX",
+    ]
+    .concat()
+}
+
+fn fake_slack_bot_token_b() -> String {
+    [
+        "xoxb-",
+        "2154536102-1638566032919-",
+        "zYxWvUtSrQpOnMlKjIhGfEdC",
+    ]
+    .concat()
+}
+
+fn fake_slack_app_token() -> String {
+    [
+        "xapp-",
+        "1-A012345BCDE-1234567890123-",
+        "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+    ]
+    .concat()
+}
+
+fn fake_aws_key() -> String {
+    ["AKIA", "IOSFODNN7EXREAL2"].concat()
+}
+
+fn marker_regex() -> Regex {
+    Regex::new(r"\[REDACTED_SECRET:[^:\]]+:[^:\]]+\]").expect("marker regex should compile")
+}
+
+fn count_occurrences(haystack: &str, needle: &str) -> usize {
+    haystack.match_indices(needle).count()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SUSPECT #1: redact_secrets early-returns when input contains [REDACTED_SECRET:
+// → any *fresh* secret in the same content is silently NOT redacted.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn regression_redact_single_stale_marker_does_not_suppress_fresh_secret() {
+    let aws = fake_aws_key();
+    let content = format!(
+        "Earlier: [REDACTED_SECRET:slack-bot-token:abc123]\nNewly pasted: AWS_ACCESS_KEY_ID={aws}"
+    );
+
+    let result = redact_secrets(&content, None, &HashMap::new(), false);
+
+    let leaked = result.redacted_string.contains(&aws);
+
+    assert!(
+        !leaked,
+        "BUG REPRODUCED: fresh AWS key was NOT redacted because content already \
+         contained an unrelated [REDACTED_SECRET:...] placeholder"
+    );
+    assert!(
+        result
+            .redacted_string
+            .contains("[REDACTED_SECRET:slack-bot-token:abc123]"),
+        "stale marker should remain unchanged"
+    );
+    assert_eq!(result.redaction_map.len(), 1, "expected one new redaction");
+}
+
+#[test]
+fn regression_redact_multiple_stale_markers_do_not_suppress_detection() {
+    let token = fake_slack_bot_token_a();
+    let stale_markers = [
+        "[REDACTED_SECRET:slack-bot-token:old111]",
+        "[REDACTED_SECRET:slack-app-token:old222]",
+        "[REDACTED_SECRET:aws-access-token:old333]",
+    ];
+    let content = format!(
+        "{}\n{}\n{}\nSLACK_BOT_TOKEN={token}",
+        stale_markers[0], stale_markers[1], stale_markers[2]
+    );
+
+    let result = redact_secrets(&content, None, &HashMap::new(), false);
+
+    assert!(!result.redacted_string.contains(&token));
+    for marker in stale_markers {
+        assert!(result.redacted_string.contains(marker));
+    }
+    assert_eq!(result.redaction_map.len(), 1);
+}
+
+#[test]
+fn regression_redact_lone_marker_round_trips_unchanged() {
+    let content = "[REDACTED_SECRET:slack-bot-token:abc123]";
+
+    let result = redact_secrets(content, None, &HashMap::new(), false);
+
+    assert_eq!(result.redacted_string, content);
+    assert!(result.redaction_map.is_empty());
+}
+
+#[test]
+fn regression_redact_session_growth_two_calls_two_secrets() {
+    let token_a = fake_slack_bot_token_a();
+    let token_b = fake_slack_bot_token_b();
+
+    let first = redact_secrets(
+        &format!("SLACK_BOT_TOKEN={token_a}"),
+        None,
+        &HashMap::new(),
+        false,
+    );
+    let second = redact_secrets(
+        &format!("SLACK_BOT_TOKEN={token_b}"),
+        None,
+        &first.redaction_map,
+        false,
+    );
+
+    assert!(!first.redacted_string.contains(&token_a));
+    assert!(!second.redacted_string.contains(&token_b));
+    assert_eq!(first.redaction_map.len(), 1);
+    assert_eq!(second.redaction_map.len(), 2);
+    assert!(second.redaction_map.values().any(|value| value == &token_a));
+    assert!(second.redaction_map.values().any(|value| value == &token_b));
+}
+
+#[test]
+fn regression_redact_identical_secret_across_calls_reuses_key() {
+    let token = fake_slack_bot_token_a();
+
+    let first = redact_secrets(
+        &format!("SLACK_BOT_TOKEN={token}"),
+        None,
+        &HashMap::new(),
+        false,
+    );
+    let second = redact_secrets(
+        &format!("SLACK_BOT_TOKEN={token}"),
+        None,
+        &first.redaction_map,
+        false,
+    );
+
+    let first_key = first
+        .redaction_map
+        .iter()
+        .find(|(_, value)| *value == &token)
+        .map(|(key, _)| key.clone())
+        .expect("first call should store token");
+    let second_key = second
+        .redaction_map
+        .iter()
+        .find(|(_, value)| *value == &token)
+        .map(|(key, _)| key.clone())
+        .expect("second call should store token");
+
+    assert_eq!(first_key, second_key);
+}
+
+#[test]
+fn regression_redact_old_map_secret_redacted_at_all_occurrences() {
+    let redaction_key = "[REDACTED_SECRET:manual:abc]";
+    let secret = "s3cret";
+    let old_map = HashMap::from([(redaction_key.to_string(), secret.to_string())]);
+    let content = "a=s3cret b=s3cret c=s3cret";
+
+    let result = redact_secrets(content, None, &old_map, false);
+
+    assert_eq!(count_occurrences(&result.redacted_string, redaction_key), 3);
+    assert_eq!(count_occurrences(&result.redacted_string, secret), 0);
+}
+
+#[test]
+fn regression_redact_password_ignores_stale_markers() {
+    let password = "supersecret123";
+    let content = format!("existing=[REDACTED_SECRET:password:abc123]\npassword={password}");
+
+    let result = redact_password(&content, password, &HashMap::new());
+
+    assert!(!result.redacted_string.contains(password));
+    assert!(
+        result
+            .redacted_string
+            .contains("[REDACTED_SECRET:password:abc123]"),
+        "stale marker should remain unchanged"
+    );
+    assert_eq!(result.redaction_map.len(), 1);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SUSPECT #2: slack token regex boundaries
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn regression_redact_slack_xoxb_full_token_redacted() {
+    let token = fake_slack_bot_token_a();
+    let content = format!("SLACK_BOT_TOKEN={token}");
+
+    let result = redact_secrets(&content, None, &HashMap::new(), false);
+
+    assert!(
+        !result.redacted_string.contains(&token),
+        "xoxb token leaked: {}",
+        result.redacted_string
+    );
+    assert!(
+        !result.redaction_map.is_empty(),
+        "no redaction recorded for xoxb"
+    );
+    let stored = result
+        .redaction_map
+        .values()
+        .find(|v| v.starts_with("xoxb-"))
+        .expect("no xoxb value in map");
+    assert_eq!(stored, &token);
+}
+
+#[test]
+fn regression_redact_slack_xapp_full_token_redacted() {
+    let token = fake_slack_app_token();
+    let content = format!("SLACK_APP_TOKEN={token}");
+
+    let result = redact_secrets(&content, None, &HashMap::new(), false);
+
+    assert!(
+        !result.redacted_string.contains(&token),
+        "xapp token leaked: {}",
+        result.redacted_string
+    );
+    let stored = result
+        .redaction_map
+        .values()
+        .find(|v| v.starts_with("xapp-"))
+        .expect("no xapp value in map");
+    assert_eq!(stored, &token);
+}
+
+#[test]
+fn regression_redact_xoxb_full_token_in_grep_style_with_example() {
+    let token = fake_slack_bot_token_b();
+    let content = format!(".env:SLACK_BOT_TOKEN={token}\n.env.example:SLACK_BOT_TOKEN=xoxb-foo");
+    let result = redact_secrets(&content, None, &HashMap::new(), false);
+
+    assert!(
+        !result.redacted_string.contains(&token),
+        "real xoxb leaked alongside example: {}",
+        result.redacted_string
+    );
+    let stored = result
+        .redaction_map
+        .values()
+        .find(|value| value.starts_with("xoxb-"))
+        .expect("no xoxb value in map");
+    assert_eq!(stored, &token);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SUSPECT #3: shell-special chars in restored secret mangle tool calls
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn regression_restore_preserves_shell_special_chars() {
+    let secret = r#"p@ss$word`with"quotes\and$VAR"#;
+    let mut map = HashMap::new();
+    map.insert(
+        "[REDACTED_SECRET:password:abc123]".to_string(),
+        secret.to_string(),
+    );
+
+    let agent_emitted = "echo \"$TOKEN\" && curl -H 'Authorization: Bearer [REDACTED_SECRET:password:abc123]' https://x";
+    let restored = restore_secrets(agent_emitted, &map);
+
+    assert!(
+        restored.contains(secret),
+        "restored output is missing the original secret characters"
+    );
+}
+
+#[test]
+fn regression_restore_value_looks_like_other_key_no_chain_replace() {
+    let mut map = HashMap::new();
+    map.insert(
+        "[REDACTED_SECRET:a:111]".to_string(),
+        "[REDACTED_SECRET:b:222]".to_string(),
+    );
+    map.insert("[REDACTED_SECRET:b:222]".to_string(), "BAD".to_string());
+
+    let agent_emitted = "value=[REDACTED_SECRET:a:111]";
+    let restored = restore_secrets(agent_emitted, &map);
+
+    assert_eq!(
+        restored, "value=[REDACTED_SECRET:b:222]",
+        "restore_secrets chain-replaced — secret a was rewritten using secret b's mapping"
+    );
+}
+
+#[test]
+fn regression_restore_determinism_50_entries_20_trials() {
+    let entries: Vec<(String, String)> = (0..50)
+        .map(|index| {
+            let key = format!("[REDACTED_SECRET:rule:{index:03}]");
+            let value = if index % 10 == 0 && index < 49 {
+                format!("[REDACTED_SECRET:rule:{:03}]", index + 1)
+            } else {
+                format!("secret-value-{index:03}")
+            };
+            (key, value)
+        })
+        .collect();
+    let redacted = entries
+        .iter()
+        .map(|(key, _)| key.as_str())
+        .collect::<Vec<_>>()
+        .join("|");
+    let expected = entries
+        .iter()
+        .map(|(_, value)| value.as_str())
+        .collect::<Vec<_>>()
+        .join("|");
+
+    for seed in 0_u64..20 {
+        let mut shuffled = entries.clone();
+        shuffled.shuffle(&mut StdRng::seed_from_u64(seed));
+        let map = shuffled.into_iter().collect::<HashMap<_, _>>();
+        let restored = restore_secrets(&redacted, &map);
+        assert_eq!(
+            restored, expected,
+            "restore output drifted for trial {seed}"
+        );
+    }
+}
+
+#[test]
+fn regression_restore_adjacent_markers() {
+    let map = HashMap::from([
+        ("[REDACTED_SECRET:a:111]".to_string(), "X".to_string()),
+        ("[REDACTED_SECRET:b:222]".to_string(), "Y".to_string()),
+    ]);
+
+    let restored = restore_secrets("[REDACTED_SECRET:a:111][REDACTED_SECRET:b:222]", &map);
+
+    assert_eq!(restored, "XY");
+}
+
+#[test]
+fn regression_restore_marker_adjacent_to_text() {
+    let map = HashMap::from([("[REDACTED_SECRET:a:111]".to_string(), "VALUE".to_string())]);
+
+    let restored = restore_secrets("prefix[REDACTED_SECRET:a:111]suffix", &map);
+
+    assert_eq!(restored, "prefixVALUEsuffix");
+}
+
+#[test]
+fn regression_restore_unknown_marker_passes_through() {
+    let map = HashMap::new();
+    let input = "prefix[REDACTED_SECRET:slack-bot-token:unknown999]suffix";
+
+    let restored = restore_secrets(input, &map);
+
+    assert_eq!(restored, input);
+}
+
+#[test]
+fn regression_marker_generated_redaction_key_matches_regex() {
+    let marker_re = marker_regex();
+
+    for index in 0..1000 {
+        let password = format!("password-{index}-with-suffix");
+        let result = redact_password(&password, &password, &HashMap::new());
+        let key = result
+            .redaction_map
+            .keys()
+            .next()
+            .expect("redact_password should generate one key");
+        assert!(
+            marker_re.is_match(key),
+            "generated key did not match regex: {key}"
+        );
+    }
+}
+
+#[test]
+fn regression_marker_regex_does_not_match_extra_colons() {
+    let marker_re = marker_regex();
+    let malformed = "[REDACTED_SECRET:a:b:c]";
+
+    assert!(
+        marker_re.find(malformed).is_none(),
+        "marker regex should ignore malformed markers with extra colons"
+    );
+}


### PR DESCRIPTION
## Description

Fix secret redaction regressions that caused fresh secrets to be silently skipped and restoration to chain-replace incorrectly.

### Bugs fixed

1. **Double-redaction early-return skip**: `redact_secrets` returned immediately when `content.contains("[REDACTED_SECRET:")`, so any *new* secret in the same text was never detected. Overhaul to use span-based overlap checks — existing markers are protected from re-detection while fresh secrets are still redacted.

2. **`restore_secrets` chain-replacement**: Iterating a `HashMap` and calling `String::replace` per entry could rewrite previously-restored markers when a secret value resembled another key. Rewrite to walk left-to-right with the marker regex, replacing each marker exactly once in order.

3. **`redact_password` early-return skip**: Same `contains("[REDACTED_SECRET:")` guard prevented password redaction when any stale marker was present. Fixed with the same span-based overlap filter.

4. **CLI secret leak in prompts**: User input and feedback in `mode_async.rs` and `mode_interactive.rs` were not routed through `SecretManager::redact_and_store_secrets`, so secrets reached the LLM in plaintext. wired redaction into both paths.

## Related Issues

Fixes secret redaction regressions reported by Abdalla.

## Changes Made

- `libs/shared/src/secrets/mod.rs`: Span-aware redaction with `find_protected_spans` / `overlaps_protected_span`; left-to-right `restore_secrets` using `REDACTED_SECRET_MARKER_RE` regex; `redact_password` uses same span filter
- `cli/src/commands/agent/run/mode_async.rs`: Route user input + feedback through `SecretManager::redact_and_store_secrets`
- `cli/src/commands/agent/run/mode_interactive.rs`: Route user input through `SecretManager::redact_and_store_secrets`
- `libs/shared/tests/secret_redaction_regressions.rs`: 18-test regression suite

## Testing

- [x] All tests pass locally (`cargo test -p stakpak-shared --test secret_redaction_regressions` — 18/18)
- [x] `cargo clippy --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — clean
- [x] Added tests for all new functionality

## Breaking Changes

None — public API signatures unchanged; internal logic fixes only.