### PR TITLE
fix(watch): refresh stale loopback gateway URLs on config reload

### DIFF
--- a/cli/src/commands/autopilot/mod.rs
+++ b/cli/src/commands/autopilot/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -1362,7 +1362,7 @@ async fn start_foreground_runtime(
     apply_gateway_policy_from_resolved_tools(&mut gateway_cfg, &resolved_tool_policy);
 
     let gateway_profile_overrides = stakpak_gateway::runtime::DispatcherProfileOverrides::new(
-        gateway_cfg.channels.profiles_map(),
+        gateway_channel_profiles_with_default(&gateway_cfg.channels, &config.profile_name),
         Arc::new(ProfileRunOverrideResolver::new(config.config_path.clone())),
     );
 
@@ -1655,6 +1655,35 @@ impl stakpak_gateway::dispatcher::RunOverrideResolver for ProfileRunOverrideReso
             Some(overrides)
         }
     }
+}
+
+fn gateway_channel_profiles_with_default(
+    channels: &stakpak_gateway::config::ChannelConfigs,
+    default_profile: &str,
+) -> HashMap<String, String> {
+    let mut profiles = channels.profiles_map();
+    let default_profile = normalize_optional_string(Some(default_profile.to_string()))
+        .unwrap_or_else(|| "default".to_string());
+
+    if channels.telegram.is_some() {
+        profiles
+            .entry("telegram".to_string())
+            .or_insert_with(|| default_profile.clone());
+    }
+
+    if channels.discord.is_some() {
+        profiles
+            .entry("discord".to_string())
+            .or_insert_with(|| default_profile.clone());
+    }
+
+    if channels.slack.is_some() {
+        profiles
+            .entry("slack".to_string())
+            .or_insert_with(|| default_profile.clone());
+    }
+
+    profiles
 }
 
 fn approved_tools_from_policy(policy: &stakpak_server::ToolApprovalPolicy) -> Vec<String> {
@@ -4679,6 +4708,36 @@ max_turns = 12
         let profiles = gateway_cfg.channels.profiles_map();
         assert_eq!(profiles.get("slack").map(String::as_str), Some("ops"));
         assert!(!profiles.contains_key("telegram"));
+    }
+
+    #[test]
+    fn gateway_channel_profiles_default_to_boot_profile_when_omitted() {
+        let mut gateway_cfg = stakpak_gateway::GatewayConfig::default();
+        gateway_cfg.channels.slack = Some(stakpak_gateway::config::SlackConfig {
+            bot_token: "xoxb-token".to_string(),
+            app_token: "xapp-token".to_string(),
+            model: None,
+            auto_approve: None,
+            profile: None,
+        });
+
+        let profiles = gateway_channel_profiles_with_default(&gateway_cfg.channels, "default");
+        assert_eq!(profiles.get("slack").map(String::as_str), Some("default"));
+    }
+
+    #[test]
+    fn gateway_channel_profiles_preserve_explicit_profile_over_default() {
+        let mut gateway_cfg = stakpak_gateway::GatewayConfig::default();
+        gateway_cfg.channels.slack = Some(stakpak_gateway::config::SlackConfig {
+            bot_token: "xoxb-token".to_string(),
+            app_token: "xapp-token".to_string(),
+            model: None,
+            auto_approve: None,
+            profile: Some("ops".to_string()),
+        });
+
+        let profiles = gateway_channel_profiles_with_default(&gateway_cfg.channels, "default");
+        assert_eq!(profiles.get("slack").map(String::as_str), Some("ops"));
     }
 
     #[test]

--- a/cli/src/commands/watch/commands/run.rs
+++ b/cli/src/commands/watch/commands/run.rs
@@ -2431,6 +2431,65 @@ auto_approve = []
     }
 
     #[tokio::test]
+    async fn test_config_reload_replaces_stale_loopback_gateway_url() {
+        let temp = tempdir().expect("failed to create temp directory");
+        let config_path = temp.path().join("autopilot.toml");
+        let db_path = temp.path().join("autopilot.db");
+
+        write_autopilot_config_with_notifications(
+            &config_path,
+            &db_path,
+            &[("alpha", "*/10 * * * *", true)],
+            "http://127.0.0.1:4096",
+            None,
+        );
+
+        let config = ScheduleConfig::load(&config_path).expect("failed to load initial config");
+        let (scheduler, snapshot, config_state, _event_rx) = build_runtime_state(&config).await;
+
+        let server = AgentServerConnection {
+            url: "http://127.0.0.1:4097".to_string(),
+            token: "runtime-token".to_string(),
+            model: None,
+            default_allowed_tools: HashSet::new(),
+            boot_profile: "default".to_string(),
+            config_path: "/tmp/config.toml".to_string(),
+        };
+
+        let loader_path = config_path.clone();
+        let success = trigger_config_reload_with_loader(
+            &scheduler,
+            &config_state,
+            &snapshot,
+            &server,
+            move || ScheduleConfig::load(&loader_path),
+        )
+        .await;
+        assert!(success);
+
+        let config_guard = config_state.read().await;
+        let notifications = config_guard
+            .notifications
+            .as_ref()
+            .expect("notifications should exist");
+        assert_eq!(
+            notifications.gateway_url, "http://127.0.0.1:4097",
+            "loopback gateway URL must follow the current runtime server URL after reload"
+        );
+        assert_eq!(
+            notifications.gateway_token.as_deref(),
+            Some("runtime-token")
+        );
+        drop(config_guard);
+
+        let mut scheduler_guard = scheduler.lock().await;
+        scheduler_guard
+            .shutdown()
+            .await
+            .expect("failed to shutdown scheduler");
+    }
+
+    #[tokio::test]
     async fn test_config_reload_preserves_custom_external_gateway_url() {
         // Users may point notifications at an external gateway (not loopback).
         // The reload must preserve their custom URL, only injecting the token.

--- a/cli/src/commands/watch/config.rs
+++ b/cli/src/commands/watch/config.rs
@@ -555,10 +555,16 @@ impl ScheduleConfig {
             if !trimmed.is_empty() {
                 notifications.gateway_token = Some(trimmed.to_string());
             }
-            // Fill the URL only when missing/empty; the user may have set a
-            // custom external gateway URL that should be preserved.
-            if notifications.gateway_url.trim().is_empty() {
-                notifications.gateway_url = url.to_string();
+            // Fill missing URLs and refresh loopback URLs. Loopback values are
+            // runtime-derived and can become stale when the server bind changes.
+            // External gateway URLs remain user-authored and are preserved.
+            if notifications.gateway_url.trim().is_empty()
+                || is_loopback_gateway_url(&notifications.gateway_url)
+            {
+                let trimmed_url = url.trim();
+                if !trimmed_url.is_empty() {
+                    notifications.gateway_url = trimmed_url.to_string();
+                }
             }
         }
     }
@@ -569,9 +575,27 @@ impl ScheduleConfig {
             return false;
         };
 
-        let url = notifications.gateway_url.to_ascii_lowercase();
-        url.contains("127.0.0.1") || url.contains("localhost")
+        is_loopback_gateway_url(&notifications.gateway_url)
     }
+}
+
+fn is_loopback_gateway_url(url: &str) -> bool {
+    let trimmed = url.trim().to_ascii_lowercase();
+    let without_scheme = trimmed
+        .strip_prefix("http://")
+        .or_else(|| trimmed.strip_prefix("https://"))
+        .unwrap_or(&trimmed);
+
+    let host = if let Some(rest) = without_scheme.strip_prefix('[') {
+        rest.split(']').next().unwrap_or_default()
+    } else {
+        without_scheme
+            .split([':', '/', '?', '#'])
+            .next()
+            .unwrap_or_default()
+    };
+
+    matches!(host, "localhost" | "127.0.0.1" | "::1")
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1243,6 +1267,23 @@ prompt = "test"
         assert_eq!(
             notifications.gateway_url, custom_url,
             "user-configured external gateway URL should not be overwritten"
+        );
+        assert_eq!(
+            notifications.gateway_token.as_deref(),
+            Some("runtime-token"),
+        );
+    }
+
+    #[test]
+    fn test_apply_credentials_replaces_stale_loopback_gateway_url() {
+        let mut config = config_with_notifications("http://127.0.0.1:4096", None);
+
+        config.apply_runtime_gateway_credentials("http://127.0.0.1:4097", "runtime-token");
+
+        let notifications = config.notifications.expect("notifications should exist");
+        assert_eq!(
+            notifications.gateway_url, "http://127.0.0.1:4097",
+            "stale loopback gateway_url should follow the current runtime bind"
         );
         assert_eq!(
             notifications.gateway_token.as_deref(),


### PR DESCRIPTION
## Description

Loopback gateway URLs (`127.0.0.1`, `localhost`, `::1`) are derived from the runtime server bind address and become stale when the bind changes (e.g. across restarts). Previously `apply_runtime_gateway_credentials` only filled empty gateway URLs, leaving stale loopback values intact. This PR makes config reload also refresh loopback URLs to match the current server bind.

Additionally, gateway channel profiles that omit an explicit profile now default to the boot profile name instead of producing empty map entries that fail to resolve.

## Changes Made

- **`watch/config.rs`**: Added `is_loopback_gateway_url()` helper detecting localhost/127.0.0.1/::1 hosts (handles scheme prefixes, IPv6 brackets, ports). `apply_runtime_gateway_credentials` now replaces loopback URLs on reload, not just empty ones.
- **`watch/commands/run.rs`**: Integration test verifying stale loopback gateway URLs are replaced after config reload.
- **`autopilot/mod.rs`**: Added `gateway_channel_profiles_with_default()` to fill omitted channel profiles with the boot profile. Replaces direct `profiles_map()` call so channels without explicit profiles resolve correctly.

## Testing

- [x] All existing tests pass
- [x] New unit tests for loopback URL detection and channel profile defaults
- [x] New integration test for config reload with stale loopback URL
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean

## Breaking Changes

None — only fixes incorrect behavior (stale URLs, missing profile defaults).