### PR TITLE
Add third-party OSS attribution notices

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,830 @@
+# Third-Party Software Notices for `agent`
+
+This product includes third-party open-source software components listed below. Each component remains under its own license; copies of those licenses are available from the respective package registries / project repositories.
+
+Total components: 822
+
+| Component | Version | Ecosystem | License |
+|-----------|---------|-----------|---------|
+| adler2 | 2.0.1 | cargo | 0BSD OR Apache-2.0 OR MIT |
+| aead | 0.5.2 | cargo | Apache-2.0 OR MIT |
+| aes | 0.8.4 | cargo | Apache-2.0 OR MIT |
+| aes-gcm | 0.10.3 | cargo | Apache-2.0 OR MIT |
+| agent-client-protocol | 0.9.3 | cargo | Apache-2.0 |
+| agent-client-protocol-schema | 0.10.6 | cargo | Apache-2.0 |
+| ahash | 0.8.12 | cargo | Apache-2.0 OR MIT |
+| aho-corasick | 1.1.4 | cargo | MIT OR Unlicense |
+| allocator-api2 | 0.2.21 | cargo | Apache-2.0 OR MIT |
+| android_system_properties | 0.1.5 | cargo | Apache-2.0 OR MIT |
+| ansi-to-tui | 7.0.0 | cargo | MIT |
+| anstream | 0.6.21 | cargo | Apache-2.0 OR MIT |
+| anstyle | 1.0.13 | cargo | Apache-2.0 OR MIT |
+| anstyle-parse | 0.2.7 | cargo | Apache-2.0 OR MIT |
+| anstyle-query | 1.1.5 | cargo | Apache-2.0 OR MIT |
+| anstyle-wincon | 3.0.11 | cargo | Apache-2.0 OR MIT |
+| anyhow | 1.0.100 | cargo | Apache-2.0 OR MIT |
+| arbitrary | 1.4.2 | cargo | Apache-2.0 OR MIT |
+| arboard | 3.6.1 | cargo | Apache-2.0 OR MIT |
+| arc-swap | 1.7.1 | cargo | Apache-2.0 OR MIT |
+| argon2 | 0.5.3 | cargo | Apache-2.0 OR MIT |
+| arraydeque | 0.5.1 | cargo | Apache-2.0 OR MIT |
+| arrayvec | 0.7.6 | cargo | Apache-2.0 OR MIT |
+| assert-json-diff | 2.0.2 | cargo | MIT |
+| async-broadcast | 0.7.2 | cargo | Apache-2.0 OR MIT |
+| async-stream | 0.3.6 | cargo | MIT |
+| async-stream-impl | 0.3.6 | cargo | MIT |
+| async-trait | 0.1.89 | cargo | Apache-2.0 OR MIT |
+| atomic-waker | 1.1.2 | cargo | Apache-2.0 OR MIT |
+| atty | 0.2.14 | cargo | MIT |
+| auto_encoder | 0.1.10 | cargo | MIT |
+| autocfg | 1.5.0 | cargo | Apache-2.0 OR MIT |
+| aws-config | 1.8.14 | cargo | Apache-2.0 |
+| aws-credential-types | 1.2.12 | cargo | Apache-2.0 |
+| aws-lc-rs | 1.15.0 | cargo | ISC AND (Apache-2.0 OR ISC) |
+| aws-lc-sys | 0.33.0 | cargo | ISC AND OpenSSL AND (Apache-2.0 OR ISC) |
+| aws-runtime | 1.7.0 | cargo | Apache-2.0 |
+| aws-sdk-bedrockruntime | 1.125.0 | cargo | Apache-2.0 |
+| aws-sdk-sso | 1.94.0 | cargo | Apache-2.0 |
+| aws-sdk-ssooidc | 1.96.0 | cargo | Apache-2.0 |
+| aws-sdk-sts | 1.98.0 | cargo | Apache-2.0 |
+| aws-sigv4 | 1.4.0 | cargo | Apache-2.0 |
+| aws-smithy-async | 1.2.12 | cargo | Apache-2.0 |
+| aws-smithy-eventstream | 0.60.19 | cargo | Apache-2.0 |
+| aws-smithy-http | 0.63.4 | cargo | Apache-2.0 |
+| aws-smithy-http-client | 1.1.10 | cargo | Apache-2.0 |
+| aws-smithy-json | 0.62.4 | cargo | Apache-2.0 |
+| aws-smithy-observability | 0.2.5 | cargo | Apache-2.0 |
+| aws-smithy-query | 0.60.14 | cargo | Apache-2.0 |
+| aws-smithy-runtime | 1.10.1 | cargo | Apache-2.0 |
+| aws-smithy-runtime-api | 1.11.4 | cargo | Apache-2.0 |
+| aws-smithy-types | 1.4.4 | cargo | Apache-2.0 |
+| aws-smithy-xml | 0.60.14 | cargo | Apache-2.0 |
+| aws-types | 1.3.12 | cargo | Apache-2.0 |
+| axum | 0.6.20 | cargo | MIT |
+| axum | 0.8.7 | cargo | MIT |
+| axum-core | 0.3.4 | cargo | MIT |
+| axum-core | 0.5.5 | cargo | MIT |
+| axum-server | 0.7.3 | cargo | MIT |
+| base16ct | 0.2.0 | cargo | Apache-2.0 OR MIT |
+| base64 | 0.21.7 | cargo | Apache-2.0 OR MIT |
+| base64 | 0.22.1 | cargo | Apache-2.0 OR MIT |
+| base64-simd | 0.8.0 | cargo | MIT |
+| base64ct | 1.6.0 | cargo | Apache-2.0 OR MIT |
+| bcrypt-pbkdf | 0.10.0 | cargo | Apache-2.0 OR MIT |
+| bincode | 1.3.3 | cargo | MIT |
+| bindgen | 0.66.1 | cargo | BSD-3-Clause |
+| bindgen | 0.72.1 | cargo | BSD-3-Clause |
+| bitflags | 1.3.2 | cargo | Apache-2.0 OR MIT |
+| bitflags | 2.10.0 | cargo | Apache-2.0 OR MIT |
+| blake2 | 0.10.6 | cargo | Apache-2.0 OR MIT |
+| block-buffer | 0.10.4 | cargo | Apache-2.0 OR MIT |
+| block-padding | 0.3.3 | cargo | Apache-2.0 OR MIT |
+| blowfish | 0.9.1 | cargo | Apache-2.0 OR MIT |
+| bstr | 1.12.1 | cargo | Apache-2.0 OR MIT |
+| bumpalo | 3.19.0 | cargo | Apache-2.0 OR MIT |
+| bytemuck | 1.24.0 | cargo | Apache-2.0 OR MIT OR Zlib |
+| byteorder | 1.5.0 | cargo | MIT OR Unlicense |
+| byteorder-lite | 0.1.0 | cargo | MIT OR Unlicense |
+| bytes | 1.11.0 | cargo | MIT |
+| bytes-utils | 0.1.4 | cargo | Apache-2.0 OR MIT |
+| bzip2 | 0.6.1 | cargo | Apache-2.0 OR MIT |
+| cassowary | 0.3.0 | cargo | Apache-2.0 OR MIT |
+| castaway | 0.2.4 | cargo | MIT |
+| cbc | 0.1.2 | cargo | Apache-2.0 OR MIT |
+| cc | 1.2.48 | cargo | Apache-2.0 OR MIT |
+| cc | 1.2.56 | cargo | Apache-2.0 OR MIT |
+| cesu8 | 1.1.0 | cargo | Apache-2.0 OR MIT |
+| cexpr | 0.6.0 | cargo | Apache-2.0 OR MIT |
+| cfg-if | 1.0.4 | cargo | Apache-2.0 OR MIT |
+| cfg_aliases | 0.2.1 | cargo | MIT |
+| chacha20 | 0.9.1 | cargo | Apache-2.0 OR MIT |
+| chardetng | 0.1.17 | cargo | Apache-2.0 OR MIT |
+| chrono | 0.4.42 | cargo | Apache-2.0 OR MIT |
+| chrono-tz | 0.10.4 | cargo | Apache-2.0 OR MIT |
+| cipher | 0.4.4 | cargo | Apache-2.0 OR MIT |
+| clang-sys | 1.8.1 | cargo | Apache-2.0 |
+| clap | 3.2.25 | cargo | Apache-2.0 OR MIT |
+| clap | 4.5.51 | cargo | Apache-2.0 OR MIT |
+| clap_builder | 4.5.51 | cargo | Apache-2.0 OR MIT |
+| clap_complete | 4.6.0 | cargo | Apache-2.0 OR MIT |
+| clap_derive | 3.2.25 | cargo | Apache-2.0 OR MIT |
+| clap_derive | 4.5.49 | cargo | Apache-2.0 OR MIT |
+| clap_lex | 0.2.4 | cargo | Apache-2.0 OR MIT |
+| clap_lex | 0.7.6 | cargo | Apache-2.0 OR MIT |
+| clipboard-win | 5.4.1 | cargo | BSL-1.0 |
+| cmake | 0.1.54 | cargo | Apache-2.0 OR MIT |
+| colorchoice | 1.0.4 | cargo | Apache-2.0 OR MIT |
+| colored | 3.0.0 | cargo | MPL-2.0 |
+| combine | 4.6.7 | cargo | MIT |
+| compact_str | 0.8.1 | cargo | MIT |
+| concurrent-queue | 2.5.0 | cargo | Apache-2.0 OR MIT |
+| config | 0.14.1 | cargo | Apache-2.0 OR MIT |
+| console | 0.15.11 | cargo | MIT |
+| const-oid | 0.9.6 | cargo | Apache-2.0 OR MIT |
+| const-random | 0.1.18 | cargo | Apache-2.0 OR MIT |
+| const-random-macro | 0.1.16 | cargo | Apache-2.0 OR MIT |
+| constant_time_eq | 0.3.1 | cargo | Apache-2.0 OR CC0-1.0 OR MIT-0 |
+| convert_case | 0.6.0 | cargo | MIT |
+| convert_case | 0.7.1 | cargo | MIT |
+| coolor | 1.1.0 | cargo | MIT |
+| core-foundation | 0.10.1 | cargo | Apache-2.0 OR MIT |
+| core-foundation | 0.9.4 | cargo | Apache-2.0 OR MIT |
+| core-foundation-sys | 0.8.7 | cargo | Apache-2.0 OR MIT |
+| cpufeatures | 0.2.17 | cargo | Apache-2.0 OR MIT |
+| crc32fast | 1.5.0 | cargo | Apache-2.0 OR MIT |
+| croner | 3.0.1 | cargo | MIT |
+| crossbeam-channel | 0.5.15 | cargo | Apache-2.0 OR MIT |
+| crossbeam-deque | 0.8.6 | cargo | Apache-2.0 OR MIT |
+| crossbeam-epoch | 0.9.18 | cargo | Apache-2.0 OR MIT |
+| crossbeam-utils | 0.8.21 | cargo | Apache-2.0 OR MIT |
+| crossterm | 0.28.1 | cargo | MIT |
+| crossterm | 0.29.0 | cargo | MIT |
+| crossterm_winapi | 0.9.1 | cargo | MIT |
+| crunchy | 0.2.4 | cargo | MIT |
+| crypto-bigint | 0.5.5 | cargo | Apache-2.0 OR MIT |
+| crypto-common | 0.1.7 | cargo | Apache-2.0 OR MIT |
+| cssparser | 0.35.0 | cargo | MPL-2.0 |
+| cssparser-macros | 0.6.1 | cargo | MPL-2.0 |
+| ctr | 0.9.2 | cargo | Apache-2.0 OR MIT |
+| curve25519-dalek | 4.1.3 | cargo | BSD-3-Clause |
+| curve25519-dalek-derive | 0.1.1 | cargo | Apache-2.0 OR MIT |
+| darling | 0.20.11 | cargo | MIT |
+| darling | 0.21.3 | cargo | MIT |
+| darling_core | 0.20.11 | cargo | MIT |
+| darling_core | 0.21.3 | cargo | MIT |
+| darling_macro | 0.20.11 | cargo | MIT |
+| darling_macro | 0.21.3 | cargo | MIT |
+| data-encoding | 2.9.0 | cargo | MIT |
+| deflate64 | 0.1.10 | cargo | MIT |
+| delegate | 0.13.5 | cargo | Apache-2.0 OR MIT |
+| der | 0.7.10 | cargo | Apache-2.0 OR MIT |
+| deranged | 0.5.5 | cargo | Apache-2.0 OR MIT |
+| derive_arbitrary | 1.4.2 | cargo | Apache-2.0 OR MIT |
+| derive_builder | 0.20.2 | cargo | Apache-2.0 OR MIT |
+| derive_builder_core | 0.20.2 | cargo | Apache-2.0 OR MIT |
+| derive_builder_macro | 0.20.2 | cargo | Apache-2.0 OR MIT |
+| derive_more | 2.0.1 | cargo | MIT |
+| derive_more-impl | 2.0.1 | cargo | MIT |
+| digest | 0.10.7 | cargo | Apache-2.0 OR MIT |
+| dirs | 5.0.1 | cargo | Apache-2.0 OR MIT |
+| dirs-sys | 0.4.1 | cargo | Apache-2.0 OR MIT |
+| dispatch2 | 0.3.0 | cargo | Apache-2.0 OR MIT OR Zlib |
+| displaydoc | 0.2.5 | cargo | Apache-2.0 OR MIT |
+| dlv-list | 0.5.2 | cargo | Apache-2.0 OR MIT |
+| document-features | 0.2.12 | cargo | Apache-2.0 OR MIT |
+| downcast-rs | 1.2.1 | cargo | Apache-2.0 OR MIT |
+| dtoa | 1.0.10 | cargo | Apache-2.0 OR MIT |
+| dtoa-short | 0.3.5 | cargo | MPL-2.0 |
+| dunce | 1.0.5 | cargo | Apache-2.0 OR CC0-1.0 OR MIT-0 |
+| dyn-clone | 1.0.20 | cargo | Apache-2.0 OR MIT |
+| ecdsa | 0.16.9 | cargo | Apache-2.0 OR MIT |
+| ed25519 | 2.2.3 | cargo | Apache-2.0 OR MIT |
+| ed25519-dalek | 2.2.0 | cargo | BSD-3-Clause |
+| either | 1.15.0 | cargo | Apache-2.0 OR MIT |
+| elliptic-curve | 0.13.8 | cargo | Apache-2.0 OR MIT |
+| encode_unicode | 1.0.0 | cargo | Apache-2.0 OR MIT |
+| encoding_rs | 0.8.35 | cargo | BSD-3-Clause AND (Apache-2.0 OR MIT) |
+| encoding_rs_io | 0.1.7 | cargo | Apache-2.0 OR MIT |
+| enum_dispatch | 0.3.13 | cargo | Apache-2.0 OR MIT |
+| env_home | 0.1.0 | cargo | Apache-2.0 OR MIT |
+| equivalent | 1.0.2 | cargo | Apache-2.0 OR MIT |
+| errno | 0.3.14 | cargo | Apache-2.0 OR MIT |
+| error-code | 3.3.2 | cargo | BSL-1.0 |
+| event-listener | 5.4.1 | cargo | Apache-2.0 OR MIT |
+| event-listener-strategy | 0.5.4 | cargo | Apache-2.0 OR MIT |
+| eventsource-stream | 0.2.3 | cargo | Apache-2.0 OR MIT |
+| fallible-iterator | 0.2.0 | cargo | Apache-2.0 OR MIT |
+| fallible-iterator | 0.3.0 | cargo | Apache-2.0 OR MIT |
+| fallible-streaming-iterator | 0.1.9 | cargo | Apache-2.0 OR MIT |
+| fast_html2md | 0.0.48 | cargo | MIT |
+| fastrand | 2.3.0 | cargo | Apache-2.0 OR MIT |
+| fax | 0.2.6 | cargo | MIT |
+| fax_derive | 0.2.0 | cargo | MIT |
+| fdeflate | 0.3.7 | cargo | Apache-2.0 OR MIT |
+| ff | 0.13.1 | cargo | Apache-2.0 OR MIT |
+| fiat-crypto | 0.2.9 | cargo | Apache-2.0 OR BSD-1-Clause OR MIT |
+| filedescriptor | 0.8.3 | cargo | MIT |
+| filetime | 0.2.26 | cargo | Apache-2.0 OR MIT |
+| find-msvc-tools | 0.1.5 | cargo | Apache-2.0 OR MIT |
+| find-msvc-tools | 0.1.9 | cargo | Apache-2.0 OR MIT |
+| flate2 | 1.1.5 | cargo | Apache-2.0 OR MIT |
+| flurry | 0.5.2 | cargo | Apache-2.0 OR MIT |
+| fnv | 1.0.7 | cargo | Apache-2.0 OR MIT |
+| foldhash | 0.1.5 | cargo | Zlib |
+| foldhash | 0.2.0 | cargo | Zlib |
+| foreign-types | 0.3.2 | cargo | Apache-2.0 OR MIT |
+| foreign-types-shared | 0.1.1 | cargo | Apache-2.0 OR MIT |
+| form_urlencoded | 1.2.2 | cargo | Apache-2.0 OR MIT |
+| fs-err | 3.2.0 | cargo | Apache-2.0 OR MIT |
+| fs_extra | 1.3.0 | cargo | MIT |
+| fsevent-sys | 4.1.0 | cargo | MIT |
+| futures | 0.3.31 | cargo | Apache-2.0 OR MIT |
+| futures-channel | 0.3.31 | cargo | Apache-2.0 OR MIT |
+| futures-core | 0.3.31 | cargo | Apache-2.0 OR MIT |
+| futures-executor | 0.3.31 | cargo | Apache-2.0 OR MIT |
+| futures-io | 0.3.31 | cargo | Apache-2.0 OR MIT |
+| futures-macro | 0.3.31 | cargo | Apache-2.0 OR MIT |
+| futures-sink | 0.3.31 | cargo | Apache-2.0 OR MIT |
+| futures-task | 0.3.31 | cargo | Apache-2.0 OR MIT |
+| futures-timer | 3.0.3 | cargo | Apache-2.0 OR MIT |
+| futures-util | 0.3.31 | cargo | Apache-2.0 OR MIT |
+| generic-array | 0.14.7 | cargo | MIT |
+| gethostname | 1.1.0 | cargo | Apache-2.0 |
+| getrandom | 0.2.16 | cargo | Apache-2.0 OR MIT |
+| getrandom | 0.3.4 | cargo | Apache-2.0 OR MIT |
+| ghash | 0.5.1 | cargo | Apache-2.0 OR MIT |
+| glob | 0.3.3 | cargo | Apache-2.0 OR MIT |
+| globset | 0.4.18 | cargo | MIT OR Unlicense |
+| grep-matcher | 0.1.8 | cargo | MIT OR Unlicense |
+| grep-regex | 0.1.14 | cargo | MIT OR Unlicense |
+| grep-searcher | 0.1.16 | cargo | MIT OR Unlicense |
+| group | 0.13.0 | cargo | Apache-2.0 OR MIT |
+| h2 | 0.3.27 | cargo | MIT |
+| h2 | 0.4.12 | cargo | MIT |
+| half | 2.7.1 | cargo | Apache-2.0 OR MIT |
+| hashbrown | 0.12.3 | cargo | Apache-2.0 OR MIT |
+| hashbrown | 0.14.5 | cargo | Apache-2.0 OR MIT |
+| hashbrown | 0.15.5 | cargo | Apache-2.0 OR MIT |
+| hashbrown | 0.16.0 | cargo | Apache-2.0 OR MIT |
+| hashbrown | 0.16.1 | cargo | Apache-2.0 OR MIT |
+| hashlink | 0.8.4 | cargo | Apache-2.0 OR MIT |
+| heck | 0.4.1 | cargo | Apache-2.0 OR MIT |
+| heck | 0.5.0 | cargo | Apache-2.0 OR MIT |
+| hermit-abi | 0.1.19 | cargo | Apache-2.0 OR MIT |
+| hermit-abi | 0.5.2 | cargo | Apache-2.0 OR MIT |
+| hex | 0.4.3 | cargo | Apache-2.0 OR MIT |
+| hex-literal | 0.4.1 | cargo | Apache-2.0 OR MIT |
+| hkdf | 0.12.4 | cargo | Apache-2.0 OR MIT |
+| hmac | 0.12.1 | cargo | Apache-2.0 OR MIT |
+| home | 0.5.12 | cargo | Apache-2.0 OR MIT |
+| http | 0.2.12 | cargo | Apache-2.0 OR MIT |
+| http | 1.3.1 | cargo | Apache-2.0 OR MIT |
+| http | 1.4.0 | cargo | Apache-2.0 OR MIT |
+| http-body | 0.4.6 | cargo | MIT |
+| http-body | 1.0.1 | cargo | MIT |
+| http-body-util | 0.1.3 | cargo | MIT |
+| http-range-header | 0.3.1 | cargo | MIT |
+| httparse | 1.10.1 | cargo | Apache-2.0 OR MIT |
+| httpdate | 1.0.3 | cargo | Apache-2.0 OR MIT |
+| humantime | 2.3.0 | cargo | Apache-2.0 OR MIT |
+| humantime-serde | 1.1.1 | cargo | Apache-2.0 OR MIT |
+| hyper | 0.14.32 | cargo | MIT |
+| hyper | 1.8.1 | cargo | MIT |
+| hyper-rustls | 0.25.0 | cargo | Apache-2.0 OR ISC OR MIT |
+| hyper-rustls | 0.27.7 | cargo | Apache-2.0 OR ISC OR MIT |
+| hyper-timeout | 0.4.1 | cargo | Apache-2.0 OR MIT |
+| hyper-tls | 0.6.0 | cargo | Apache-2.0 OR MIT |
+| hyper-util | 0.1.18 | cargo | MIT |
+| iana-time-zone | 0.1.64 | cargo | Apache-2.0 OR MIT |
+| iana-time-zone-haiku | 0.1.2 | cargo | Apache-2.0 OR MIT |
+| icu_collections | 2.1.1 | cargo | Unicode-3.0 |
+| icu_locale_core | 2.1.1 | cargo | Unicode-3.0 |
+| icu_normalizer | 2.1.1 | cargo | Unicode-3.0 |
+| icu_normalizer_data | 2.1.1 | cargo | Unicode-3.0 |
+| icu_properties | 2.1.1 | cargo | Unicode-3.0 |
+| icu_properties_data | 2.1.1 | cargo | Unicode-3.0 |
+| icu_provider | 2.1.1 | cargo | Unicode-3.0 |
+| ident_case | 1.0.1 | cargo | Apache-2.0 OR MIT |
+| idna | 1.1.0 | cargo | Apache-2.0 OR MIT |
+| idna_adapter | 1.2.1 | cargo | Apache-2.0 OR MIT |
+| ignore | 0.4.25 | cargo | MIT OR Unlicense |
+| image | 0.25.9 | cargo | Apache-2.0 OR MIT |
+| include_dir | 0.7.4 | cargo | MIT |
+| include_dir_macros | 0.7.4 | cargo | MIT |
+| indexmap | 1.9.3 | cargo | Apache-2.0 OR MIT |
+| indexmap | 2.12.0 | cargo | Apache-2.0 OR MIT |
+| indexmap | 2.12.1 | cargo | Apache-2.0 OR MIT |
+| indoc | 2.0.7 | cargo | Apache-2.0 OR MIT |
+| inotify | 0.11.0 | cargo | ISC |
+| inotify-sys | 0.1.5 | cargo | ISC |
+| inout | 0.1.4 | cargo | Apache-2.0 OR MIT |
+| instability | 0.3.9 | cargo | MIT |
+| internal-russh-forked-ssh-key | 0.6.11+upstream-0.6.7 | cargo | UNKNOWN |
+| ioctl-rs | 0.1.6 | cargo | MIT |
+| ipnet | 2.11.0 | cargo | Apache-2.0 OR MIT |
+| iri-string | 0.7.9 | cargo | Apache-2.0 OR MIT |
+| is-docker | 0.2.0 | cargo | MIT |
+| is-wsl | 0.4.0 | cargo | MIT |
+| is_terminal_polyfill | 1.70.2 | cargo | Apache-2.0 OR MIT |
+| itertools | 0.12.1 | cargo | Apache-2.0 OR MIT |
+| itertools | 0.13.0 | cargo | Apache-2.0 OR MIT |
+| itertools | 0.14.0 | cargo | Apache-2.0 OR MIT |
+| itoa | 1.0.15 | cargo | Apache-2.0 OR MIT |
+| jni | 0.21.1 | cargo | Apache-2.0 OR MIT |
+| jni-sys | 0.3.0 | cargo | Apache-2.0 OR MIT |
+| jobserver | 0.1.34 | cargo | Apache-2.0 OR MIT |
+| js-sys | 0.3.82 | cargo | Apache-2.0 OR MIT |
+| js-sys | 0.3.83 | cargo | Apache-2.0 OR MIT |
+| json5 | 0.4.1 | cargo | ISC |
+| jsonrpc-core | 18.0.0 | cargo | MIT |
+| jsonrpc-derive | 18.0.0 | cargo | MIT |
+| kqueue | 1.1.1 | cargo | MIT |
+| kqueue-sys | 1.0.4 | cargo | MIT |
+| lazy_static | 1.5.0 | cargo | Apache-2.0 OR MIT |
+| lazycell | 1.3.0 | cargo | Apache-2.0 OR MIT |
+| libbz2-rs-sys | 0.2.2 | cargo | bzip2-1.0.6 |
+| libc | 0.2.177 | cargo | Apache-2.0 OR MIT |
+| libloading | 0.8.9 | cargo | ISC |
+| liblzma | 0.4.5 | cargo | Apache-2.0 OR MIT |
+| liblzma-sys | 0.4.4 | cargo | Apache-2.0 OR MIT |
+| libm | 0.2.15 | cargo | MIT |
+| libredox | 0.1.10 | cargo | MIT |
+| libsql | 0.9.29 | cargo | MIT |
+| libsql-ffi | 0.9.29 | cargo | MIT |
+| libsql-hrana | 0.9.29 | cargo | MIT |
+| libsql-rusqlite | 0.9.29 | cargo | MIT |
+| libsql-sqlite3-parser | 0.13.0 | cargo | Apache-2.0 OR MIT |
+| libsql-sys | 0.9.29 | cargo | MIT |
+| libsql_replication | 0.9.29 | cargo | MIT |
+| libz-rs-sys | 0.5.2 | cargo | Zlib |
+| linked-hash-map | 0.5.6 | cargo | Apache-2.0 OR MIT |
+| linux-raw-sys | 0.11.0 | cargo | Apache-2.0 OR MIT OR Apache-2.0 WITH LLVM-exception |
+| linux-raw-sys | 0.4.15 | cargo | Apache-2.0 OR MIT OR Apache-2.0 WITH LLVM-exception |
+| litemap | 0.8.1 | cargo | Unicode-3.0 |
+| litrs | 1.0.0 | cargo | Apache-2.0 OR MIT |
+| lock_api | 0.4.14 | cargo | Apache-2.0 OR MIT |
+| log | 0.4.28 | cargo | Apache-2.0 OR MIT |
+| lol_html | 2.7.0 | cargo | BSD-3-Clause |
+| lru | 0.12.5 | cargo | MIT |
+| lru-slab | 0.1.2 | cargo | Apache-2.0 OR MIT OR Zlib |
+| matchers | 0.2.0 | cargo | MIT |
+| matchit | 0.7.3 | cargo | BSD-3-Clause AND MIT |
+| matchit | 0.8.4 | cargo | BSD-3-Clause AND MIT |
+| md5 | 0.7.0 | cargo | Apache-2.0 OR MIT |
+| memchr | 2.7.6 | cargo | MIT OR Unlicense |
+| memmap2 | 0.9.9 | cargo | Apache-2.0 OR MIT |
+| memoffset | 0.6.5 | cargo | MIT |
+| mime | 0.3.17 | cargo | Apache-2.0 OR MIT |
+| minimal-lexical | 0.2.1 | cargo | Apache-2.0 OR MIT |
+| miniz_oxide | 0.8.9 | cargo | Apache-2.0 OR MIT OR Zlib |
+| mio | 1.1.0 | cargo | MIT |
+| mockito | 1.7.1 | cargo | MIT |
+| moxcms | 0.7.9 | cargo | Apache-2.0 OR BSD-3-Clause |
+| names | 0.14.0 | cargo | MIT |
+| native-tls | 0.2.14 | cargo | Apache-2.0 OR MIT |
+| new_debug_unreachable | 1.0.6 | cargo | MIT |
+| nix | 0.25.1 | cargo | MIT |
+| nix | 0.29.0 | cargo | MIT |
+| nix | 0.30.1 | cargo | MIT |
+| nom | 7.1.3 | cargo | MIT |
+| notify | 8.2.0 | cargo | CC0-1.0 |
+| notify-types | 2.0.0 | cargo | Apache-2.0 OR MIT |
+| nu-ansi-term | 0.50.3 | cargo | MIT |
+| nucleo-matcher | 0.3.1 | cargo | MPL-2.0 |
+| num-bigint | 0.4.6 | cargo | Apache-2.0 OR MIT |
+| num-bigint-dig | 0.8.6 | cargo | Apache-2.0 OR MIT |
+| num-conv | 0.1.0 | cargo | Apache-2.0 OR MIT |
+| num-derive | 0.4.2 | cargo | Apache-2.0 OR MIT |
+| num-integer | 0.1.46 | cargo | Apache-2.0 OR MIT |
+| num-iter | 0.1.45 | cargo | Apache-2.0 OR MIT |
+| num-traits | 0.2.19 | cargo | Apache-2.0 OR MIT |
+| num_cpus | 1.17.0 | cargo | Apache-2.0 OR MIT |
+| objc2 | 0.6.3 | cargo | MIT |
+| objc2-app-kit | 0.3.2 | cargo | Apache-2.0 OR MIT OR Zlib |
+| objc2-core-foundation | 0.3.2 | cargo | Apache-2.0 OR MIT OR Zlib |
+| objc2-core-graphics | 0.3.2 | cargo | Apache-2.0 OR MIT OR Zlib |
+| objc2-encode | 4.1.0 | cargo | MIT |
+| objc2-foundation | 0.3.2 | cargo | MIT |
+| objc2-io-surface | 0.3.2 | cargo | Apache-2.0 OR MIT OR Zlib |
+| once_cell | 1.21.3 | cargo | Apache-2.0 OR MIT |
+| once_cell_polyfill | 1.70.2 | cargo | Apache-2.0 OR MIT |
+| onig | 6.5.1 | cargo | MIT |
+| onig_sys | 69.9.1 | cargo | MIT |
+| opaque-debug | 0.3.1 | cargo | Apache-2.0 OR MIT |
+| open | 5.3.2 | cargo | MIT |
+| openssl | 0.10.75 | cargo | Apache-2.0 |
+| openssl-macros | 0.1.1 | cargo | Apache-2.0 OR MIT |
+| openssl-probe | 0.1.6 | cargo | Apache-2.0 OR MIT |
+| openssl-sys | 0.9.111 | cargo | MIT |
+| opentelemetry | 0.31.0 | cargo | Apache-2.0 |
+| option-ext | 0.2.0 | cargo | MPL-2.0 |
+| ordered-multimap | 0.7.3 | cargo | MIT |
+| os_str_bytes | 6.6.1 | cargo | Apache-2.0 OR MIT |
+| outref | 0.5.2 | cargo | MIT |
+| p256 | 0.13.2 | cargo | Apache-2.0 OR MIT |
+| p384 | 0.13.1 | cargo | Apache-2.0 OR MIT |
+| p521 | 0.13.3 | cargo | Apache-2.0 OR MIT |
+| pageant | 0.0.3 | cargo | Apache-2.0 |
+| parking | 2.2.1 | cargo | Apache-2.0 OR MIT |
+| parking_lot | 0.12.5 | cargo | Apache-2.0 OR MIT |
+| parking_lot_core | 0.9.12 | cargo | Apache-2.0 OR MIT |
+| password-hash | 0.5.0 | cargo | Apache-2.0 OR MIT |
+| paste | 1.0.15 | cargo | Apache-2.0 OR MIT |
+| pastey | 0.2.0 | cargo | Apache-2.0 OR MIT |
+| pathdiff | 0.2.3 | cargo | Apache-2.0 OR MIT |
+| pbkdf2 | 0.12.2 | cargo | Apache-2.0 OR MIT |
+| peeking_take_while | 0.1.2 | cargo | Apache-2.0 OR MIT |
+| pem | 3.0.6 | cargo | MIT |
+| pem-rfc7468 | 0.7.0 | cargo | Apache-2.0 OR MIT |
+| percent-encoding | 2.3.2 | cargo | Apache-2.0 OR MIT |
+| pest | 2.8.3 | cargo | Apache-2.0 OR MIT |
+| pest_derive | 2.8.3 | cargo | Apache-2.0 OR MIT |
+| pest_generator | 2.8.3 | cargo | Apache-2.0 OR MIT |
+| pest_meta | 2.8.3 | cargo | Apache-2.0 OR MIT |
+| phf | 0.11.3 | cargo | MIT |
+| phf | 0.12.1 | cargo | MIT |
+| phf_codegen | 0.11.3 | cargo | MIT |
+| phf_generator | 0.11.3 | cargo | MIT |
+| phf_macros | 0.11.3 | cargo | MIT |
+| phf_shared | 0.11.3 | cargo | MIT |
+| phf_shared | 0.12.1 | cargo | MIT |
+| pin-project | 1.1.10 | cargo | Apache-2.0 OR MIT |
+| pin-project-internal | 1.1.10 | cargo | Apache-2.0 OR MIT |
+| pin-project-lite | 0.2.16 | cargo | Apache-2.0 OR MIT |
+| pin-utils | 0.1.0 | cargo | Apache-2.0 OR MIT |
+| pkcs1 | 0.7.5 | cargo | Apache-2.0 OR MIT |
+| pkcs5 | 0.7.1 | cargo | Apache-2.0 OR MIT |
+| pkcs8 | 0.10.2 | cargo | Apache-2.0 OR MIT |
+| pkg-config | 0.3.32 | cargo | Apache-2.0 OR MIT |
+| plist | 1.8.0 | cargo | MIT |
+| png | 0.18.0 | cargo | Apache-2.0 OR MIT |
+| poly1305 | 0.8.0 | cargo | Apache-2.0 OR MIT |
+| polyval | 0.6.2 | cargo | Apache-2.0 OR MIT |
+| portable-pty | 0.8.1 | cargo | MIT |
+| potential_utf | 0.1.4 | cargo | Unicode-3.0 |
+| powerfmt | 0.2.0 | cargo | Apache-2.0 OR MIT |
+| ppmd-rust | 1.3.0 | cargo | CC0-1.0 |
+| ppv-lite86 | 0.2.21 | cargo | Apache-2.0 OR MIT |
+| precomputed-hash | 0.1.1 | cargo | MIT |
+| prettyplease | 0.2.37 | cargo | Apache-2.0 OR MIT |
+| primeorder | 0.13.6 | cargo | Apache-2.0 OR MIT |
+| proc-macro-crate | 0.1.5 | cargo | Apache-2.0 OR MIT |
+| proc-macro-error | 1.0.4 | cargo | Apache-2.0 OR MIT |
+| proc-macro-error-attr | 1.0.4 | cargo | Apache-2.0 OR MIT |
+| proc-macro2 | 1.0.103 | cargo | Apache-2.0 OR MIT |
+| process-wrap | 8.2.1 | cargo | Apache-2.0 OR MIT |
+| prost | 0.12.6 | cargo | Apache-2.0 |
+| prost-derive | 0.12.6 | cargo | Apache-2.0 |
+| pulldown-cmark | 0.13.0 | cargo | MIT |
+| pxfm | 0.1.25 | cargo | Apache-2.0 OR BSD-3-Clause |
+| quick-error | 2.0.1 | cargo | Apache-2.0 OR MIT |
+| quick-xml | 0.38.4 | cargo | MIT |
+| quinn | 0.11.9 | cargo | Apache-2.0 OR MIT |
+| quinn-proto | 0.11.13 | cargo | Apache-2.0 OR MIT |
+| quinn-udp | 0.5.14 | cargo | Apache-2.0 OR MIT |
+| quote | 1.0.42 | cargo | Apache-2.0 OR MIT |
+| r-efi | 5.3.0 | cargo | Apache-2.0 OR LGPL-2.1-or-later OR MIT |
+| rand | 0.8.5 | cargo | Apache-2.0 OR MIT |
+| rand | 0.9.2 | cargo | Apache-2.0 OR MIT |
+| rand_chacha | 0.3.1 | cargo | Apache-2.0 OR MIT |
+| rand_chacha | 0.9.0 | cargo | Apache-2.0 OR MIT |
+| rand_core | 0.6.4 | cargo | Apache-2.0 OR MIT |
+| rand_core | 0.9.3 | cargo | Apache-2.0 OR MIT |
+| ratatui | 0.29.0 | cargo | MIT |
+| rcgen | 0.12.1 | cargo | Apache-2.0 OR MIT |
+| redox_syscall | 0.5.18 | cargo | MIT |
+| redox_users | 0.4.6 | cargo | MIT |
+| ref-cast | 1.0.25 | cargo | Apache-2.0 OR MIT |
+| ref-cast-impl | 1.0.25 | cargo | Apache-2.0 OR MIT |
+| regex | 1.12.2 | cargo | Apache-2.0 OR MIT |
+| regex-automata | 0.4.13 | cargo | Apache-2.0 OR MIT |
+| regex-lite | 0.1.9 | cargo | Apache-2.0 OR MIT |
+| regex-syntax | 0.8.8 | cargo | Apache-2.0 OR MIT |
+| reqwest | 0.12.15 | cargo | Apache-2.0 OR MIT |
+| reqwest | 0.12.24 | cargo | Apache-2.0 OR MIT |
+| reqwest-eventsource | 0.6.0 | cargo | Apache-2.0 OR MIT |
+| reqwest-middleware | 0.4.2 | cargo | Apache-2.0 OR MIT |
+| reqwest-retry | 0.8.0 | cargo | Apache-2.0 OR MIT |
+| retry-policies | 0.5.1 | cargo | Apache-2.0 OR MIT |
+| rfc6979 | 0.4.0 | cargo | Apache-2.0 OR MIT |
+| ring | 0.17.14 | cargo | Apache-2.0 AND ISC |
+| rmcp | 0.11.0 | cargo | MIT |
+| rmcp-macros | 0.11.0 | cargo | MIT |
+| ron | 0.8.1 | cargo | Apache-2.0 OR MIT |
+| rpassword | 7.4.0 | cargo | Apache-2.0 |
+| rsa | 0.9.9 | cargo | Apache-2.0 OR MIT |
+| rtoolbox | 0.0.3 | cargo | Apache-2.0 |
+| russh | 0.53.0 | cargo | Apache-2.0 |
+| russh-cryptovec | 0.52.0 | cargo | Apache-2.0 |
+| russh-sftp | 2.1.1 | cargo | Apache-2.0 |
+| russh-util | 0.52.0 | cargo | Apache-2.0 |
+| rust-ini | 0.20.0 | cargo | MIT |
+| rustc-hash | 1.1.0 | cargo | Apache-2.0 OR MIT |
+| rustc-hash | 2.1.1 | cargo | Apache-2.0 OR MIT |
+| rustc_version | 0.4.1 | cargo | Apache-2.0 OR MIT |
+| rustix | 0.38.44 | cargo | Apache-2.0 OR MIT OR Apache-2.0 WITH LLVM-exception |
+| rustix | 1.1.2 | cargo | Apache-2.0 OR MIT OR Apache-2.0 WITH LLVM-exception |
+| rustls | 0.22.4 | cargo | Apache-2.0 OR ISC OR MIT |
+| rustls | 0.23.35 | cargo | Apache-2.0 OR ISC OR MIT |
+| rustls-native-certs | 0.7.3 | cargo | Apache-2.0 OR ISC OR MIT |
+| rustls-native-certs | 0.8.2 | cargo | Apache-2.0 OR ISC OR MIT |
+| rustls-pemfile | 2.2.0 | cargo | Apache-2.0 OR ISC OR MIT |
+| rustls-pki-types | 1.13.0 | cargo | Apache-2.0 OR MIT |
+| rustls-pki-types | 1.13.1 | cargo | Apache-2.0 OR MIT |
+| rustls-platform-verifier | 0.5.3 | cargo | Apache-2.0 OR MIT |
+| rustls-platform-verifier-android | 0.1.1 | cargo | Apache-2.0 OR MIT |
+| rustls-webpki | 0.102.8 | cargo | ISC |
+| rustls-webpki | 0.103.8 | cargo | ISC |
+| rustversion | 1.0.22 | cargo | Apache-2.0 OR MIT |
+| ryu | 1.0.20 | cargo | Apache-2.0 OR BSL-1.0 |
+| salsa20 | 0.10.2 | cargo | Apache-2.0 OR MIT |
+| same-file | 1.0.6 | cargo | MIT OR Unlicense |
+| schannel | 0.1.28 | cargo | MIT |
+| schemars | 1.1.0 | cargo | MIT |
+| schemars_derive | 1.1.0 | cargo | MIT |
+| scopeguard | 1.2.0 | cargo | Apache-2.0 OR MIT |
+| scrypt | 0.11.0 | cargo | Apache-2.0 OR MIT |
+| sec1 | 0.7.3 | cargo | Apache-2.0 OR MIT |
+| security-framework | 2.11.1 | cargo | Apache-2.0 OR MIT |
+| security-framework | 3.5.1 | cargo | Apache-2.0 OR MIT |
+| security-framework-sys | 2.15.0 | cargo | Apache-2.0 OR MIT |
+| seize | 0.3.3 | cargo | MIT |
+| selectors | 0.32.0 | cargo | MPL-2.0 |
+| semver | 1.0.27 | cargo | Apache-2.0 OR MIT |
+| serde | 1.0.228 | cargo | Apache-2.0 OR MIT |
+| serde_core | 1.0.228 | cargo | Apache-2.0 OR MIT |
+| serde_derive | 1.0.228 | cargo | Apache-2.0 OR MIT |
+| serde_derive_internals | 0.29.1 | cargo | Apache-2.0 OR MIT |
+| serde_json | 1.0.145 | cargo | Apache-2.0 OR MIT |
+| serde_path_to_error | 0.1.20 | cargo | Apache-2.0 OR MIT |
+| serde_spanned | 0.6.9 | cargo | Apache-2.0 OR MIT |
+| serde_urlencoded | 0.7.1 | cargo | Apache-2.0 OR MIT |
+| serde_yaml | 0.9.34+deprecated | cargo | UNKNOWN |
+| serial | 0.4.0 | cargo | MIT |
+| serial-core | 0.4.0 | cargo | MIT |
+| serial-unix | 0.4.0 | cargo | MIT |
+| serial-windows | 0.4.0 | cargo | MIT |
+| servo_arc | 0.4.3 | cargo | Apache-2.0 OR MIT |
+| sha1 | 0.10.6 | cargo | Apache-2.0 OR MIT |
+| sha2 | 0.10.9 | cargo | Apache-2.0 OR MIT |
+| sharded-slab | 0.1.7 | cargo | MIT |
+| shared_library | 0.1.9 | cargo | Apache-2.0 OR MIT |
+| shell-words | 1.1.0 | cargo | Apache-2.0 OR MIT |
+| shlex | 1.3.0 | cargo | Apache-2.0 OR MIT |
+| signal-hook | 0.3.18 | cargo | Apache-2.0 OR MIT |
+| signal-hook-mio | 0.2.5 | cargo | Apache-2.0 OR MIT |
+| signal-hook-registry | 1.4.6 | cargo | Apache-2.0 OR MIT |
+| signal-hook-registry | 1.4.7 | cargo | Apache-2.0 OR MIT |
+| signature | 2.2.0 | cargo | Apache-2.0 OR MIT |
+| simd-adler32 | 0.3.7 | cargo | MIT |
+| simdutf8 | 0.1.5 | cargo | Apache-2.0 OR MIT |
+| similar | 2.7.0 | cargo | Apache-2.0 |
+| siphasher | 1.0.1 | cargo | Apache-2.0 OR MIT |
+| slab | 0.4.11 | cargo | MIT |
+| smallvec | 1.15.1 | cargo | Apache-2.0 OR MIT |
+| smawk | 0.3.2 | cargo | MIT |
+| socket2 | 0.5.10 | cargo | Apache-2.0 OR MIT |
+| socket2 | 0.6.1 | cargo | Apache-2.0 OR MIT |
+| spin | 0.9.8 | cargo | MIT |
+| spki | 0.7.3 | cargo | Apache-2.0 OR MIT |
+| sse-stream | 0.2.1 | cargo | Apache-2.0 OR MIT |
+| ssh-cipher | 0.2.0 | cargo | Apache-2.0 OR MIT |
+| ssh-encoding | 0.2.0 | cargo | Apache-2.0 OR MIT |
+| stable_deref_trait | 1.2.1 | cargo | Apache-2.0 OR MIT |
+| stakai | 0.1.0 | cargo | UNKNOWN |
+| stakai | 0.3.88 | cargo | Apache-2.0 |
+| stakpak | 0.3.88 | cargo | Apache-2.0 |
+| stakpak-agent-core | 0.3.88 | cargo | Apache-2.0 |
+| stakpak-ak | 0.3.88 | cargo | Apache-2.0 |
+| stakpak-api | 0.3.88 | cargo | Apache-2.0 |
+| stakpak-gateway | 0.3.88 | cargo | Apache-2.0 |
+| stakpak-mcp-client | 0.3.88 | cargo | Apache-2.0 |
+| stakpak-mcp-config | 0.3.88 | cargo | Apache-2.0 |
+| stakpak-mcp-proxy | 0.3.88 | cargo | Apache-2.0 |
+| stakpak-mcp-server | 0.3.88 | cargo | Apache-2.0 |
+| stakpak-server | 0.3.88 | cargo | Apache-2.0 |
+| stakpak-shared | 0.3.88 | cargo | Apache-2.0 |
+| stakpak-shell-tool-approvals | 0.3.88 | cargo | Apache-2.0 |
+| stakpak-tui | 0.3.88 | cargo | Apache-2.0 |
+| static_assertions | 1.1.0 | cargo | Apache-2.0 OR MIT |
+| streaming-iterator | 0.1.9 | cargo | Apache-2.0 OR MIT |
+| strsim | 0.10.0 | cargo | MIT |
+| strsim | 0.11.1 | cargo | MIT |
+| strum | 0.26.3 | cargo | MIT |
+| strum | 0.27.2 | cargo | MIT |
+| strum_macros | 0.26.4 | cargo | MIT |
+| strum_macros | 0.27.2 | cargo | MIT |
+| subtle | 2.6.1 | cargo | BSD-3-Clause |
+| syn | 1.0.109 | cargo | Apache-2.0 OR MIT |
+| syn | 2.0.110 | cargo | Apache-2.0 OR MIT |
+| syn | 2.0.111 | cargo | Apache-2.0 OR MIT |
+| sync_wrapper | 0.1.2 | cargo | Apache-2.0 |
+| sync_wrapper | 1.0.2 | cargo | Apache-2.0 |
+| synstructure | 0.13.2 | cargo | MIT |
+| syntect | 5.3.0 | cargo | MIT |
+| system-configuration | 0.6.1 | cargo | Apache-2.0 OR MIT |
+| system-configuration-sys | 0.6.0 | cargo | Apache-2.0 OR MIT |
+| tar | 0.4.44 | cargo | Apache-2.0 OR MIT |
+| tempfile | 3.23.0 | cargo | Apache-2.0 OR MIT |
+| termcolor | 1.4.1 | cargo | MIT OR Unlicense |
+| terminal-light | 1.8.0 | cargo | MIT |
+| termios | 0.2.2 | cargo | MIT |
+| test-case | 3.3.1 | cargo | MIT |
+| test-case-core | 3.3.1 | cargo | MIT |
+| test-case-macros | 3.3.1 | cargo | MIT |
+| textwrap | 0.16.2 | cargo | MIT |
+| thiserror | 1.0.69 | cargo | Apache-2.0 OR MIT |
+| thiserror | 2.0.17 | cargo | Apache-2.0 OR MIT |
+| thiserror-impl | 1.0.69 | cargo | Apache-2.0 OR MIT |
+| thiserror-impl | 2.0.17 | cargo | Apache-2.0 OR MIT |
+| thread_local | 1.1.9 | cargo | Apache-2.0 OR MIT |
+| tiff | 0.10.3 | cargo | MIT |
+| tikv-jemalloc-sys | 0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7 | cargo | UNKNOWN |
+| tikv-jemallocator | 0.6.1 | cargo | Apache-2.0 OR MIT |
+| time | 0.3.44 | cargo | Apache-2.0 OR MIT |
+| time-core | 0.1.6 | cargo | Apache-2.0 OR MIT |
+| time-macros | 0.2.24 | cargo | Apache-2.0 OR MIT |
+| tiny-keccak | 2.0.2 | cargo | CC0-1.0 |
+| tinystr | 0.8.2 | cargo | Unicode-3.0 |
+| tinyvec | 1.10.0 | cargo | Apache-2.0 OR MIT OR Zlib |
+| tinyvec_macros | 0.1.1 | cargo | Apache-2.0 OR MIT OR Zlib |
+| tokio | 1.48.0 | cargo | MIT |
+| tokio-cron-scheduler | 0.15.1 | cargo | Apache-2.0 OR MIT |
+| tokio-io-timeout | 1.2.1 | cargo | Apache-2.0 OR MIT |
+| tokio-macros | 2.6.0 | cargo | MIT |
+| tokio-native-tls | 0.3.1 | cargo | MIT |
+| tokio-rustls | 0.25.0 | cargo | Apache-2.0 OR MIT |
+| tokio-rustls | 0.26.4 | cargo | Apache-2.0 OR MIT |
+| tokio-stream | 0.1.17 | cargo | MIT |
+| tokio-test | 0.4.4 | cargo | MIT |
+| tokio-tungstenite | 0.24.0 | cargo | MIT |
+| tokio-util | 0.7.17 | cargo | MIT |
+| toml | 0.5.11 | cargo | Apache-2.0 OR MIT |
+| toml | 0.8.23 | cargo | Apache-2.0 OR MIT |
+| toml_datetime | 0.6.11 | cargo | Apache-2.0 OR MIT |
+| toml_edit | 0.22.27 | cargo | Apache-2.0 OR MIT |
+| toml_write | 0.1.2 | cargo | Apache-2.0 OR MIT |
+| tonic | 0.11.0 | cargo | MIT |
+| tonic-web | 0.11.0 | cargo | MIT |
+| tower | 0.4.13 | cargo | MIT |
+| tower | 0.5.2 | cargo | MIT |
+| tower-http | 0.4.4 | cargo | MIT |
+| tower-http | 0.6.7 | cargo | MIT |
+| tower-layer | 0.3.3 | cargo | MIT |
+| tower-service | 0.3.3 | cargo | MIT |
+| tracing | 0.1.43 | cargo | MIT |
+| tracing | 0.1.44 | cargo | MIT |
+| tracing-appender | 0.2.4 | cargo | MIT |
+| tracing-attributes | 0.1.31 | cargo | MIT |
+| tracing-core | 0.1.35 | cargo | MIT |
+| tracing-core | 0.1.36 | cargo | MIT |
+| tracing-log | 0.2.0 | cargo | MIT |
+| tracing-opentelemetry | 0.32.1 | cargo | MIT |
+| tracing-subscriber | 0.3.22 | cargo | MIT |
+| tree-sitter | 0.26.6 | cargo | MIT |
+| tree-sitter-bash | 0.25.1 | cargo | MIT |
+| tree-sitter-language | 0.1.7 | cargo | MIT |
+| try-lock | 0.2.5 | cargo | MIT |
+| tungstenite | 0.24.0 | cargo | Apache-2.0 OR MIT |
+| typenum | 1.19.0 | cargo | Apache-2.0 OR MIT |
+| ucd-trie | 0.1.7 | cargo | Apache-2.0 OR MIT |
+| uncased | 0.9.10 | cargo | Apache-2.0 OR MIT |
+| unicase | 2.9.0 | cargo | Apache-2.0 OR MIT |
+| unicode-ident | 1.0.22 | cargo | Unicode-3.0 AND (Apache-2.0 OR MIT) |
+| unicode-linebreak | 0.1.5 | cargo | Apache-2.0 |
+| unicode-segmentation | 1.12.0 | cargo | Apache-2.0 OR MIT |
+| unicode-truncate | 1.1.0 | cargo | Apache-2.0 OR MIT |
+| unicode-width | 0.1.14 | cargo | Apache-2.0 OR MIT |
+| unicode-width | 0.2.0 | cargo | Apache-2.0 OR MIT |
+| unicode-xid | 0.2.6 | cargo | Apache-2.0 OR MIT |
+| universal-hash | 0.5.1 | cargo | Apache-2.0 OR MIT |
+| unsafe-libyaml | 0.2.11 | cargo | MIT |
+| untrusted | 0.7.1 | cargo | ISC |
+| untrusted | 0.9.0 | cargo | ISC |
+| url | 2.5.7 | cargo | Apache-2.0 OR MIT |
+| urlencoding | 2.1.3 | cargo | MIT |
+| utf-8 | 0.7.6 | cargo | Apache-2.0 OR MIT |
+| utf8_iter | 1.0.4 | cargo | Apache-2.0 OR MIT |
+| utf8parse | 0.2.2 | cargo | Apache-2.0 OR MIT |
+| utoipa | 5.4.0 | cargo | Apache-2.0 OR MIT |
+| utoipa-gen | 5.4.0 | cargo | Apache-2.0 OR MIT |
+| uuid | 1.18.1 | cargo | Apache-2.0 OR MIT |
+| valuable | 0.1.1 | cargo | MIT |
+| vcpkg | 0.2.15 | cargo | Apache-2.0 OR MIT |
+| version_check | 0.9.5 | cargo | Apache-2.0 OR MIT |
+| vsimd | 0.8.0 | cargo | MIT |
+| vt100 | 0.15.2 | cargo | MIT |
+| vte | 0.11.1 | cargo | Apache-2.0 OR MIT |
+| vte_generate_state_changes | 0.1.2 | cargo | Apache-2.0 OR MIT |
+| walkdir | 2.5.0 | cargo | MIT OR Unlicense |
+| want | 0.3.1 | cargo | MIT |
+| wasi | 0.11.1+wasi-snapshot-preview1 | cargo | UNKNOWN |
+| wasip2 | 1.0.1+wasi-0.2.4 | cargo | UNKNOWN |
+| wasm-bindgen | 0.2.105 | cargo | Apache-2.0 OR MIT |
+| wasm-bindgen | 0.2.106 | cargo | Apache-2.0 OR MIT |
+| wasm-bindgen-futures | 0.4.55 | cargo | Apache-2.0 OR MIT |
+| wasm-bindgen-futures | 0.4.56 | cargo | Apache-2.0 OR MIT |
+| wasm-bindgen-macro | 0.2.105 | cargo | Apache-2.0 OR MIT |
+| wasm-bindgen-macro | 0.2.106 | cargo | Apache-2.0 OR MIT |
+| wasm-bindgen-macro-support | 0.2.105 | cargo | Apache-2.0 OR MIT |
+| wasm-bindgen-macro-support | 0.2.106 | cargo | Apache-2.0 OR MIT |
+| wasm-bindgen-shared | 0.2.105 | cargo | Apache-2.0 OR MIT |
+| wasm-bindgen-shared | 0.2.106 | cargo | Apache-2.0 OR MIT |
+| wasm-streams | 0.4.2 | cargo | Apache-2.0 OR MIT |
+| wasmtimer | 0.4.3 | cargo | MIT |
+| web-sys | 0.3.82 | cargo | Apache-2.0 OR MIT |
+| web-sys | 0.3.83 | cargo | Apache-2.0 OR MIT |
+| web-time | 1.1.0 | cargo | Apache-2.0 OR MIT |
+| webpki-root-certs | 0.26.11 | cargo | CDLA-Permissive-2.0 |
+| webpki-root-certs | 1.0.4 | cargo | CDLA-Permissive-2.0 |
+| webpki-roots | 0.26.11 | cargo | CDLA-Permissive-2.0 |
+| webpki-roots | 1.0.4 | cargo | CDLA-Permissive-2.0 |
+| weezl | 0.1.12 | cargo | Apache-2.0 OR MIT |
+| which | 4.4.2 | cargo | MIT |
+| which | 7.0.3 | cargo | MIT |
+| winapi | 0.3.9 | cargo | Apache-2.0 OR MIT |
+| winapi-i686-pc-windows-gnu | 0.4.0 | cargo | Apache-2.0 OR MIT |
+| winapi-util | 0.1.11 | cargo | MIT OR Unlicense |
+| winapi-x86_64-pc-windows-gnu | 0.4.0 | cargo | Apache-2.0 OR MIT |
+| windows | 0.58.0 | cargo | Apache-2.0 OR MIT |
+| windows | 0.61.3 | cargo | Apache-2.0 OR MIT |
+| windows-collections | 0.2.0 | cargo | Apache-2.0 OR MIT |
+| windows-core | 0.58.0 | cargo | Apache-2.0 OR MIT |
+| windows-core | 0.61.2 | cargo | Apache-2.0 OR MIT |
+| windows-core | 0.62.2 | cargo | Apache-2.0 OR MIT |
+| windows-future | 0.2.1 | cargo | Apache-2.0 OR MIT |
+| windows-implement | 0.58.0 | cargo | Apache-2.0 OR MIT |
+| windows-implement | 0.60.2 | cargo | Apache-2.0 OR MIT |
+| windows-interface | 0.58.0 | cargo | Apache-2.0 OR MIT |
+| windows-interface | 0.59.3 | cargo | Apache-2.0 OR MIT |
+| windows-link | 0.1.3 | cargo | Apache-2.0 OR MIT |
+| windows-link | 0.2.1 | cargo | Apache-2.0 OR MIT |
+| windows-numerics | 0.2.0 | cargo | Apache-2.0 OR MIT |
+| windows-registry | 0.4.0 | cargo | Apache-2.0 OR MIT |
+| windows-registry | 0.6.1 | cargo | Apache-2.0 OR MIT |
+| windows-result | 0.2.0 | cargo | Apache-2.0 OR MIT |
+| windows-result | 0.3.4 | cargo | Apache-2.0 OR MIT |
+| windows-result | 0.4.1 | cargo | Apache-2.0 OR MIT |
+| windows-strings | 0.1.0 | cargo | Apache-2.0 OR MIT |
+| windows-strings | 0.3.1 | cargo | Apache-2.0 OR MIT |
+| windows-strings | 0.4.2 | cargo | Apache-2.0 OR MIT |
+| windows-strings | 0.5.1 | cargo | Apache-2.0 OR MIT |
+| windows-sys | 0.45.0 | cargo | Apache-2.0 OR MIT |
+| windows-sys | 0.48.0 | cargo | Apache-2.0 OR MIT |
+| windows-sys | 0.52.0 | cargo | Apache-2.0 OR MIT |
+| windows-sys | 0.59.0 | cargo | Apache-2.0 OR MIT |
+| windows-sys | 0.60.2 | cargo | Apache-2.0 OR MIT |
+| windows-sys | 0.61.2 | cargo | Apache-2.0 OR MIT |
+| windows-targets | 0.42.2 | cargo | Apache-2.0 OR MIT |
+| windows-targets | 0.48.5 | cargo | Apache-2.0 OR MIT |
+| windows-targets | 0.52.6 | cargo | Apache-2.0 OR MIT |
+| windows-targets | 0.53.5 | cargo | Apache-2.0 OR MIT |
+| windows-threading | 0.1.0 | cargo | Apache-2.0 OR MIT |
+| windows_aarch64_gnullvm | 0.42.2 | cargo | Apache-2.0 OR MIT |
+| windows_aarch64_gnullvm | 0.48.5 | cargo | Apache-2.0 OR MIT |
+| windows_aarch64_gnullvm | 0.52.6 | cargo | Apache-2.0 OR MIT |
+| windows_aarch64_gnullvm | 0.53.1 | cargo | Apache-2.0 OR MIT |
+| windows_aarch64_msvc | 0.42.2 | cargo | Apache-2.0 OR MIT |
+| windows_aarch64_msvc | 0.48.5 | cargo | Apache-2.0 OR MIT |
+| windows_aarch64_msvc | 0.52.6 | cargo | Apache-2.0 OR MIT |
+| windows_aarch64_msvc | 0.53.1 | cargo | Apache-2.0 OR MIT |
+| windows_i686_gnu | 0.42.2 | cargo | Apache-2.0 OR MIT |
+| windows_i686_gnu | 0.48.5 | cargo | Apache-2.0 OR MIT |
+| windows_i686_gnu | 0.52.6 | cargo | Apache-2.0 OR MIT |
+| windows_i686_gnu | 0.53.1 | cargo | Apache-2.0 OR MIT |
+| windows_i686_gnullvm | 0.52.6 | cargo | Apache-2.0 OR MIT |
+| windows_i686_gnullvm | 0.53.1 | cargo | Apache-2.0 OR MIT |
+| windows_i686_msvc | 0.42.2 | cargo | Apache-2.0 OR MIT |
+| windows_i686_msvc | 0.48.5 | cargo | Apache-2.0 OR MIT |
+| windows_i686_msvc | 0.52.6 | cargo | Apache-2.0 OR MIT |
+| windows_i686_msvc | 0.53.1 | cargo | Apache-2.0 OR MIT |
+| windows_x86_64_gnu | 0.42.2 | cargo | Apache-2.0 OR MIT |
+| windows_x86_64_gnu | 0.48.5 | cargo | Apache-2.0 OR MIT |
+| windows_x86_64_gnu | 0.52.6 | cargo | Apache-2.0 OR MIT |
+| windows_x86_64_gnu | 0.53.1 | cargo | Apache-2.0 OR MIT |
+| windows_x86_64_gnullvm | 0.42.2 | cargo | Apache-2.0 OR MIT |
+| windows_x86_64_gnullvm | 0.48.5 | cargo | Apache-2.0 OR MIT |
+| windows_x86_64_gnullvm | 0.52.6 | cargo | Apache-2.0 OR MIT |
+| windows_x86_64_gnullvm | 0.53.1 | cargo | Apache-2.0 OR MIT |
+| windows_x86_64_msvc | 0.42.2 | cargo | Apache-2.0 OR MIT |
+| windows_x86_64_msvc | 0.48.5 | cargo | Apache-2.0 OR MIT |
+| windows_x86_64_msvc | 0.52.6 | cargo | Apache-2.0 OR MIT |
+| windows_x86_64_msvc | 0.53.1 | cargo | Apache-2.0 OR MIT |
+| winnow | 0.7.13 | cargo | MIT |
+| winreg | 0.10.1 | cargo | MIT |
+| winsafe | 0.0.19 | cargo | MIT |
+| wit-bindgen | 0.46.0 | cargo | Apache-2.0 OR MIT OR Apache-2.0 WITH LLVM-exception |
+| writeable | 0.6.2 | cargo | Unicode-3.0 |
+| x11rb | 0.13.2 | cargo | Apache-2.0 OR MIT |
+| x11rb-protocol | 0.13.2 | cargo | Apache-2.0 OR MIT |
+| xattr | 1.6.1 | cargo | Apache-2.0 OR MIT |
+| xmlparser | 0.13.6 | cargo | Apache-2.0 OR MIT |
+| xterm-query | 0.5.2 | cargo | MIT |
+| yaml-rust | 0.4.5 | cargo | Apache-2.0 OR MIT |
+| yaml-rust2 | 0.8.1 | cargo | Apache-2.0 OR MIT |
+| yasna | 0.5.2 | cargo | Apache-2.0 OR MIT |
+| yoke | 0.8.1 | cargo | Unicode-3.0 |
+| yoke-derive | 0.8.1 | cargo | Unicode-3.0 |
+| zerocopy | 0.7.35 | cargo | Apache-2.0 OR BSD-2-Clause OR MIT |
+| zerocopy | 0.8.27 | cargo | Apache-2.0 OR BSD-2-Clause OR MIT |
+| zerocopy | 0.8.31 | cargo | Apache-2.0 OR BSD-2-Clause OR MIT |
+| zerocopy-derive | 0.7.35 | cargo | Apache-2.0 OR BSD-2-Clause OR MIT |
+| zerocopy-derive | 0.8.27 | cargo | Apache-2.0 OR BSD-2-Clause OR MIT |
+| zerocopy-derive | 0.8.31 | cargo | Apache-2.0 OR BSD-2-Clause OR MIT |
+| zerofrom | 0.1.6 | cargo | Unicode-3.0 |
+| zerofrom-derive | 0.1.6 | cargo | Unicode-3.0 |
+| zeroize | 1.8.2 | cargo | Apache-2.0 OR MIT |
+| zeroize_derive | 1.4.2 | cargo | Apache-2.0 OR MIT |
+| zerotrie | 0.2.3 | cargo | Unicode-3.0 |
+| zerovec | 0.11.5 | cargo | Unicode-3.0 |
+| zerovec-derive | 0.11.2 | cargo | Unicode-3.0 |
+| zip | 4.6.1 | cargo | MIT |
+| zlib-rs | 0.5.2 | cargo | Zlib |
+| zopfli | 0.8.3 | cargo | Apache-2.0 |
+| zstd | 0.13.3 | cargo | MIT |
+| zstd-safe | 7.2.4 | cargo | Apache-2.0 OR MIT |
+| zstd-sys | 2.0.16+zstd.1.5.7 | cargo | UNKNOWN |
+| zune-core | 0.4.12 | cargo | Apache-2.0 OR MIT OR Zlib |
+| zune-core | 0.5.0 | cargo | Apache-2.0 OR MIT OR Zlib |
+| zune-jpeg | 0.4.21 | cargo | Apache-2.0 OR MIT OR Zlib |
+| zune-jpeg | 0.5.5 | cargo | Apache-2.0 OR MIT OR Zlib |


### PR DESCRIPTION
Adds a THIRD-PARTY-NOTICES.md file listing bundled open-source components and their licenses.