### PR TITLE
feat(mcp/server): propagate profile env to child processes & harden subagent quoting

### DIFF
--- a/libs/mcp/server/src/local_tools.rs
+++ b/libs/mcp/server/src/local_tools.rs
@@ -22,7 +22,7 @@ use stakpak_shared::models::integrations::mcp::CallToolResultExt;
 use stakpak_shared::models::integrations::openai::{
     ProgressType, TaskPauseInfo, TaskUpdate, ToolCallResultProgress,
 };
-use stakpak_shared::task_manager::TaskInfo;
+use stakpak_shared::task_manager::{StartTaskOptions, TaskInfo};
 use stakpak_shared::tls_client::{TlsClientConfig, create_tls_client};
 use stakpak_shared::utils::{
     LocalFileSystemProvider, generate_directory_tree, handle_large_output, sanitize_text_output,
@@ -401,7 +401,15 @@ Use the get_all_tasks tool to monitor task progress, or the cancel_task tool to 
 
         let result = self
             .get_task_manager()
-            .start_task(command, description, timeout_duration, None)
+            .start_task(
+                command,
+                StartTaskOptions {
+                    description,
+                    timeout: timeout_duration,
+                    remote_connection: None,
+                    child_env: self.task_child_env_defaults(None),
+                },
+            )
             .await;
 
         Self::format_task_result(result)
@@ -454,13 +462,17 @@ Use the get_all_tasks tool to monitor task progress, or the cancel_task tool to 
             private_key_path,
         };
 
+        let child_env = self.task_child_env_defaults(Some(&remote_connection));
         let result = self
             .get_task_manager()
             .start_task(
                 command,
-                description,
-                timeout_duration,
-                Some(remote_connection),
+                StartTaskOptions {
+                    description,
+                    timeout: timeout_duration,
+                    remote_connection: Some(remote_connection),
+                    child_env,
+                },
             )
             .await;
 
@@ -1271,6 +1283,31 @@ SAFETY NOTES:
         }
     }
 
+    fn apply_local_command_env(&self, cmd: &mut Command) {
+        if let Some(profile_name) = self.local_runtime_defaults.active_profile_name() {
+            cmd.env("STAKPAK_PROFILE", profile_name);
+        }
+    }
+
+    fn local_child_env_defaults(&self) -> std::collections::HashMap<String, String> {
+        let mut child_env = std::collections::HashMap::new();
+        if let Some(profile_name) = self.local_runtime_defaults.active_profile_name() {
+            child_env.insert("STAKPAK_PROFILE".to_string(), profile_name.to_string());
+        }
+        child_env
+    }
+
+    fn task_child_env_defaults(
+        &self,
+        remote_connection: Option<&RemoteConnectionInfo>,
+    ) -> std::collections::HashMap<String, String> {
+        if remote_connection.is_some() {
+            std::collections::HashMap::new()
+        } else {
+            self.local_child_env_defaults()
+        }
+    }
+
     /// Execute command either locally or remotely based on parameters.
     async fn execute_command_unified(
         &self,
@@ -1339,6 +1376,7 @@ SAFETY NOTES:
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
+        self.apply_local_command_env(&mut cmd);
         #[cfg(unix)]
         {
             cmd.env("DEBIAN_FRONTEND", "noninteractive")
@@ -3367,6 +3405,94 @@ mod tests {
         assert!(
             result.is_err(),
             "RunCommandRequest must reject unknown 'password' field"
+        );
+    }
+
+    fn local_container_with_profile(profile_name: Option<&str>) -> ToolContainer {
+        let task_manager = stakpak_shared::task_manager::TaskManager::new();
+        ToolContainer::new(
+            None,
+            crate::EnabledToolsConfig::default(),
+            task_manager.handle(),
+            ToolContainer::tool_router_local(),
+            Vec::new(),
+            crate::SubagentConfig {
+                profile_name: profile_name.map(str::to_string),
+                config_path: None,
+                model: None,
+            },
+        )
+        .expect("tool container should be constructed")
+    }
+
+    async fn run_profile_probe(container: &ToolContainer, shell: &str) -> String {
+        let mut cmd = tokio::process::Command::new("sh");
+        cmd.env_remove("STAKPAK_PROFILE")
+            .arg("-c")
+            .arg(shell)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+        container.apply_local_command_env(&mut cmd);
+
+        let output = cmd.output().await.expect("profile probe should spawn");
+        assert!(
+            output.status.success(),
+            "profile probe should succeed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).expect("profile probe output should be utf8")
+    }
+
+    #[tokio::test]
+    async fn run_command_spawn_inherits_active_profile_env() {
+        let container = local_container_with_profile(Some("ops"));
+
+        let output = run_profile_probe(&container, "printf '%s' \"$STAKPAK_PROFILE\"").await;
+
+        assert_eq!(output, "ops");
+    }
+
+    #[tokio::test]
+    async fn run_command_spawn_does_not_inject_empty_profile_env() {
+        let container = local_container_with_profile(Some("   "));
+
+        let output = run_profile_probe(
+            &container,
+            "if [ \"${STAKPAK_PROFILE+x}\" = x ]; then printf 'present:%s' \"$STAKPAK_PROFILE\"; else printf missing; fi",
+        )
+        .await;
+
+        assert_eq!(output, "missing");
+    }
+
+    #[tokio::test]
+    async fn run_command_inline_profile_env_override_wins() {
+        let container = local_container_with_profile(Some("ops"));
+
+        let output = run_profile_probe(
+            &container,
+            "STAKPAK_PROFILE=readonly sh -c 'printf %s \"$STAKPAK_PROFILE\"'",
+        )
+        .await;
+
+        assert_eq!(output, "readonly");
+    }
+
+    #[test]
+    fn remote_command_task_gets_no_local_profile_child_env_defaults() {
+        let container = local_container_with_profile(Some("ops"));
+        let remote_connection = RemoteConnectionInfo {
+            connection_string: "user@example.com".to_string(),
+            password: None,
+            private_key_path: None,
+        };
+
+        let child_env = container.task_child_env_defaults(Some(&remote_connection));
+
+        assert!(
+            !child_env.contains_key("STAKPAK_PROFILE"),
+            "remote task child env must not inherit the local profile"
         );
     }
 

--- a/libs/mcp/server/src/subagent_tools.rs
+++ b/libs/mcp/server/src/subagent_tools.rs
@@ -9,6 +9,7 @@ use rmcp::{
 use serde::Deserialize;
 use serde_json::json;
 use stakpak_shared::local_store::LocalStore;
+use stakpak_shared::task_manager::StartTaskOptions;
 use tracing::{error, info};
 use uuid::Uuid;
 
@@ -47,10 +48,12 @@ pub struct DynamicSubagentRequest {
     pub tools: Vec<String>,
 
     /// Model to use (the "M" in the 4-tuple).
-    #[schemars(
-        description = "Subagent model override in provider/short_name format. Used verbatim when set; otherwise resolution falls back through profile config, built-in default for the parent provider, then the parent model."
-    )]
+    /// Not exposed to the LLM — resolved automatically from profile config,
+    /// built-in defaults for the parent provider, or inherited from the parent model.
+    #[serde(default, skip_deserializing)]
+    #[schemars(skip)]
     pub model: Option<String>,
+
     /// Maximum steps the subagent can take (default: 30)
     #[schemars(description = "Maximum steps the subagent can take (default: 30)")]
     pub max_steps: Option<usize>,
@@ -116,15 +119,13 @@ PARAMETERS:
 - instruction: What the subagent should do - be specific and include success criteria
 - context: (Optional) Curated context from previous work - include relevant findings, key references, failed approaches
 - tools: Array of tool names to grant (follow least-privilege - minimum tools required)
-- model: (Optional) Subagent model override in provider/short_name format; used verbatim when set, otherwise the resolution chain below applies
 - max_steps: (Optional) Maximum steps, default 30
 - enable_sandbox: (Optional) Run in isolated warden container with security policies
 
 MODEL RESOLUTION:
-1. Caller-supplied model override
-2. Profile [subagent].model setting
-3. Built-in default for the parent provider
-4. Parent model verbatim (silent inherit)
+1. Profile [subagent].model setting
+2. Built-in default for the parent provider
+3. Parent model verbatim (silent inherit)
 
 WHEN TO USE:
 - When you need fine-grained control over subagent capabilities
@@ -240,7 +241,13 @@ The subagent runs asynchronously. Use get_task_details to monitor progress."
         };
         let task_info = match self
             .get_task_manager()
-            .start_task(subagent_command, Some(task_description), None, None)
+            .start_task(
+                subagent_command,
+                StartTaskOptions {
+                    description: Some(task_description),
+                    ..StartTaskOptions::default()
+                },
+            )
             .await
         {
             Ok(task_info) => task_info,
@@ -527,7 +534,11 @@ NOTES:
             args.push(tool.clone());
         }
 
-        let mut command = args.join(" ");
+        let mut command = args
+            .iter()
+            .map(|arg| shell_quote_arg(arg))
+            .collect::<Vec<_>>()
+            .join(" ");
 
         // If sandbox mode is enabled, wrap the command in warden.
         //
@@ -569,10 +580,17 @@ NOTES:
 
             let stakpak_image = stakpak_agent_image();
 
-            let mut warden_command = format!("{} warden wrap {}", current_exe, stakpak_image);
+            let mut warden_command = format!(
+                "{} warden wrap {}",
+                shell_quote_arg(&current_exe),
+                shell_quote_arg(&stakpak_image)
+            );
 
             let warden_prompt_path = format!("/tmp/{}", prompt_filename);
-            warden_command.push_str(&format!(" -v {}:{}", prompt_file_path, warden_prompt_path));
+            warden_command.push_str(&format!(
+                " -v {}",
+                shell_quote_arg(&format!("{}:{}", prompt_file_path, warden_prompt_path))
+            ));
 
             // Profile-overlay precedence: user `-v` flags are appended after
             // prepare_volumes() defaults, so this overlay wins.
@@ -580,9 +598,12 @@ NOTES:
                 let path = Path::new(p);
                 if path.exists() && path.is_file() {
                     warden_command.push_str(&format!(
-                        " -v {}:{}:ro",
-                        path.display(),
-                        CONTAINER_CONFIG_PATH
+                        " -v {}",
+                        shell_quote_arg(&format!(
+                            "{}:{}:ro",
+                            path.display(),
+                            CONTAINER_CONFIG_PATH
+                        ))
                     ));
                     Some(CONTAINER_CONFIG_PATH.to_string())
                 } else {
@@ -592,7 +613,7 @@ NOTES:
 
             for arg in warden_ak_store_args(host_knowledge_root.as_deref()) {
                 warden_command.push(' ');
-                warden_command.push_str(&arg);
+                warden_command.push_str(&shell_quote_arg(&arg));
             }
 
             let inner_command = command.replace(&prompt_file_path, &warden_prompt_path);
@@ -618,6 +639,20 @@ struct ResolvedModel {
 
 fn trimmed_non_empty(value: Option<&str>) -> Option<&str> {
     value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn shell_quote_arg(value: &str) -> String {
+    if value.is_empty() {
+        return "''".to_string();
+    }
+
+    if value.bytes().all(|byte| {
+        byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'/' | b':' | b'=')
+    }) {
+        return value.to_string();
+    }
+
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn default_subagent_model(provider: &str) -> Option<&'static str> {
@@ -678,7 +713,63 @@ fn resolve_subagent_model(
 
 #[cfg(test)]
 mod tests {
-    use super::{default_subagent_model, resolve_subagent_model};
+    use super::{DynamicSubagentRequest, default_subagent_model, resolve_subagent_model};
+    use crate::{EnabledToolsConfig, SubagentConfig, ToolContainer};
+    use stakpak_shared::task_manager::TaskManager;
+
+    #[test]
+    fn deserialized_dynamic_subagent_request_ignores_caller_model() {
+        let request: DynamicSubagentRequest = serde_json::from_value(serde_json::json!({
+            "description": "probe",
+            "instructions": "do the thing",
+            "tools": ["stakpak__view"],
+            "model": "evil/model; touch /tmp/pwned",
+            "max_steps": 1,
+            "enable_sandbox": false
+        }))
+        .expect("request should deserialize even when model is supplied");
+
+        assert_eq!(request.model, None);
+    }
+
+    #[test]
+    fn dynamic_subagent_tool_description_does_not_expose_model_parameter() {
+        let source = include_str!("subagent_tools.rs");
+
+        assert!(!source.contains(&["- ", "model:"].concat()));
+        assert!(!source.contains(&["Caller-supplied", " model override"].concat()));
+    }
+
+    #[test]
+    fn dynamic_subagent_command_shell_quotes_model_and_tools() {
+        let task_manager = TaskManager::new();
+        let container = ToolContainer::new(
+            None,
+            EnabledToolsConfig::default(),
+            task_manager.handle(),
+            ToolContainer::tool_router_subagent(),
+            Vec::new(),
+            SubagentConfig::default(),
+        )
+        .expect("tool container should be constructed");
+
+        let command = container
+            .build_dynamic_subagent_command(
+                "do the thing",
+                None,
+                &["stakpak__view; touch /tmp/tool_pwn".to_string()],
+                Some("provider/model; touch /tmp/model_pwn"),
+                1,
+                false,
+                None,
+                None,
+                None,
+            )
+            .expect("subagent command should be built");
+
+        assert!(command.contains("--model 'provider/model; touch /tmp/model_pwn'"));
+        assert!(command.contains("-t 'stakpak__view; touch /tmp/tool_pwn'"));
+    }
 
     #[test]
     fn caller_override_wins_verbatim() {

--- a/libs/mcp/server/src/tool_container.rs
+++ b/libs/mcp/server/src/tool_container.rs
@@ -10,6 +10,27 @@ use stakpak_shared::task_manager::TaskManagerHandle;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+#[derive(Clone, Debug, Default)]
+pub struct LocalToolRuntimeDefaults {
+    active_profile_name: Option<String>,
+}
+
+impl LocalToolRuntimeDefaults {
+    pub fn new(active_profile_name: Option<String>) -> Self {
+        let active_profile_name = active_profile_name
+            .map(|profile| profile.trim().to_string())
+            .filter(|profile| !profile.is_empty());
+
+        Self {
+            active_profile_name,
+        }
+    }
+
+    pub fn active_profile_name(&self) -> Option<&str> {
+        self.active_profile_name.as_deref()
+    }
+}
+
 #[derive(Clone)]
 pub struct ToolContainer {
     pub client: Option<Arc<dyn AgentProvider>>,
@@ -19,6 +40,7 @@ pub struct ToolContainer {
     pub tool_router: ToolRouter<Self>,
     pub skill_directories: Vec<PathBuf>,
     pub subagent_config: SubagentConfig,
+    pub local_runtime_defaults: LocalToolRuntimeDefaults,
 }
 
 #[tool_router]
@@ -31,6 +53,9 @@ impl ToolContainer {
         skill_directories: Vec<PathBuf>,
         subagent_config: SubagentConfig,
     ) -> Result<Self, String> {
+        let local_runtime_defaults =
+            LocalToolRuntimeDefaults::new(subagent_config.profile_name.clone());
+
         Ok(Self {
             client,
             task_manager,
@@ -39,6 +64,7 @@ impl ToolContainer {
             tool_router,
             skill_directories,
             subagent_config,
+            local_runtime_defaults,
         })
     }
 

--- a/libs/shared/src/task_manager.rs
+++ b/libs/shared/src/task_manager.rs
@@ -102,6 +102,7 @@ pub struct Task {
     pub duration: Option<Duration>,
     pub timeout: Option<Duration>,
     pub pause_info: Option<PauseInfo>,
+    pub child_env: HashMap<String, String>,
 }
 
 pub struct TaskEntry {
@@ -157,6 +158,22 @@ pub struct TaskCompletion {
     pub final_status: TaskStatus,
 }
 
+struct TaskExecution {
+    id: TaskId,
+    command: String,
+    remote_connection: Option<RemoteConnectionInfo>,
+    task_timeout: Option<Duration>,
+    child_env: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct StartTaskOptions {
+    pub description: Option<String>,
+    pub timeout: Option<Duration>,
+    pub remote_connection: Option<RemoteConnectionInfo>,
+    pub child_env: HashMap<String, String>,
+}
+
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct PauseInfo {
     pub checkpoint_id: Option<String>,
@@ -187,9 +204,7 @@ pub enum TaskMessage {
     Start {
         id: Option<TaskId>,
         command: String,
-        description: Option<String>,
-        remote_connection: Option<RemoteConnectionInfo>,
-        timeout: Option<Duration>,
+        options: StartTaskOptions,
         response_tx: oneshot::Sender<Result<TaskId, TaskError>>,
     },
     Cancel {
@@ -291,21 +306,11 @@ impl TaskManager {
             TaskMessage::Start {
                 id,
                 command,
-                description,
-                remote_connection,
-                timeout,
+                options,
                 response_tx,
             } => {
                 let task_id = id.unwrap_or_else(|| generate_simple_id(6));
-                let result = self
-                    .start_task(
-                        task_id.clone(),
-                        command,
-                        description,
-                        timeout,
-                        remote_connection,
-                    )
-                    .await;
+                let result = self.start_task(task_id.clone(), command, options).await;
                 let _ = response_tx.send(result.map(|_| task_id.clone()));
                 false
             }
@@ -407,13 +412,18 @@ impl TaskManager {
         &mut self,
         id: TaskId,
         command: String,
-        description: Option<String>,
-        timeout: Option<Duration>,
-        remote_connection: Option<RemoteConnectionInfo>,
+        options: StartTaskOptions,
     ) -> Result<(), TaskError> {
         if self.tasks.contains_key(&id) {
             return Err(TaskError::TaskAlreadyRunning(id));
         }
+
+        let StartTaskOptions {
+            description,
+            timeout,
+            remote_connection,
+            child_env,
+        } = options;
 
         let task = Task {
             id: id.clone(),
@@ -427,6 +437,7 @@ impl TaskManager {
             duration: None,
             timeout,
             pause_info: None,
+            child_env: child_env.clone(),
         };
 
         let (cancel_tx, cancel_rx) = oneshot::channel();
@@ -436,14 +447,16 @@ impl TaskManager {
         let is_remote_task = remote_connection.is_some();
 
         // Spawn task immediately - SSH connection happens inside the task
-        let handle = tokio::spawn(Self::execute_task(
-            id.clone(),
+        let execution = TaskExecution {
+            id: id.clone(),
             command,
             remote_connection,
-            timeout,
-            cancel_rx,
-            process_tx,
-            task_tx,
+            task_timeout: timeout,
+            child_env,
+        };
+
+        let handle = tokio::spawn(Self::execute_task(
+            execution, cancel_rx, process_tx, task_tx,
         ));
 
         let entry = TaskEntry {
@@ -496,15 +509,18 @@ impl TaskManager {
 
         let remote_connection = entry.task.remote_connection.clone();
         let timeout = entry.task.timeout;
+        let child_env = entry.task.child_env.clone();
+
+        let execution = TaskExecution {
+            id: id.clone(),
+            command,
+            remote_connection: remote_connection.clone(),
+            task_timeout: timeout,
+            child_env,
+        };
 
         let handle = tokio::spawn(Self::execute_task(
-            id.clone(),
-            command,
-            remote_connection.clone(),
-            timeout,
-            cancel_rx,
-            process_tx,
-            task_tx,
+            execution, cancel_rx, process_tx, task_tx,
         ));
 
         entry.handle = handle;
@@ -542,14 +558,18 @@ impl TaskManager {
     }
 
     async fn execute_task(
-        id: TaskId,
-        command: String,
-        remote_connection: Option<RemoteConnectionInfo>,
-        task_timeout: Option<Duration>,
+        execution: TaskExecution,
         mut cancel_rx: oneshot::Receiver<()>,
         process_tx: oneshot::Sender<u32>,
         task_tx: mpsc::UnboundedSender<TaskMessage>,
     ) {
+        let TaskExecution {
+            id,
+            command,
+            remote_connection,
+            task_timeout,
+            child_env,
+        } = execution;
         let completion = if let Some(remote_info) = remote_connection {
             // Remote execution
             Self::execute_remote_task(
@@ -570,6 +590,7 @@ impl TaskManager {
                 &mut cancel_rx,
                 process_tx,
                 &task_tx,
+                child_env,
             )
             .await
         };
@@ -588,6 +609,7 @@ impl TaskManager {
         cancel_rx: &mut oneshot::Receiver<()>,
         process_tx: oneshot::Sender<u32>,
         task_tx: &mpsc::UnboundedSender<TaskMessage>,
+        child_env: HashMap<String, String>,
     ) -> TaskCompletion {
         let mut cmd = Command::new("sh");
         cmd.arg("-c")
@@ -595,6 +617,9 @@ impl TaskManager {
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        for (key, value) in child_env {
+            cmd.env(key, value);
+        }
         #[cfg(unix)]
         {
             cmd.env("DEBIAN_FRONTEND", "noninteractive")
@@ -861,9 +886,7 @@ impl TaskManagerHandle {
     pub async fn start_task(
         &self,
         command: String,
-        description: Option<String>,
-        timeout: Option<Duration>,
-        remote_connection: Option<RemoteConnectionInfo>,
+        options: StartTaskOptions,
     ) -> Result<TaskInfo, TaskError> {
         let (response_tx, response_rx) = oneshot::channel();
 
@@ -871,9 +894,7 @@ impl TaskManagerHandle {
             .send(TaskMessage::Start {
                 id: None,
                 command: command.clone(),
-                description,
-                remote_connection: remote_connection.clone(),
-                timeout,
+                options,
                 response_tx,
             })
             .map_err(|_| TaskError::ManagerShutdown)?;
@@ -1021,7 +1042,7 @@ mod tests {
 
         // Start a background task
         let task_info = handle
-            .start_task("sleep 5".to_string(), None, None, None)
+            .start_task("sleep 5".to_string(), StartTaskOptions::default())
             .await
             .expect("Failed to start task");
 
@@ -1057,7 +1078,7 @@ mod tests {
 
         // Start a long-running background task
         let task_info = handle
-            .start_task("sleep 10".to_string(), None, None, None)
+            .start_task("sleep 10".to_string(), StartTaskOptions::default())
             .await
             .expect("Failed to start task");
 
@@ -1093,7 +1114,10 @@ mod tests {
 
         // Start a simple task
         let task_info = handle
-            .start_task("echo 'Hello, World!'".to_string(), None, None, None)
+            .start_task(
+                "echo 'Hello, World!'".to_string(),
+                StartTaskOptions::default(),
+            )
             .await
             .expect("Failed to start task");
 
@@ -1123,6 +1147,103 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn task_manager_local_task_receives_child_env_defaults() {
+        let task_manager = TaskManager::new();
+        let handle = task_manager.handle();
+
+        let _manager_handle = tokio::spawn(async move {
+            task_manager.run().await;
+        });
+
+        let mut child_env = HashMap::new();
+        child_env.insert("STAKPAK_PROFILE".to_string(), "ops".to_string());
+
+        let task_info = handle
+            .start_task(
+                "printf '%s\\n' \"$STAKPAK_PROFILE\"".to_string(),
+                StartTaskOptions {
+                    child_env,
+                    ..StartTaskOptions::default()
+                },
+            )
+            .await
+            .expect("task should start with child env defaults");
+
+        sleep(Duration::from_millis(500)).await;
+
+        let details = handle
+            .get_task_details(task_info.id.clone())
+            .await
+            .expect("task details request should succeed")
+            .expect("task details should exist");
+
+        assert_eq!(details.status, TaskStatus::Completed);
+        assert_eq!(details.output.as_deref(), Some("ops\n"));
+
+        handle
+            .shutdown()
+            .await
+            .expect("Failed to shutdown task manager");
+    }
+
+    #[tokio::test]
+    async fn resumed_local_task_reuses_child_env_defaults() {
+        let task_manager = TaskManager::new();
+        let handle = task_manager.handle();
+
+        let _manager_handle = tokio::spawn(async move {
+            task_manager.run().await;
+        });
+
+        let mut child_env = HashMap::new();
+        child_env.insert("STAKPAK_PROFILE".to_string(), "ops".to_string());
+
+        let task_info = handle
+            .start_task(
+                "exit 10".to_string(),
+                StartTaskOptions {
+                    child_env,
+                    ..StartTaskOptions::default()
+                },
+            )
+            .await
+            .expect("pausing task should start");
+
+        sleep(Duration::from_millis(500)).await;
+
+        let paused = handle
+            .get_task_details(task_info.id.clone())
+            .await
+            .expect("task details request should succeed")
+            .expect("task details should exist");
+        assert_eq!(paused.status, TaskStatus::Paused);
+
+        handle
+            .resume_task(
+                task_info.id.clone(),
+                "printf '%s\\n' \"$STAKPAK_PROFILE\"".to_string(),
+            )
+            .await
+            .expect("paused task should resume");
+
+        sleep(Duration::from_millis(500)).await;
+
+        let details = handle
+            .get_task_details(task_info.id)
+            .await
+            .expect("task details request should succeed")
+            .expect("task details should exist");
+
+        assert_eq!(details.status, TaskStatus::Completed);
+        assert_eq!(details.output.as_deref(), Some("ops\n"));
+
+        handle
+            .shutdown()
+            .await
+            .expect("Failed to shutdown task manager");
+    }
+
+    #[tokio::test]
     async fn test_task_manager_detects_immediate_failure() {
         let task_manager = TaskManager::new();
         let handle = task_manager.handle();
@@ -1134,7 +1255,10 @@ mod tests {
 
         // Start a task that will fail immediately
         let result = handle
-            .start_task("nonexistent_command_12345".to_string(), None, None, None)
+            .start_task(
+                "nonexistent_command_12345".to_string(),
+                StartTaskOptions::default(),
+            )
             .await;
 
         // Should get a TaskFailedOnStart error
@@ -1158,7 +1282,7 @@ mod tests {
 
         // Start a long-running task
         let _task_info = handle
-            .start_task("sleep 30".to_string(), None, None, None)
+            .start_task("sleep 30".to_string(), StartTaskOptions::default())
             .await
             .expect("Failed to start task");
 
@@ -1188,7 +1312,10 @@ mod tests {
         // Start a task that writes a marker file while running
         let marker = format!("/tmp/stakpak_test_drop_{}", std::process::id());
         let task_info = handle
-            .start_task(format!("touch {} && sleep 30", marker), None, None, None)
+            .start_task(
+                format!("touch {} && sleep 30", marker),
+                StartTaskOptions::default(),
+            )
             .await
             .expect("Failed to start task");
 
@@ -1219,7 +1346,7 @@ mod tests {
 
         // Start a task that will exit with non-zero code immediately
         let result = handle
-            .start_task("exit 1".to_string(), None, None, None)
+            .start_task("exit 1".to_string(), StartTaskOptions::default())
             .await;
 
         // Should get a TaskFailedOnStart error


### PR DESCRIPTION
## Description

Propagates the active `STAKPAK_PROFILE` environment variable to locally-spawned task/command child processes and hardens subagent command construction against shell injection.

## Changes Made

- **Profile env propagation**: Adds `LocalToolRuntimeDefaults` to `ToolContainer` that injects `STAKPAK_PROFILE` into local child environments. Remote tasks are excluded — they must not inherit the local profile.
- **StartTaskOptions refactor**: Consolidates `start_task` parameters (description, timeout, remote_connection) into a single `StartTaskOptions` struct with an additional `child_env` field. Resumed tasks carry forward the same `child_env` from their initial `Task` entry.
- **Subagent model field hardening**: Makes `DynamicSubagentRequest.model` non-deserializable (`skip_deserializing`) so callers cannot inject arbitrary model strings via JSON payloads.
- **Shell quoting**: Adds `shell_quote_arg()` to properly quote model names, tool names, volume paths, and executables in subagent commands — preventing injection from values containing semicolons, spaces, or shell metacharacters.

## Testing

- [x] All tests pass locally (`cargo test -p stakpak-shared -p stakpak-mcp-server`)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets` clean
- [x] New tests: profile env inheritance, empty-profile suppression, env override precedence, remote-task isolation, shell quoting, model deserialization blocklist

## Breaking Changes

None — `StartTaskOptions` defaults match the previous positional-parameter behavior. Callers using `DynamicSubagentRequest.model` externally are now silently ignored (field was already caller-controlled; this hardens it).