### PR TITLE
feat(mcp): add aap as built-in remote MCP server

### DIFF
--- a/cli/src/commands/agent/run/mcp_init.rs
+++ b/cli/src/commands/agent/run/mcp_init.rs
@@ -187,6 +187,8 @@ async fn start_mcp_server(
 fn build_proxy_config(
     local_server_url: String,
     server_cert_chain: Arc<Option<CertificateChain>>,
+    api_endpoint: &str,
+    api_key: Option<&str>,
 ) -> ClientPoolConfig {
     let mut servers: HashMap<String, ServerConfig> = HashMap::new();
 
@@ -201,12 +203,32 @@ fn build_proxy_config(
         },
     );
 
-    // Add external paks server
+    // Add external paks server (derived from api_endpoint so local profiles work)
+    let api_base = api_endpoint.trim_end_matches('/');
     servers.insert(
         "paks".to_string(),
         ServerConfig::Http {
-            url: "https://apiv2.stakpak.dev/v1/paks/mcp".to_string(),
+            url: format!("{api_base}/v1/paks/mcp"),
             headers: None,
+            certificate_chain: Arc::new(None),
+            client_tls_config: None,
+        },
+    );
+
+    // Add external aap server (derived from api_endpoint so local profiles work).
+    // AAP requires `Authorization: Bearer <api_key>` on every call. The session
+    // id is forwarded via the JSON-RPC `_meta["dev.stakpak/session-id"]` field
+    // (set in cli/src/commands/agent/run/tooling.rs), not as an HTTP header.
+    let aap_headers = api_key.map(|key| {
+        let mut h = HashMap::new();
+        h.insert("Authorization".to_string(), format!("Bearer {key}"));
+        h
+    });
+    servers.insert(
+        "aap".to_string(),
+        ServerConfig::Http {
+            url: format!("{api_base}/v1/aap/mcp"),
+            headers: aap_headers,
             certificate_chain: Arc::new(None),
             client_tls_config: None,
         },
@@ -218,7 +240,7 @@ fn build_proxy_config(
             Ok(external_servers) => {
                 let mut loaded_servers = 0;
                 for (name, config) in external_servers {
-                    if name == "stakpak" || name == "paks" {
+                    if name == "stakpak" || name == "paks" || name == "aap" {
                         tracing::warn!(
                             "Skipping external MCP server {} (reserved for stakpak's internal use)",
                             name
@@ -365,7 +387,12 @@ pub async fn initialize_mcp_server_and_tools(
     .await?;
 
     // 5. Build and start proxy
-    let pool_config = build_proxy_config(local_mcp_server_url, certs.server_chain);
+    let pool_config = build_proxy_config(
+        local_mcp_server_url,
+        certs.server_chain,
+        &app_config.api_endpoint,
+        app_config.api_key.as_deref(),
+    );
     start_proxy(
         pool_config,
         &mcp_config,

--- a/cli/src/commands/agent/run/tooling.rs
+++ b/cli/src/commands/agent/run/tooling.rs
@@ -63,9 +63,16 @@ pub async fn run_tool_call(
         let metadata = Some({
             let mut meta = serde_json::Map::new();
             if let Some(session_id) = session_id {
+                let session_id_str = session_id.to_string();
+                // Legacy key — consumed by the local stakpak MCP server (ctx.meta.get("session_id"))
                 meta.insert(
                     "session_id".to_string(),
-                    serde_json::Value::String(session_id.to_string()),
+                    serde_json::Value::String(session_id_str.clone()),
+                );
+                // MCP-spec-compliant reverse-DNS key — consumed by the AAP MCP server
+                meta.insert(
+                    "dev.stakpak/session-id".to_string(),
+                    serde_json::Value::String(session_id_str),
                 );
             }
             if let Some(model_id) = model_id {

--- a/libs/mcp/config/src/lib.rs
+++ b/libs/mcp/config/src/lib.rs
@@ -236,7 +236,7 @@ pub fn add_server(
     name: &str,
     entry: McpServerEntry,
 ) -> Result<(), String> {
-    if name == "stakpak" || name == "paks" {
+    if name == "stakpak" || name == "paks" || name == "aap" {
         return Err(format!("Cannot add server with reserved name '{name}'."));
     }
 
@@ -251,7 +251,7 @@ pub fn add_server(
 
 /// Remove a server entry. Fails if name not found.
 pub fn remove_server(config: &mut McpConfigFile, name: &str) -> Result<McpServerEntry, String> {
-    if name == "stakpak" || name == "paks" {
+    if name == "stakpak" || name == "paks" || name == "aap" {
         return Err(format!("Cannot remove internal server '{name}'."));
     }
 
@@ -267,7 +267,7 @@ pub fn set_server_disabled(
     name: &str,
     disabled: bool,
 ) -> Result<(), String> {
-    if name == "stakpak" || name == "paks" {
+    if name == "stakpak" || name == "paks" || name == "aap" {
         return Err(format!("Cannot modify internal server '{name}'."));
     }
 

--- a/libs/server/src/sandbox.rs
+++ b/libs/server/src/sandbox.rs
@@ -883,6 +883,17 @@ fn build_sandbox_proxy_config(
         },
     );
 
+    // Keep the external aap server accessible
+    servers.insert(
+        "aap".to_string(),
+        ServerConfig::Http {
+            url: "https://apiv2.stakpak.dev/v1/aap/mcp".to_string(),
+            headers: None,
+            certificate_chain: Arc::new(None),
+            client_tls_config: None,
+        },
+    );
+
     ClientPoolConfig::with_servers(servers)
 }
 


### PR DESCRIPTION
## Summary

Wires up the AAP MCP service (`/v1/aap/mcp`) as a built-in upstream alongside `stakpak` and `paks`, with auth and session forwarding per the AAP spec.

## Changes

- **`cli/src/commands/agent/run/mcp_init.rs`** — register `aap` upstream in `build_proxy_config()`, derive its URL from `AppConfig.api_endpoint` (so local profiles work), and attach a static `Authorization: Bearer <api_key>` header. `paks` URL is also derived from `api_endpoint` now for consistency.
- **`cli/src/commands/agent/run/tooling.rs`** — add the MCP-spec-compliant reverse-DNS key `dev.stakpak/session-id` to per-call `_meta` alongside the legacy `session_id` key. AAP reads the new key; existing consumers (local stakpak server) keep using the legacy one.
- **`libs/mcp/config/src/lib.rs`** — add `aap` to the reserved-name list so user-supplied MCP configs can't shadow the built-in.
- **`libs/server/src/sandbox.rs`** — register `aap` in the sandbox proxy too.

## How AAP receives the session id

Per coordination with the AAP server team: session id flows via standard MCP `_meta` (not an HTTP header), using a reverse-DNS key:

```json
{
  "jsonrpc": "2.0",
  "method": "tools/call",
  "params": {
    "name": "execute_capability",
    "arguments": { ... },
    "_meta": {
      "session_id": "550e8400-...",                  // legacy, for stakpak server
      "dev.stakpak/session-id": "550e8400-..."       // MCP-spec key, for AAP
    }
  }
}
```

Auth is a static `Authorization: Bearer <api_key>` header set once on the connection and applied to every tool call (handled by rmcp's `StreamableHttpClientTransport`).

## Testing

Manually tested against a local AAP server with `./target/debug/stakpak --profile local -a`:

- `aap__list_capabilities` → returned 2 Langfuse capabilities
- `aap__execute_capability` (`langfuse.list_observations`) → returned real Langfuse data

Both calls succeeded end-to-end, confirming auth header + `_meta["dev.stakpak/session-id"]` are wired correctly. Existing tests pass (`cargo test -p stakpak-mcp-config`).

## Known follow-up (out of scope)

The sandbox path (`libs/server/src/sandbox.rs::build_sandbox_proxy_config`) still hardcodes `apiv2.stakpak.dev` and sends no auth header, since `SandboxConfig` doesn't carry `api_endpoint`/`api_key`. Sandboxed autopilot sessions hitting AAP will fail until that's plumbed through. Tracked separately.
