### PR TITLE
fix(docker): pre-create and chown persistent storage mount parents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,8 @@ RUN chmod +x /usr/local/bin/stakpak
 # entrypoint script then patches /etc/passwd, chowns writable paths, and
 # drops to the target user via gosu.
 RUN groupadd -g 1000 agent && useradd -u 1000 -g 1000 -s /bin/bash -m agent \
-    && mkdir -p /agent && chown -R agent:agent /agent
+    && mkdir -p /agent /home/agent/.stakpak/data /home/agent/.agent-board \
+    && chown -R agent:agent /agent /home/agent/.stakpak /home/agent/.agent-board
 # Create docker group and add agent user to it
 RUN groupadd -r docker && usermod -aG docker agent
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -719,6 +719,11 @@ mod tests {
     }
 
     #[cfg(unix)]
+    fn agent_dockerfile_path() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../Dockerfile")
+    }
+
+    #[cfg(unix)]
     fn setup_fake_entrypoint_bin(fake_bin: &std::path::Path) -> String {
         std::fs::create_dir_all(fake_bin).expect("create fake bin");
 
@@ -733,6 +738,10 @@ mod tests {
         write_executable_script(
             &fake_bin.join("find"),
             "#!/bin/sh\nprintf 'find:%s\\n' \"$*\" >> \"$ENTRYPOINT_LOG\"\nexit 0\n",
+        );
+        write_executable_script(
+            &fake_bin.join("chown"),
+            "#!/bin/sh\nprintf 'chown:%s\\n' \"$*\" >> \"$ENTRYPOINT_LOG\"\nexit 0\n",
         );
         write_executable_script(
             &fake_bin.join("gosu"),
@@ -766,6 +775,33 @@ mod tests {
     fn auto_update_gate_is_true_for_default_interactive_startup() {
         let cli = Cli::try_parse_from(["stakpak"]).expect("parse cli");
         assert!(should_spawn_auto_update(&cli, false));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn agent_dockerfile_precreates_persistent_storage_mount_parents() {
+        let dockerfile = std::fs::read_to_string(agent_dockerfile_path()).expect("read Dockerfile");
+
+        assert!(
+            dockerfile.contains("/home/agent/.stakpak/data"),
+            "Dockerfile must pre-create the parent of the local.db file bind mount"
+        );
+        assert!(
+            dockerfile.contains("/home/agent/.agent-board"),
+            "Dockerfile must pre-create the parent of the agent-board data.db file bind mount"
+        );
+        assert!(
+            dockerfile.contains("chown -R agent:agent"),
+            "Dockerfile must assign agent ownership to writable image paths"
+        );
+        assert!(
+            dockerfile.contains("/home/agent/.stakpak"),
+            "Dockerfile must make the stakpak home tree agent-owned"
+        );
+        assert!(
+            dockerfile.contains("/home/agent/.agent-board"),
+            "Dockerfile must make the agent-board storage parent agent-owned"
+        );
     }
 
     #[test]
@@ -910,6 +946,52 @@ mod tests {
         assert!(
             log.contains(&aqua_log_fragment),
             "expected aqua-cache ownership fixup, got: {log}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn entrypoint_fixes_known_file_mount_parent_dirs() {
+        let temp_dir = tempfile::TempDir::new().expect("temp dir");
+        let fake_bin = temp_dir.path().join("fake-bin");
+        let log_path = temp_dir.path().join("entrypoint.log");
+        let path_env = setup_fake_entrypoint_bin(&fake_bin);
+        let home_dir = temp_dir.path().join("agent-home");
+        let stakpak_data_dir = home_dir.join(".stakpak/data");
+        let agent_board_dir = home_dir.join(".agent-board");
+        std::fs::create_dir_all(&stakpak_data_dir).expect("create stakpak data dir");
+        std::fs::create_dir_all(&agent_board_dir).expect("create agent board dir");
+
+        let output = std::process::Command::new("sh")
+            .arg(entrypoint_script_path())
+            .arg("/usr/local/bin/stakpak")
+            .arg("mcp")
+            .arg("start")
+            .env("PATH", path_env)
+            .env("ENTRYPOINT_LOG", &log_path)
+            .env("STAKPAK_TARGET_UID", "1000")
+            .env("STAKPAK_TARGET_GID", "1000")
+            .env("STAKPAK_HOME_DIR", &home_dir)
+            .output()
+            .expect("run entrypoint");
+
+        assert!(
+            output.status.success(),
+            "entrypoint failed: stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let log = std::fs::read_to_string(&log_path).expect("read entrypoint log");
+        let stakpak_data_chown = format!("chown:1000:1000 {}", stakpak_data_dir.display());
+        let agent_board_chown = format!("chown:1000:1000 {}", agent_board_dir.display());
+        assert!(
+            log.contains(&stakpak_data_chown),
+            "expected stakpak data dir ownership fixup, got: {log}"
+        );
+        assert!(
+            log.contains(&agent_board_chown),
+            "expected agent-board dir ownership fixup, got: {log}"
         );
     }
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -53,6 +53,14 @@ if [ "$CURRENT_UID" = "0" ] && [ -n "$STAKPAK_TARGET_UID" ]; then
         fi
     fi
 
+    # Docker creates missing parent directories for single-file bind mounts as
+    # root before this script runs. These Stakpak-owned SQLite parents must stay
+    # writable after gosu drops to the target agent user, even when the target
+    # UID/GID already matches the image defaults.
+    for dir in "$HOME/.stakpak/data" "$HOME/.agent-board"; do
+        [ -d "$dir" ] && chown "$TARGET_UID:$TARGET_GID" "$dir" 2>/dev/null || true
+    done
+
     # Drop to the (now-remapped) agent user.
     exec gosu agent "$@"
 fi


### PR DESCRIPTION
## Description

Docker creates missing parent directories for single-file bind mounts as `root:root` before the entrypoint runs. When Stakpak-owned SQLite databases (`local.db`, `data.db`) are bind-mounted into the container, their parent directories (`~/.stakpak/data`, `~/.agent-board`) can end up root-owned and unwritable by the agent user, causing database permission errors at runtime.

## Changes Made

- **Dockerfile**: Pre-create `/home/agent/.stakpak/data` and `/home/agent/.agent-board` with agent ownership during image build
- **entrypoint.sh**: Add a chown loop for the same directories so existing containers with root-owned parents get fixed on every start
- **Tests**: Two new `#[cfg(unix)]` tests:
  - `agent_dockerfile_precreates_persistent_storage_mount_parents` — asserts the Dockerfile contains the required directories and chown directives
  - `entrypoint_fixes_known_file_mount_parent_dirs` — verifies the entrypoint script fixes ownership at runtime

## Testing

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -p stakpak -- -D warnings` passes
- [x] `cargo check --tests -p stakpak` compiles successfully
- [ ] Full `cargo test -p stakpak` blocked by local disk space; will verify in CI

## Breaking Changes

None — this only adds directories and chown calls that are no-ops when the directories already have correct ownership.