### PR TITLE
fix(ak): specify version for stakpak-api dependency

### DIFF
--- a/libs/ak/Cargo.toml
+++ b/libs/ak/Cargo.toml
@@ -17,7 +17,7 @@ regex = { workspace = true }
 globset = { workspace = true }
 grep-matcher = { workspace = true }
 grep-regex = { workspace = true }
-stakpak-api = { path = "../api" }
+stakpak-api = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Problem

Publishing `stakpak-ak` to crates.io fails with:

```
error: failed to verify manifest at `libs/ak/Cargo.toml`
Caused by:
  all dependencies must have a version requirement specified when publishing.
  dependency `stakpak-api` does not specify a version
```

`libs/ak/Cargo.toml` referenced `stakpak-api` via a bare path dependency (`{ path = "../api" }`) with no version. On `cargo publish`, the `path` is stripped and replaced with a crates.io version, so a version requirement must be declared.

## Fix

Switch to the workspace dependency (`{ workspace = true }`), matching every other crate in the repo. It inherits `stakpak-api = { path = "libs/api", version = "0.3.87" }` from the root `[workspace.dependencies]`.

## Verification

`cargo build -p stakpak-ak` succeeds.