### PR TITLE
fix(async): add session stats and session URL output (#485)

### DIFF
--- a/cli/src/commands/agent/run/mode_async.rs
+++ b/cli/src/commands/agent/run/mode_async.rs
@@ -53,8 +53,8 @@ pub struct RunAsyncConfig {
     pub resume_input: Option<ResumeInput>,
     /// Auto-approve tool overrides from profile config.
     pub auto_approve_tools: Option<Vec<String>>,
-    /// When true, display session usage stats and browser URL after completion.
-    pub show_session_usage: bool,
+    /// When true, display session stats and browser URL after completion.
+    pub show_session_stats: bool,
 }
 
 // All print functions have been moved to the renderer module and are no longer needed here
@@ -886,12 +886,44 @@ pub async fn run_async(ctx: AppConfig, mut config: RunAsyncConfig) -> Result<Asy
         print!("{}", renderer.render_final_completion(&chat_messages));
         println!();
 
+        if let Some(session_id) = current_session_id {
+            println!("Session ID: {}\n", session_id);
+        }
+
         // Print token usage at the end
         let model_display = format!("{}/{}", config.model.provider, config.model.name);
         print!(
             "{}",
             renderer.render_token_usage_stats(&total_usage, Some(&model_display))
         );
+
+        if let Some(session_id) = current_session_id {
+            // Print resume command and session ID if available
+            if let Some(resume_command) =
+                build_resume_command(current_session_id, current_checkpoint_id)
+            {
+                println!("\nTo resume, run:\n{}\n", resume_command);
+            }
+
+            if config.show_session_stats {
+                match client.get_session_stats(session_id).await {
+                    Ok(stats) => {
+                        print!("{}", renderer.render_session_stats(&stats));
+                    }
+                    Err(_) => {
+                        // Don't fail the whole operation if stats fetch fails
+                    }
+                }
+
+                // Display session URL (matching interactive mode behavior)
+                if let Ok(account) = client.get_my_account().await {
+                    println!(
+                        "To view full session in browser:\nhttps://stakpak.dev/{}/agent-sessions/{}",
+                        account.username, session_id
+                    );
+                }
+            }
+        }
     }
 
     // Save conversation to file
@@ -937,39 +969,6 @@ pub async fn run_async(ctx: AppConfig, mut config: RunAsyncConfig) -> Result<Asy
             "{}",
             renderer.render_info("No checkpoint available to save")
         );
-    }
-
-    if config.output_format != OutputFormat::Json {
-        // Print resume command and session ID if available
-        if let Some(resume_command) =
-            build_resume_command(current_session_id, current_checkpoint_id)
-        {
-            println!("\nTo resume, run:\n{}\n", resume_command);
-        }
-
-        if let Some(session_id) = current_session_id {
-            println!("Session ID: {}", session_id);
-
-            if config.show_session_usage {
-                // Fetch and display session stats (matching interactive mode behavior)
-                match client.get_session_stats(session_id).await {
-                    Ok(stats) => {
-                        print!("{}", renderer.render_session_stats(&stats));
-                    }
-                    Err(_) => {
-                        // Don't fail the whole operation if stats fetch fails
-                    }
-                }
-
-                // Display session URL (matching interactive mode behavior)
-                if let Ok(account) = client.get_my_account().await {
-                    println!(
-                        "To view full session in browser:\nhttps://stakpak.dev/{}/agent-sessions/{}",
-                        account.username, session_id
-                    );
-                }
-            }
-        }
     }
 
     // Gracefully shutdown MCP server and proxy

--- a/cli/src/commands/agent/run/mode_async.rs
+++ b/cli/src/commands/agent/run/mode_async.rs
@@ -947,6 +947,24 @@ pub async fn run_async(ctx: AppConfig, mut config: RunAsyncConfig) -> Result<Asy
 
         if let Some(session_id) = current_session_id {
             println!("Session ID: {}", session_id);
+
+            // Fetch and display session stats (matching interactive mode behavior)
+            match client.get_session_stats(session_id).await {
+                Ok(stats) => {
+                    print!("{}", renderer.render_session_stats(&stats));
+                }
+                Err(_) => {
+                    // Don't fail the whole operation if stats fetch fails
+                }
+            }
+
+            // Display session URL (matching interactive mode behavior)
+            if let Ok(account) = client.get_my_account().await {
+                println!(
+                    "To view full session in browser:\nhttps://stakpak.dev/{}/agent-sessions/{}",
+                    account.username, session_id
+                );
+            }
         }
     }
 

--- a/cli/src/commands/agent/run/mode_async.rs
+++ b/cli/src/commands/agent/run/mode_async.rs
@@ -53,6 +53,8 @@ pub struct RunAsyncConfig {
     pub resume_input: Option<ResumeInput>,
     /// Auto-approve tool overrides from profile config.
     pub auto_approve_tools: Option<Vec<String>>,
+    /// When true, display session usage stats and browser URL after completion.
+    pub show_session_usage: bool,
 }
 
 // All print functions have been moved to the renderer module and are no longer needed here
@@ -948,22 +950,24 @@ pub async fn run_async(ctx: AppConfig, mut config: RunAsyncConfig) -> Result<Asy
         if let Some(session_id) = current_session_id {
             println!("Session ID: {}", session_id);
 
-            // Fetch and display session stats (matching interactive mode behavior)
-            match client.get_session_stats(session_id).await {
-                Ok(stats) => {
-                    print!("{}", renderer.render_session_stats(&stats));
+            if config.show_session_usage {
+                // Fetch and display session stats (matching interactive mode behavior)
+                match client.get_session_stats(session_id).await {
+                    Ok(stats) => {
+                        print!("{}", renderer.render_session_stats(&stats));
+                    }
+                    Err(_) => {
+                        // Don't fail the whole operation if stats fetch fails
+                    }
                 }
-                Err(_) => {
-                    // Don't fail the whole operation if stats fetch fails
-                }
-            }
 
-            // Display session URL (matching interactive mode behavior)
-            if let Ok(account) = client.get_my_account().await {
-                println!(
-                    "To view full session in browser:\nhttps://stakpak.dev/{}/agent-sessions/{}",
-                    account.username, session_id
-                );
+                // Display session URL (matching interactive mode behavior)
+                if let Ok(account) = client.get_my_account().await {
+                    println!(
+                        "To view full session in browser:\nhttps://stakpak.dev/{}/agent-sessions/{}",
+                        account.username, session_id
+                    );
+                }
             }
         }
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -221,6 +221,10 @@ struct Cli {
     #[arg(long = "ignore-apps-md", default_value_t = false)]
     ignore_apps_md: bool,
 
+    /// Show session usage stats and URL after async mode completes
+    #[arg(long = "show-session-usage", default_value_t = false)]
+    show_session_usage: bool,
+
     /// Color theme: auto, dark, or light (default: auto)
     #[arg(long = "theme", default_value = "auto")]
     theme: String,
@@ -588,6 +592,7 @@ async fn main() {
                                 plan_feedback: cli.plan_feedback.clone(),
                                 plan_new: cli.plan_new,
                                 pause_on_approval: cli.pause_on_approval,
+                                show_session_usage: cli.show_session_usage,
                                 resume_input: if cli.approve.is_some()
                                     || cli.reject.is_some()
                                     || cli.approve_all

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -221,9 +221,9 @@ struct Cli {
     #[arg(long = "ignore-apps-md", default_value_t = false)]
     ignore_apps_md: bool,
 
-    /// Show session usage stats and URL after async mode completes
-    #[arg(long = "show-session-usage", default_value_t = false)]
-    show_session_usage: bool,
+    /// Show session stats and URL after async mode completes
+    #[arg(long = "show-session-stats", default_value_t = false)]
+    show_session_stats: bool,
 
     /// Color theme: auto, dark, or light (default: auto)
     #[arg(long = "theme", default_value = "auto")]
@@ -592,7 +592,7 @@ async fn main() {
                                 plan_feedback: cli.plan_feedback.clone(),
                                 plan_new: cli.plan_new,
                                 pause_on_approval: cli.pause_on_approval,
-                                show_session_usage: cli.show_session_usage,
+                                show_session_stats: cli.show_session_stats,
                                 resume_input: if cli.approve.is_some()
                                     || cli.reject.is_some()
                                     || cli.approve_all


### PR DESCRIPTION
## Summary

Fixes #485: Async mode now fetches and displays session stats and session URL, matching interactive mode behavior.

## Problem

When running `stakpak --async`, the agent exits without:
- Fetching/displaying session stats (interactive mode calls `get_session_stats()`)
- Printing the session URL (interactive mode prints `https://stakpak.dev/{user}/agent-sessions/{id}`)

## Changes

**File: `cli/src/commands/agent/run/mode_async.rs`**

After printing the session ID (line ~948), added:

1. **Session stats**: Call `client.get_session_stats(session_id)` and render via `renderer.render_session_stats()`
2. **Session URL**: Call `client.get_my_account()` to get the username and print the session browser URL

Both follow the same pattern as `mode_interactive.rs:1724-1770` and gracefully handle errors without failing the operation.

## Testing

- Verify async mode prints session stats after completion
- Verify async mode prints "To view full session in browser:" URL
- Verify no regression when session ID is not available