### PR TITLE
fix(mcp): artifact large tool outputs in proxy

### DIFF
--- a/libs/mcp/proxy/src/client/mod.rs
+++ b/libs/mcp/proxy/src/client/mod.rs
@@ -25,12 +25,20 @@ impl ProxyClientHandler {
     }
 }
 
+fn progress_notification_for_forwarding(
+    notification: ProgressNotificationParam,
+) -> ProgressNotificationParam {
+    notification
+}
+
 impl ClientHandler for ProxyClientHandler {
     async fn on_progress(
         &self,
         notification: ProgressNotificationParam,
         _ctx: NotificationContext<RoleClient>,
     ) {
+        let notification = progress_notification_for_forwarding(notification);
+
         // Then forward progress notification from upstream server to downstream server
         let peer = self.downstream_peer.lock().await;
         if let Some(ref peer) = *peer {
@@ -282,6 +290,7 @@ fn substitute_env_vars(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rmcp::model::{NumberOrString, ProgressToken};
     use std::env;
     use std::sync::Mutex;
 
@@ -316,6 +325,28 @@ mod tests {
                 },
             }
         }
+    }
+
+    #[test]
+    fn progress_notification_forwarding_preserves_large_message_without_artifacting() {
+        let large_message = "progress line\n".repeat(400);
+        let notification = ProgressNotificationParam {
+            progress_token: ProgressToken(NumberOrString::Number(0)),
+            progress: 50.0,
+            total: None,
+            message: Some(large_message.clone()),
+        };
+
+        let forwarded = progress_notification_for_forwarding(notification);
+
+        assert_eq!(forwarded.message.as_deref(), Some(large_message.as_str()));
+        assert!(
+            !forwarded
+                .message
+                .as_deref()
+                .expect("message should be preserved")
+                .contains("Full output saved to ")
+        );
     }
 
     #[test]

--- a/libs/mcp/proxy/src/server/mod.rs
+++ b/libs/mcp/proxy/src/server/mod.rs
@@ -22,6 +22,7 @@ use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig
 use stakpak_shared::cert_utils::CertificateChain;
 use stakpak_shared::paths::stakpak_home_dir;
 use stakpak_shared::secret_manager::SecretManager;
+use stakpak_shared::utils::{LargeOutputLimits, handle_large_output_with_limits};
 use std::collections::HashMap;
 use std::future::Future;
 use std::sync::Arc;
@@ -124,6 +125,51 @@ fn restore_secrets_in_json_value(
         }
         _ => {}
     }
+}
+
+const PROXY_LARGE_OUTPUT_MAX_LINES: usize = 300;
+const PROXY_LARGE_OUTPUT_MAX_BYTES: usize = 64 * 1024;
+
+fn artifact_final_tool_result_text(
+    mut result: CallToolResult,
+    client_name: &str,
+    tool_name: &str,
+) -> CallToolResult {
+    let mut text_blocks = Vec::new();
+    let mut non_text_content = Vec::new();
+
+    for item in result.content {
+        if let Some(text_content) = item.raw.as_text() {
+            text_blocks.push(text_content.text.clone());
+        } else {
+            non_text_content.push(item);
+        }
+    }
+
+    if text_blocks.is_empty() {
+        result.content = non_text_content;
+        return result;
+    }
+
+    let flattened_text = text_blocks.join("\n");
+    let file_prefix = format!("mcp-tool-output.{}.{}", client_name, tool_name);
+    let processed_text = match handle_large_output_with_limits(
+        &flattened_text,
+        LargeOutputLimits {
+            file_prefix: &file_prefix,
+            max_lines: PROXY_LARGE_OUTPUT_MAX_LINES,
+            max_bytes: PROXY_LARGE_OUTPUT_MAX_BYTES,
+            show_head: false,
+        },
+    ) {
+        Ok(text) => text,
+        Err(e) => format!("FAILED_TO_HANDLE_LARGE_OUTPUT: {}", e),
+    };
+
+    result.content = std::iter::once(Content::text(processed_text))
+        .chain(non_text_content)
+        .collect();
+    result
 }
 
 #[derive(Debug, Clone)]
@@ -670,6 +716,8 @@ impl ServerHandler for ProxyServer {
                 .collect();
         }
 
+        result = artifact_final_tool_result_text(result, &client_name, &tool_name);
+
         Ok(result)
     }
 
@@ -881,7 +929,39 @@ pub async fn start_proxy_server(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rmcp::model::ResourceContents;
     use serde_json::json;
+
+    fn text_content(content: &Content) -> &str {
+        content
+            .raw
+            .as_text()
+            .map(|text| text.text.as_str())
+            .expect("content should be text")
+    }
+
+    fn artifact_path_from_preview(preview: &str) -> &str {
+        preview
+            .lines()
+            .next()
+            .and_then(|line| line.split_once("Full output saved to "))
+            .map(|(_, path)| path)
+            .expect("preview should contain saved artifact path")
+    }
+
+    fn read_artifact_from_preview(preview: &str) -> String {
+        let artifact_path = artifact_path_from_preview(preview);
+        let artifact = std::fs::read_to_string(artifact_path).expect("artifact should be readable");
+        std::fs::remove_file(artifact_path).expect("artifact should be removable");
+        artifact
+    }
+
+    fn numbered_lines(prefix: &str, count: usize) -> String {
+        (1..=count)
+            .map(|line| format!("{prefix}-{line:03}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
 
     /// Helper: build a redaction map from pairs
     fn map(pairs: &[(&str, &str)]) -> HashMap<String, String> {
@@ -889,6 +969,109 @@ mod tests {
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect()
+    }
+
+    #[test]
+    fn artifact_final_tool_result_previews_large_success_text() {
+        let output = numbered_lines("success", 301);
+        let result = CallToolResult::success(vec![Content::text(output.clone())]);
+
+        let processed = artifact_final_tool_result_text(result, "stakpak", "run_command");
+
+        assert_eq!(processed.is_error, Some(false));
+        assert_eq!(processed.content.len(), 1);
+        let preview = text_content(&processed.content[0]);
+        assert!(preview.starts_with("Showing the last 300 / 301 output lines."));
+        assert!(preview.contains("Full output saved to "));
+        assert!(!preview.contains("success-001"));
+        assert!(preview.contains("success-301"));
+
+        let artifact = read_artifact_from_preview(preview);
+        assert_eq!(artifact, output);
+    }
+
+    #[test]
+    fn artifact_final_tool_result_preserves_large_error_status() {
+        let output = numbered_lines("error", 301);
+        let result = CallToolResult::error(vec![Content::text(output.clone())]);
+
+        let processed = artifact_final_tool_result_text(result, "stakpak", "get_task_details");
+
+        assert_eq!(processed.is_error, Some(true));
+        assert_eq!(processed.content.len(), 1);
+        let preview = text_content(&processed.content[0]);
+        assert!(preview.starts_with("Showing the last 300 / 301 output lines."));
+
+        let artifact = read_artifact_from_preview(preview);
+        assert_eq!(artifact, output);
+    }
+
+    #[test]
+    fn artifact_final_tool_result_flattens_multiple_text_blocks_once() {
+        let first = numbered_lines("first", 200);
+        let second = numbered_lines("second", 200);
+        let flattened = format!("{first}\n{second}");
+        let result = CallToolResult::success(vec![
+            Content::text(first.clone()),
+            Content::text(second.clone()),
+        ]);
+
+        let processed = artifact_final_tool_result_text(result, "docs", "search_docs");
+
+        assert_eq!(processed.content.len(), 1);
+        let preview = text_content(&processed.content[0]);
+        assert!(preview.starts_with("Showing the last 300 / 400 output lines."));
+
+        let artifact = read_artifact_from_preview(preview);
+        assert_eq!(artifact, flattened);
+    }
+
+    #[test]
+    fn artifact_final_tool_result_preserves_non_text_after_preview() {
+        let output = numbered_lines("image", 301);
+        let image = Content::image("abc123", "image/png");
+        let result = CallToolResult::success(vec![Content::text(output), image.clone()]);
+
+        let processed = artifact_final_tool_result_text(result, "vision", "inspect");
+
+        assert_eq!(processed.content.len(), 2);
+        assert!(text_content(&processed.content[0]).contains("Full output saved to "));
+        assert_eq!(processed.content[1], image);
+
+        let _ = read_artifact_from_preview(text_content(&processed.content[0]));
+    }
+
+    #[test]
+    fn artifact_final_tool_result_preserves_resource_after_small_text_normalization() {
+        let resource = Content::resource(ResourceContents::text("resource body", "file:///a.txt"));
+        let result = CallToolResult::success(vec![
+            Content::text("alpha"),
+            resource.clone(),
+            Content::text("beta"),
+        ]);
+
+        let processed = artifact_final_tool_result_text(result, "files", "read_resource");
+
+        assert_eq!(processed.content.len(), 2);
+        assert_eq!(text_content(&processed.content[0]), "alpha\nbeta");
+        assert_eq!(processed.content[1], resource);
+    }
+
+    #[test]
+    fn artifact_final_tool_result_previews_large_single_line_by_bytes() {
+        let output = "x".repeat(65 * 1024);
+        let result = CallToolResult::success(vec![Content::text(output.clone())]);
+
+        let processed = artifact_final_tool_result_text(result, "json", "large_payload");
+
+        assert_eq!(processed.content.len(), 1);
+        let preview = text_content(&processed.content[0]);
+        assert!(preview.starts_with("Showing the last 65536 / 66560 output bytes."));
+        assert!(preview.contains("Full output saved to "));
+        assert!(preview.len() < output.len());
+
+        let artifact = read_artifact_from_preview(preview);
+        assert_eq!(artifact, output);
     }
 
     // ---------------------------------------------------------------

--- a/libs/mcp/proxy/src/server/mod.rs
+++ b/libs/mcp/proxy/src/server/mod.rs
@@ -152,7 +152,7 @@ fn artifact_final_tool_result_text(
     }
 
     let flattened_text = text_blocks.join("\n");
-    let file_prefix = format!("mcp-tool-output.{}.{}", client_name, tool_name);
+    let file_prefix = format!("tool-output.{}.{}", client_name, tool_name);
     let processed_text = match handle_large_output_with_limits(
         &flattened_text,
         LargeOutputLimits {

--- a/libs/mcp/server/src/local_tools.rs
+++ b/libs/mcp/server/src/local_tools.rs
@@ -25,7 +25,7 @@ use stakpak_shared::models::integrations::openai::{
 use stakpak_shared::task_manager::{StartTaskOptions, TaskInfo};
 use stakpak_shared::tls_client::{TlsClientConfig, create_tls_client};
 use stakpak_shared::utils::{
-    LocalFileSystemProvider, generate_directory_tree, handle_large_output, sanitize_text_output,
+    LocalFileSystemProvider, generate_directory_tree, sanitize_text_output,
 };
 use std::fs::{self};
 use std::path::Path;
@@ -309,8 +309,6 @@ impl ToolContainer {
     #[tool(
         description = "Execute a shell command locally with full system access.
 
-If the command's output exceeds 300 lines the result will be truncated and the full output will be saved to a file in the current directory.
-
 For remote command execution via SSH, use the run_remote_command tool instead."
     )]
     pub async fn run_command(
@@ -337,8 +335,6 @@ REMOTE EXECUTION:
 - Examples:
   * 'user@server.com' (uses default port 22 and auto-discovered keys)
   * 'user@server.com:2222' with password authentication
-
-If the command's output exceeds 300 lines the result will be truncated and the full output will be saved to a file in the current directory.
 
 For local command execution, use the run_command tool instead.")]
     pub async fn run_remote_command(
@@ -702,8 +698,6 @@ This tool provides comprehensive details about a background task started with ru
 - Complete command output
 - Error information if the task failed
 
-If the task output exceeds 300 lines the result will be truncated and the full output will be saved to a file in the current directory.
-
 Use this tool to check the progress and results of long-running background tasks."
     )]
     pub async fn get_task_details(
@@ -760,16 +754,7 @@ Use this tool to check the progress and results of long-running background tasks
                         // Subagent output - use Display impl for LLM-friendly formatting
                         manifest.to_string()
                     } else {
-                        // Regular task output - use standard handling
-                        match handle_large_output(output, "task.output", 300, false) {
-                            Ok(result) => result,
-                            Err(e) => {
-                                return Ok(CallToolResult::error(vec![
-                                    Content::text("OUTPUT_HANDLING_ERROR"),
-                                    Content::text(format!("Failed to handle task output: {}", e)),
-                                ]));
-                            }
-                        }
+                        output.clone()
                     }
                 } else {
                     "No output available".to_string()
@@ -1018,9 +1003,7 @@ SECURITY FEATURES:
 - Only allows HTTPS URLs for secure connections
 - Follows redirects safely with limits
 
-The tool fetches the HTML content from the specified URL and converts it to clean, readable markdown. This is useful for reading web articles, documentation, or any web content in a text-friendly format.
-
-The response will be truncated if it exceeds 300 lines, with the full content saved to a local file."
+The tool fetches the HTML content from the specified URL and converts it to clean, readable markdown. This is useful for reading web articles, documentation, or any web content in a text-friendly format."
     )]
     pub async fn view_web_page(
         &self,
@@ -1097,17 +1080,7 @@ The response will be truncated if it exceeds 300 lines, with the full content sa
         let markdown_content = html2md::rewrite_html(&html_content, false);
         let sanitized_content = sanitize_text_output(&markdown_content);
 
-        let result = match handle_large_output(&sanitized_content, "webpage", 300, false) {
-            Ok(result) => result,
-            Err(e) => {
-                return Ok(CallToolResult::error(vec![
-                    Content::text("OUTPUT_HANDLING_ERROR"),
-                    Content::text(format!("Failed to handle output: {}", e)),
-                ]));
-            }
-        };
-
-        let formatted_output = format!("# Web Page Content: {}\n\n{}", url, result);
+        let formatted_output = format!("# Web Page Content: {}\n\n{}", url, sanitized_content);
 
         Ok(CallToolResult::success(vec![Content::text(
             &formatted_output,
@@ -1232,17 +1205,6 @@ SAFETY NOTES:
     fn format_command_result(
         command_result: &mut CommandResult,
     ) -> Result<CallToolResult, McpError> {
-        command_result.output =
-            match handle_large_output(&command_result.output, "command.output", 300, false) {
-                Ok(result) => result,
-                Err(e) => {
-                    return Ok(CallToolResult::error(vec![
-                        Content::text("OUTPUT_HANDLING_ERROR"),
-                        Content::text(format!("Failed to handle command output: {}", e)),
-                    ]));
-                }
-            };
-
         if command_result.output.is_empty() {
             return Ok(CallToolResult::success(vec![Content::text("No output")]));
         }

--- a/libs/mcp/server/src/remote_tools.rs
+++ b/libs/mcp/server/src/remote_tools.rs
@@ -5,7 +5,7 @@ use rmcp::{
 };
 use serde::Deserialize;
 use stakpak_api::models::SearchDocsRequest as ApiSearchDocsRequest;
-use stakpak_shared::utils::{handle_large_output, sanitize_text_output};
+use stakpak_shared::utils::sanitize_text_output;
 // use stakpak_api::models::CodeIndex;
 // use stakpak_shared::local_store::LocalStore;
 // use stakpak_shared::models::indexing::IndexingStatus;
@@ -302,34 +302,11 @@ If your goal requires understanding multiple distinct topics or technologies, ma
             }
         };
 
-        const MAX_LINES: usize = 600;
-
-        let mut remaining_lines = MAX_LINES;
-        let mut remaining_items = response.len();
-
         let processed: Vec<Content> = response
             .into_iter()
             .map(|c| {
-                // Compute this element's allowance at the last possible moment
-                let allowance = if remaining_items > 0 {
-                    (remaining_lines / remaining_items).max(1)
-                } else {
-                    1
-                };
-
-                remaining_items = remaining_items.saturating_sub(1);
-
                 if let Some(RawTextContent { text, meta: None }) = c.as_text() {
-                    let sanitized = sanitize_text_output(text);
-                    match handle_large_output(&sanitized, "search", allowance, true) {
-                        Ok(final_text) => {
-                            // Estimate consumption (best-effort)
-                            let used = final_text.lines().count().min(remaining_lines);
-                            remaining_lines = remaining_lines.saturating_sub(used);
-                            Content::text(final_text)
-                        }
-                        Err(e) => Content::text(format!("FAILED_TO_HANDLE_LARGE_OUTPUT: {}", e)),
-                    }
+                    Content::text(sanitize_text_output(text))
                 } else {
                     c
                 }

--- a/libs/shared/src/utils.rs
+++ b/libs/shared/src/utils.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 use rand::Rng;
 use std::fs;
 use std::path::{Path, PathBuf};
+use uuid::Uuid;
 use walkdir::DirEntry;
 
 /// Read .gitignore patterns from the specified base directory
@@ -250,6 +251,132 @@ pub fn truncate_chars_with_ellipsis(text: &str, max_chars: usize) -> String {
     truncated
 }
 
+pub struct LargeOutputLimits<'a> {
+    pub file_prefix: &'a str,
+    pub max_lines: usize,
+    pub max_bytes: usize,
+    pub show_head: bool,
+}
+
+fn sanitize_artifact_file_prefix(file_prefix: &str) -> String {
+    let sanitized = file_prefix
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches(|c| matches!(c, '-' | '_' | '.'))
+        .to_string();
+
+    if sanitized.is_empty() {
+        "output".to_string()
+    } else {
+        sanitized
+    }
+}
+
+fn write_output_artifact(file_prefix: &str, output: &str) -> Result<String, String> {
+    let output_file = format!(
+        "{}.{}.txt",
+        sanitize_artifact_file_prefix(file_prefix),
+        Uuid::new_v4().simple()
+    );
+
+    LocalStore::write_session_data(&output_file, output)
+        .map_err(|e| format!("Failed to write session data: {}", e))
+}
+
+fn line_preview(
+    output_lines: &[&str],
+    output_file_path: &str,
+    max_lines: usize,
+    show_head: bool,
+) -> String {
+    let excerpt = if show_head {
+        let head_lines: Vec<&str> = output_lines.iter().take(max_lines).copied().collect();
+        head_lines.join("\n")
+    } else {
+        let mut tail_lines: Vec<&str> =
+            output_lines.iter().rev().take(max_lines).copied().collect();
+        tail_lines.reverse();
+        tail_lines.join("\n")
+    };
+
+    let position = if show_head { "first" } else { "last" };
+    format!(
+        "Showing the {} {} / {} output lines. Full output saved to {}\n{}\n{}",
+        position,
+        max_lines,
+        output_lines.len(),
+        output_file_path,
+        if show_head { "" } else { "...\n" },
+        excerpt
+    )
+}
+
+// start/end are adjusted to valid UTF-8 character boundaries before slicing.
+#[allow(clippy::string_slice)]
+fn byte_excerpt(output: &str, max_bytes: usize, show_head: bool) -> (&str, usize) {
+    if show_head {
+        let mut end = max_bytes.min(output.len());
+        while end > 0 && !output.is_char_boundary(end) {
+            end -= 1;
+        }
+        (&output[..end], end)
+    } else {
+        let mut start = output.len().saturating_sub(max_bytes);
+        while start < output.len() && !output.is_char_boundary(start) {
+            start += 1;
+        }
+        (&output[start..], output.len() - start)
+    }
+}
+
+fn byte_preview(output: &str, output_file_path: &str, max_bytes: usize, show_head: bool) -> String {
+    let (excerpt, excerpt_bytes) = byte_excerpt(output, max_bytes, show_head);
+    let position = if show_head { "first" } else { "last" };
+
+    format!(
+        "Showing the {} {} / {} output bytes. Full output saved to {}\n{}\n{}",
+        position,
+        excerpt_bytes,
+        output.len(),
+        output_file_path,
+        if show_head { "" } else { "...\n" },
+        excerpt
+    )
+}
+
+pub fn handle_large_output_with_limits(
+    output: &str,
+    limits: LargeOutputLimits<'_>,
+) -> Result<String, String> {
+    let output_lines = output.lines().collect::<Vec<_>>();
+    if output_lines.len() >= limits.max_lines {
+        let output_file_path = write_output_artifact(limits.file_prefix, output)?;
+        Ok(line_preview(
+            &output_lines,
+            &output_file_path,
+            limits.max_lines,
+            limits.show_head,
+        ))
+    } else if output.len() > limits.max_bytes {
+        let output_file_path = write_output_artifact(limits.file_prefix, output)?;
+        Ok(byte_preview(
+            output,
+            &output_file_path,
+            limits.max_bytes,
+            limits.show_head,
+        ))
+    } else {
+        Ok(output.to_string())
+    }
+}
+
 /// Handle large output: if the output has >= `max_lines`, save the full content to session
 /// storage and return a string showing only the first or last `max_lines` lines with a pointer
 /// to the saved file. Returns `Ok(final_string)` or `Err(error_string)` on failure.
@@ -259,44 +386,15 @@ pub fn handle_large_output(
     max_lines: usize,
     show_head: bool,
 ) -> Result<String, String> {
-    let output_lines = output.lines().collect::<Vec<_>>();
-    if output_lines.len() >= max_lines {
-        let mut __rng__ = rand::rng();
-        let output_file = format!(
-            "{}.{:06x}.txt",
+    handle_large_output_with_limits(
+        output,
+        LargeOutputLimits {
             file_prefix,
-            __rng__.random_range(0..=0xFFFFFF)
-        );
-        let output_file_path = match LocalStore::write_session_data(&output_file, output) {
-            Ok(path) => path,
-            Err(e) => {
-                return Err(format!("Failed to write session data: {}", e));
-            }
-        };
-
-        let excerpt = if show_head {
-            let head_lines: Vec<&str> = output_lines.iter().take(max_lines).copied().collect();
-            head_lines.join("\n")
-        } else {
-            let mut tail_lines: Vec<&str> =
-                output_lines.iter().rev().take(max_lines).copied().collect();
-            tail_lines.reverse();
-            tail_lines.join("\n")
-        };
-
-        let position = if show_head { "first" } else { "last" };
-        Ok(format!(
-            "Showing the {} {} / {} output lines. Full output saved to {}\n{}\n{}",
-            position,
             max_lines,
-            output_lines.len(),
-            output_file_path,
-            if show_head { "" } else { "...\n" },
-            excerpt
-        ))
-    } else {
-        Ok(output.to_string())
-    }
+            max_bytes: usize::MAX,
+            show_head,
+        },
+    )
 }
 
 #[cfg(test)]
@@ -362,6 +460,7 @@ mod password_tests {
 #[cfg(test)]
 mod truncate_tests {
     use super::*;
+    use std::path::Path;
 
     #[test]
     fn normalize_optional_string_trims_and_drops_empty() {
@@ -385,6 +484,116 @@ mod truncate_tests {
         let value = "é".repeat(10);
         let truncated = truncate_chars_with_ellipsis(&value, 5);
         assert_eq!(truncated, "ééééé...");
+    }
+
+    fn artifact_path_from_preview(preview: &str) -> &str {
+        preview
+            .lines()
+            .next()
+            .and_then(|line| line.split_once("Full output saved to "))
+            .map(|(_, path)| path)
+            .expect("preview should contain saved artifact path")
+    }
+
+    #[test]
+    fn handle_large_output_line_trigger_artifacts_full_output() {
+        let output = (1..=4)
+            .map(|line| format!("line {line}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let preview = handle_large_output(&output, "line-test", 3, true)
+            .expect("large output should be handled");
+
+        assert!(preview.starts_with("Showing the first 3 / 4 output lines."));
+        assert!(preview.contains("\n\nline 1\nline 2\nline 3"));
+        assert!(!preview.contains("line 4"));
+
+        let artifact_path = artifact_path_from_preview(&preview);
+        let artifact = std::fs::read_to_string(artifact_path).expect("artifact should be readable");
+        assert_eq!(artifact, output);
+        std::fs::remove_file(artifact_path).expect("artifact should be removable");
+    }
+
+    #[test]
+    fn handle_large_output_with_limits_byte_trigger_artifacts_full_output() {
+        let output = "a".repeat(64);
+
+        let preview = handle_large_output_with_limits(
+            &output,
+            LargeOutputLimits {
+                file_prefix: "mcp tool/output",
+                max_lines: 300,
+                max_bytes: 32,
+                show_head: true,
+            },
+        )
+        .expect("large output should be handled");
+
+        assert!(preview.starts_with("Showing the first 32 / 64 output bytes."));
+        assert!(preview.contains("Full output saved to "));
+        assert!(preview.contains(&"a".repeat(32)));
+        assert!(!preview.contains(&"a".repeat(64)));
+
+        let artifact_path = artifact_path_from_preview(&preview);
+        let artifact = std::fs::read_to_string(artifact_path).expect("artifact should be readable");
+        assert_eq!(artifact, output);
+
+        let file_name = Path::new(artifact_path)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("artifact should have a valid UTF-8 file name");
+        assert!(file_name.starts_with("mcp-tool-output."));
+        assert!(file_name.ends_with(".txt"));
+        assert_eq!(
+            file_name.len(),
+            "mcp-tool-output.".len() + 32 + ".txt".len()
+        );
+
+        std::fs::remove_file(artifact_path).expect("artifact should be removable");
+    }
+
+    #[test]
+    fn handle_large_output_with_limits_byte_preview_is_utf8_safe() {
+        let output = format!("{}end", "é".repeat(20));
+
+        let preview = handle_large_output_with_limits(
+            &output,
+            LargeOutputLimits {
+                file_prefix: "utf8-test",
+                max_lines: 300,
+                max_bytes: 9,
+                show_head: true,
+            },
+        )
+        .expect("large output should be handled");
+
+        assert!(preview.starts_with("Showing the first 8 / 43 output bytes."));
+        assert!(preview.contains("\n\néééé"));
+        assert!(!preview.contains("end"));
+
+        let artifact_path = artifact_path_from_preview(&preview);
+        let artifact = std::fs::read_to_string(artifact_path).expect("artifact should be readable");
+        assert_eq!(artifact, output);
+        std::fs::remove_file(artifact_path).expect("artifact should be removable");
+    }
+
+    #[test]
+    fn handle_large_output_with_limits_small_output_passes_through() {
+        let output = "small\noutput";
+
+        let preview = handle_large_output_with_limits(
+            output,
+            LargeOutputLimits {
+                file_prefix: "small-test",
+                max_lines: 300,
+                max_bytes: 1024,
+                show_head: true,
+            },
+        )
+        .expect("small output should pass through");
+
+        assert_eq!(preview, output);
     }
 }
 


### PR DESCRIPTION
## Description
Move large-output artifacting to the MCP proxy boundary so final tool results are compacted before reaching downstream clients while preserving raw tool-server output internally.

## Related Issues
None

## Changes Made
- Add shared large-output handling with line and byte limits plus sanitized artifact names
- Apply large-output artifact previews to final MCP proxy tool results while preserving error status and non-text content
- Remove server-side output truncation from local and remote MCP tools so progress/intermediate outputs stay untouched
- Add tests for proxy artifact previews, UTF-8-safe byte excerpts, and progress notification forwarding

## Testing
- [x] rustfmt --edition 2024 --check libs/mcp/proxy/src/client/mod.rs libs/mcp/proxy/src/server/mod.rs libs/mcp/server/src/local_tools.rs libs/mcp/server/src/remote_tools.rs libs/shared/src/utils.rs
- [x] cargo clippy -p stakpak-mcp-proxy -p stakpak-mcp-server -p stakpak-shared --all-targets -- -D warnings
- [ ] cargo test --workspace

## Screenshots (if applicable)

N/A

## Breaking Changes
None
